### PR TITLE
Verify census consistency before creating a group quote report

### DIFF
--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1423,7 +1423,7 @@ void CensusView::ViewComposite()
 
 bool CensusView::DoAllCells(mcenum_emission emission)
 {
-    assert_consistent_run_order(case_parms()[0], cell_parms());
+    assert_consistency_in_context(emission, case_parms()[0], cell_parms());
 
     illustrator z(emission);
     if(!z(base_filename(), cell_parms()))

--- a/group_quote_pdf_gen_wx.cpp
+++ b/group_quote_pdf_gen_wx.cpp
@@ -530,6 +530,10 @@ void group_quote_pdf_generator_wx::global_report_data::fill_global_report_data
     (LedgerInvariant const& ledger
     )
 {
+    // Note that all the fields used here must be checked for consistency in
+    // assert_consistency_in_context() and that function should be modified
+    // if the code here changes.
+
     company_          = ledger.CorpName;
     prepared_by_      = ledger.ProducerName;
     product_          = ledger.PolicyMktgName;
@@ -557,10 +561,12 @@ void group_quote_pdf_generator_wx::add_ledger(Ledger const& ledger)
 {
     LedgerInvariant const& Invar = ledger.GetLedgerInvariant();
 
-    // Header and footer data must be the same for all ledgers.
-    // FIXME This needs to be asserted. And leaving "Company"
-    // empty is a plausible user error that should be protected
-    // against by an assertion.
+    // Because we know that assert_consistency_in_context(), which had been
+    // called prior to starting the report generation, verifies that the
+    // company name is not empty, we can use it as a flag indicating that
+    // fill_global_report_data() hasn't been called yet. And we only need to
+    // call it once because assert_consistency_in_context() also ensures that
+    // the values used by it are the same for all ledgers.
     if(report_data_.company_.empty())
         {
         report_data_.fill_global_report_data(Invar);

--- a/group_values.cpp
+++ b/group_values.cpp
@@ -711,7 +711,7 @@ census_run_result run_census::operator()
 
     // Use the first cell's run order for the entire census, ignoring
     // any conflicting run order for any other cell--which would have
-    // been prevented upstream by assert_consistent_run_order().
+    // been prevented upstream by assert_consistency_in_context().
     mcenum_run_order order = yare_input(cells[0]).RunOrder;
     switch(order)
         {

--- a/illustrator.hpp
+++ b/illustrator.hpp
@@ -73,8 +73,12 @@ class LMI_SO illustrator
 
 Input const& LMI_SO default_cell();
 
-void LMI_SO assert_consistent_run_order
-    (Input              const& case_default
+/// Throw an exception if the cells data is not sufficiently consistent with
+/// the case default to allow creating an emission of the specified type.
+
+void LMI_SO assert_consistency_in_context
+    (mcenum_emission           emission
+    ,Input              const& case_default
     ,std::vector<Input> const& cells
     );
 


### PR DESCRIPTION
Replace assert_consistent_run_order() with a more generic function
assert_consistency_in_context() which performs the run order check and also
the check for consistency of the fields used in the group quote report if one
is to be generated.

This ensures that the data in the group quotes header and footer is correct
for all cells.

---
This corresponds to the "Option Zero" from the email discussion.