### PR TITLE
Check that the run order is the same for all cells and the case

### DIFF
--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1408,7 +1408,7 @@ void CensusView::ViewComposite()
 
 bool CensusView::DoAllCells(mcenum_emission emission)
 {
-    assert_consistency(case_parms()[0], cell_parms()[0]);
+    assert_consistency(case_parms()[0], cell_parms());
 
     illustrator z(emission);
     if(!z(base_filename(), cell_parms()))

--- a/illustrator.cpp
+++ b/illustrator.cpp
@@ -69,7 +69,7 @@ bool illustrator::operator()(fs::path const& file_path)
         {
         Timer timer;
         multiple_cell_document doc(file_path.string());
-        assert_consistency(doc.case_parms()[0], doc.cell_parms()[0]);
+        assert_consistency(doc.case_parms()[0], doc.cell_parms());
         seconds_for_input_ = timer.stop().elapsed_seconds();
         return operator()(file_path, doc.cell_parms());
         }
@@ -247,19 +247,26 @@ Input const& default_cell()
 
 void assert_consistency
     (Input const& case_default
-    ,Input const& cell
+    ,std::vector<Input> const& cells
     )
 {
-    if(case_default["RunOrder"] != cell["RunOrder"])
+    std::size_t const number_of_cells = cells.size();
+    for(std::size_t n = 0; n < number_of_cells; ++n)
         {
-        fatal_error()
-            << "Case-default run order '"
-            << case_default["RunOrder"]
-            << "' differs from first cell's run order '"
-            << cell["RunOrder"]
-            << "'. Make them consistent before running illustrations."
-            << LMI_FLUSH
-            ;
+        Input const& cell = cells[n];
+        if(case_default["RunOrder"] != cell["RunOrder"])
+            {
+            fatal_error()
+                << "Case-default run order '"
+                << case_default["RunOrder"]
+                << "' differs from the run order '"
+                << cell["RunOrder"]
+                << "' for the cell #"
+                << (n + 1)
+                << ". Make them consistent before running illustrations."
+                << LMI_FLUSH
+                ;
+            }
         }
 }
 

--- a/illustrator.hpp
+++ b/illustrator.hpp
@@ -75,7 +75,7 @@ Input const& LMI_SO default_cell();
 
 void LMI_SO assert_consistency
     (Input const& case_default
-    ,Input const& cell
+    ,std::vector<Input> const& cells
     );
 
 #endif // illustrator_hpp


### PR DESCRIPTION
Generalize assert_consistency() function to check that the run order for all
cells is the same as for the case instead of checking just the first one.

Benchmarking shows that the timings of illustration generation are not
significantly affected by this change, but it catches inconsistencies which
could previously pass unnoticed.

---
To be precise, the timing were obtained using the following patch
```diff
diff --git a/census_view.cpp b/census_view.cpp
index 2df1746..384f064 100644
--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1408,7 +1408,13 @@ void CensusView::ViewComposite()

 bool CensusView::DoAllCells(mcenum_emission emission)
 {
-    assert_consistency(case_parms()[0], cell_parms());
+    Timer timer;
+    for(int n = 0; n < 1000; ++n)
+        {
+        assert_consistency(case_parms()[0], cell_parms());
+        }
+    double total_seconds = timer.stop().elapsed_seconds();
+    std::cout << "assert_consistency() time: " << Timer::elapsed_msec_str(total_seconds) << std::endl;

     illustrator z(emission);
     if(!z(base_filename(), cell_parms()))
```
and generating the group quote summary. The result is that they changed from 2ms (i.e. 2μs per iteration) to a result wildly varying between 4 and 13ms across many runs for a small (7 cells) census and to ~7600ms (i.e. <8ms per iteration) for the big census (4232 cells). I think extra 8ms is not too much, even though the "TODO" remaining before the function would be still worth fixing IMHO.