### PR TITLE
Verify census consistency before creating a group quote report

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -37183,7 +37183,7 @@ Swap two fields to improve layout (KMM).
 20151011T1607Z <gchicares@sbcglobal.net> [472]
 
   group_quote_pdf_gen_wx.cpp
-In boxed summary, wrap only name, not value (VZ).
+In boxed summary, wrap only value, not name (VZ).
 
 20151011T1608Z <gchicares@sbcglobal.net> [472]
 
@@ -37199,4 +37199,9 @@ Refactor image drawing (VZ).
 
   group_quote_pdf_gen_wx.cpp
 Scale logo (VZ).
+
+20151011T2219Z <gchicares@sbcglobal.net> [472]
+
+  group_quote_pdf_gen_wx.cpp
+Remove a needless attribute; fix the 20151011T1607Z commit message.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -37180,3 +37180,23 @@ Validate run order for all cells.
   group_quote_pdf_gen_wx.cpp
 Swap two fields to improve layout (KMM).
 
+20151011T1607Z <gchicares@sbcglobal.net> [472]
+
+  group_quote_pdf_gen_wx.cpp
+In boxed summary, wrap only name, not value (VZ).
+
+20151011T1608Z <gchicares@sbcglobal.net> [472]
+
+  group_quote_pdf_gen_wx.cpp
+Regularize case (VZ).
+
+20151011T1632Z <gchicares@sbcglobal.net> [472]
+
+  group_quote_pdf_gen_wx.cpp
+Refactor image drawing (VZ).
+
+20151011T1633Z <gchicares@sbcglobal.net> [472]
+
+  group_quote_pdf_gen_wx.cpp
+Scale logo (VZ).
+

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1423,7 +1423,7 @@ void CensusView::ViewComposite()
 
 bool CensusView::DoAllCells(mcenum_emission emission)
 {
-    assert_consistent_run_order(case_parms()[0], cell_parms());
+    assert_consistency_in_context(emission, case_parms()[0], cell_parms());
 
     illustrator z(emission);
     if(!z(base_filename(), cell_parms()))

--- a/group_quote_pdf_gen_wx.cpp
+++ b/group_quote_pdf_gen_wx.cpp
@@ -105,7 +105,7 @@ void append_name_value_to_html_table
     )
 {
     html_table += wxString::Format
-        ("<td nowrap=\"1\" align=\"right\"><b>%s%s&nbsp;&nbsp;</b></td>"
+        ("<td nowrap align=\"right\"><b>%s%s&nbsp;&nbsp;</b></td>"
          "<td>%s&nbsp;&nbsp;&nbsp;&nbsp;</td>"
         ,escape_for_html_elem(name)
         ,(value.empty() ? "" : ":")

--- a/group_quote_pdf_gen_wx.cpp
+++ b/group_quote_pdf_gen_wx.cpp
@@ -530,6 +530,10 @@ void group_quote_pdf_generator_wx::global_report_data::fill_global_report_data
     (LedgerInvariant const& ledger
     )
 {
+    // Note that all the fields used here must be checked for consistency in
+    // assert_consistency_in_context() and that function should be modified
+    // if the code here changes.
+
     company_          = ledger.CorpName;
     prepared_by_      = ledger.ProducerName;
     product_          = ledger.PolicyMktgName;
@@ -557,10 +561,12 @@ void group_quote_pdf_generator_wx::add_ledger(Ledger const& ledger)
 {
     LedgerInvariant const& Invar = ledger.GetLedgerInvariant();
 
-    // Header and footer data must be the same for all ledgers.
-    // FIXME This needs to be asserted. And leaving "Company"
-    // empty is a plausible user error that should be protected
-    // against by an assertion.
+    // Because we know that assert_consistency_in_context(), which had been
+    // called prior to starting the report generation, verifies that the
+    // company name is not empty, we can use it as a flag indicating that
+    // fill_global_report_data() hasn't been called yet. And we only need to
+    // call it once because assert_consistency_in_context() also ensures that
+    // the values used by it are the same for all ledgers.
     if(report_data_.company_.empty())
         {
         report_data_.fill_global_report_data(Invar);

--- a/group_quote_pdf_gen_wx.cpp
+++ b/group_quote_pdf_gen_wx.cpp
@@ -249,6 +249,54 @@ wxImage load_image(char const* file)
     return image;
 }
 
+/// Output an image at the given scale into the PDF.
+///
+/// The scale specifies how many times the image should be shrunk, i.e. scale >
+/// 1 makes the image smaller while scale < 1 makes it larger.
+///
+/// Updates pos_y by increasing it by the height of the specified image at the
+/// given scale.
+
+void output_image
+    (wxPdfDC&         pdf_dc
+    ,wxImage const&   image
+    ,char const*      image_name
+    ,double           scale
+    ,int              x
+    ,int*             pos_y
+    ,enum_output_mode output_mode = e_output_normal
+    )
+{
+    int const y = wxRound(image.GetHeight() / scale);
+
+    switch(output_mode)
+        {
+        case e_output_normal:
+            {
+            // Use wxPdfDocument API directly as wxDC doesn't provide a way to
+            // set the image scale at PDF level and also because passing via
+            // wxDC wastefully converts wxImage to wxBitmap only to convert it
+            // back to wxImage when embedding it into the PDF.
+            wxPdfDocument* const pdf_doc = pdf_dc.GetPdfDocument();
+            LMI_ASSERT(pdf_doc);
+
+            pdf_doc->SetImageScale(scale);
+            pdf_doc->Image(image_name, image, x, *pos_y);
+            pdf_doc->SetImageScale(1);
+            }
+            break;
+        case e_output_measure_only:
+            // Do nothing.
+            break;
+        default:
+            {
+            fatal_error() << "Case " << output_mode << " not found." << LMI_FLUSH;
+            }
+        }
+
+    *pos_y += y;
+}
+
 /// Render, or just pretend rendering in order to measure it, the given HTML
 /// contents at the specified position wrapping it at the given width.
 /// Return the height of the output (using this width).
@@ -861,24 +909,11 @@ void group_quote_pdf_generator_wx::output_image_header
         return;
         }
 
-    // Use wxPdfDocument API directly as wxDC doesn't provide a way to set the
-    // image scale at PDF level and also because passing via wxDC wastefully
-    // converts wxImage to wxBitmap only to convert it back to wxImage when
-    // embedding it into the PDF.
-    wxPdfDocument* const pdf_doc = pdf_dc.GetPdfDocument();
-    LMI_ASSERT(pdf_doc);
-
-    wxSize const image_size = banner_image.GetSize();
-
     // Set the scale to fit the image to the document width.
-    pdf_doc->SetImageScale
-        (static_cast<double>(image_size.x) / page_.total_size_.x
-        );
-    pdf_doc->Image("banner", banner_image, 0, *pos_y);
-
-    int const y = wxRound(image_size.y / pdf_doc->GetImageScale());
-
-    pdf_doc->SetImageScale(1);
+    double const
+        scale = static_cast<double>(banner_image.GetWidth()) / page_.total_size_.x;
+    int const pos_top = *pos_y;
+    output_image(pdf_dc, banner_image, "banner", scale, 0, pos_y);
 
     wxDCFontChanger set_bigger_font(pdf_dc, pdf_dc.GetFont().Scaled(1.5));
     wxDCTextColourChanger set_white_text(pdf_dc, *wxWHITE);
@@ -893,13 +928,11 @@ void group_quote_pdf_generator_wx::output_image_header
     pdf_dc.DrawLabel
         (image_text
         ,wxRect
-            (wxPoint(horz_margin, *pos_y + y / 2),
+            (wxPoint(horz_margin, (pos_top + *pos_y) / 2),
              pdf_dc.GetMultiLineTextExtent(image_text)
             )
         ,wxALIGN_CENTER_HORIZONTAL
         );
-
-    *pos_y += y;
 }
 
 void group_quote_pdf_generator_wx::output_document_header

--- a/group_quote_pdf_gen_wx.cpp
+++ b/group_quote_pdf_gen_wx.cpp
@@ -1155,22 +1155,11 @@ void group_quote_pdf_generator_wx::output_footer
     wxImage logo_image(load_image("company_logo.png"));
     if(logo_image.IsOk())
         {
-        switch(output_mode)
-            {
-            case e_output_normal:
-                {
-                pdf_dc.DrawBitmap(logo_image, horz_margin, *pos_y);
-                }
-                break;
-            case e_output_measure_only:
-                // Do nothing.
-                break;
-            default:
-                {
-                fatal_error() << "Case " << output_mode << " not found." << LMI_FLUSH;
-                }
-            }
-        *pos_y += logo_image.GetSize().y + vert_skip;
+        // Arbitrarily scale down the logo by a factor of 2 to avoid making it
+        // too big.
+        output_image(pdf_dc, logo_image, "company_logo", 2.0, horz_margin, pos_y, output_mode);
+
+        *pos_y += vert_skip;
         }
 
     wxString const footer_html = "<p>" + report_data_.footer_ + "</p>";

--- a/group_values.cpp
+++ b/group_values.cpp
@@ -711,7 +711,7 @@ census_run_result run_census::operator()
 
     // Use the first cell's run order for the entire census, ignoring
     // any conflicting run order for any other cell--which would have
-    // been prevented upstream by assert_consistent_run_order().
+    // been prevented upstream by assert_consistency_in_context().
     mcenum_run_order order = yare_input(cells[0]).RunOrder;
     switch(order)
         {

--- a/illustrator.hpp
+++ b/illustrator.hpp
@@ -73,8 +73,12 @@ class LMI_SO illustrator
 
 Input const& LMI_SO default_cell();
 
-void LMI_SO assert_consistent_run_order
-    (Input              const& case_default
+/// Throw an exception if the cells data is not sufficiently consistent with
+/// the case default to allow creating an emission of the specified type.
+
+void LMI_SO assert_consistency_in_context
+    (mcenum_emission           emission
+    ,Input              const& case_default
     ,std::vector<Input> const& cells
     );
 


### PR DESCRIPTION
Add a function assert_okay_to_run_group_quote() similar to the existing
assert_consistent_run_order() which is called before creating a group quote
report and verifies that the census values are consistent with the assumptions
about them made in the group quote report generation code, notably that all
the values used in the header and in the footer are the same for all of them.