### PR TITLE
Clang fixes

### DIFF
--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1788,7 +1788,7 @@ void CensusView::UponPasteCensus(wxCommandEvent&)
         cell_parms ().clear();
         }
 
-    unsigned int selection = cell_parms().size();
+    auto selection = cell_parms().size();
     std::back_insert_iterator<std::vector<Input> > iip(cell_parms());
     std::copy(cells.begin(), cells.end(), iip);
     document().Modify(true);

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -718,7 +718,7 @@ renderer_type_convertor const& renderer_type_convertor::get(any_member<Input> co
 template<typename T>
 renderer_type_convertor const& renderer_type_convertor::get_impl()
 {
-    static const T singleton;
+    static T singleton;
     return singleton;
 }
 

--- a/config.hpp
+++ b/config.hpp
@@ -72,7 +72,9 @@ namespace fs = boost::filesystem;
 
 #if defined __GNUC__
 // This selects a correct snprintf() for MinGW-w64.
-#   define _ISOC99_SOURCE
+#   ifndef _ISOC99_SOURCE
+#       define _ISOC99_SOURCE
+#   endif
 #endif // defined __GNUC__
 
 // 'platform_dependent.hpp' includes standard headers in an unusual

--- a/configure.ac
+++ b/configure.ac
@@ -124,6 +124,27 @@ AX_CXX_COMPILE_STDCXX(11, noext)
 
 AC_PROG_LD
 
+AC_CACHE_CHECK([if using clang],
+    lmi_cv_prog_clang,
+    [
+        AC_LANG_PUSH([C++])
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+                [],
+                [[
+                #ifndef __clang__
+                    not clang
+                #endif
+                ]],
+            )],
+            lmi_cv_prog_clang=yes,
+            lmi_cv_prog_clang=no
+        )
+        AC_LANG_POP([C++])
+    ]
+)
+
+CLANG=$lmi_cv_prog_clang
+
 if test "$USE_WINDOWS" = "1"; then
     AC_CHECK_TOOL([WINDRES], [windres], no)
 fi
@@ -502,47 +523,74 @@ AC_SUBST(CGICC_INCLUDE_FLAGS)
 AC_SUBST(CGICC_LIBS)
 AC_SUBST(CGICC_LIB_LDADD)
 
-dnl --- enable all possible warnings for gcc/g++ ----
-CFLAGS_gcc_common="\
-    -pedantic-errors \
-    -Werror \
-    -Wall \
-    -Wcast-align \
-    -Wdeprecated-declarations \
-    -Wdisabled-optimization \
-    -Wimport \
-    -Wmultichar \
-    -Wno-long-long \
-    -Wno-variadic-macros \
-    -Wpacked \
-    -Wpointer-arith \
-    -Wsign-compare \
-    -Wundef \
-    -Wwrite-strings"
+dnl Try to enable as many useful warnings as possible depending on the
+dnl compiler (and its version) used.
+if test "$GCC" == "yes"; then
+    dnl These flags are understood by both gcc and clang and, hopefully, other
+    dnl compatible compilers.
+    c_warnings_flags="\
+        -pedantic-errors \
+        -Werror \
+        -Wall \
+        -Wundef"
 
-if test "x$GCC" == "xyes"; then
-    CFLAGS="$CFLAGS $CFLAGS_gcc_common -std=c99 -Wmissing-prototypes"
+    if test "$CLANG" = "yes"; then
+        :
+    else
+        dnl Assume this is the real gcc.
+        c_warnings_flags="$c_warnings_flags \
+            -Wcast-align \
+            -Wdeprecated-declarations \
+            -Wdisabled-optimization \
+            -Wimport \
+            -Wmultichar \
+            -Wno-long-long \
+            -Wno-variadic-macros \
+            -Wpacked \
+            -Wpointer-arith \
+            -Wsign-compare \
+            -Wwrite-strings"
+    fi
+
+    CFLAGS="$CFLAGS $c_warnings_flags -std=c99 -Wmissing-prototypes"
 fi
 
 if test "x$GXX" == "xyes"; then
-    CXXFLAGS="$CXXFLAGS $CFLAGS_gcc_common \
+    if test "$CLANG" = "yes"; then
+        cxx_warnings_flags="$cxx_warnings_flags \
+            -Wno-inconsistent-missing-override"
+    else
+        cxx_warnings_flags="$cxx_warnings_flags \
         -Wctor-dtor-privacy \
         -Wdeprecated \
         -Wnon-template-friend \
         -Woverloaded-virtual \
         -Wpmf-conversions \
         -Wsynth"
+    fi
+
+    CXXFLAGS="$CXXFLAGS $c_warnings_flags $cxx_warnings_flags"
 
     dnl we need to use this option with g++ 4.3 to prevent its complaints
     dnl about "-funit-at-a-time is required for inlining of functions that are
     dnl only called once" in debug builds
     dnl
     dnl NB: this is needed for expm1.c so we must add it to CFLAGS too
-    LMI_C_CXX_ADD_IF_SUPPORTED(-fno-inline-functions-called-once)
+    if test "$CLANG" != "yes"; then
+        LMI_C_CXX_ADD_IF_SUPPORTED(-fno-inline-functions-called-once)
+    fi
 
-    dnl this one must be disabled with g++ 4.x because there are tons of
-    dnl occurrences of this warning in both wx and LMI sources
-    LMI_CXX_ADD_IF_SUPPORTED(-Wno-parentheses)
+    dnl this one must be disabled because there are tons of occurrences of
+    dnl this warning in both wx and LMI sources
+    if test "$CLANG" = "yes"; then
+        LMI_CXX_ADD_IF_SUPPORTED(-Wno-logical-op-parentheses)
+        LMI_CXX_ADD_IF_SUPPORTED(-Wno-bitwise-op-parentheses)
+    else
+        LMI_CXX_ADD_IF_SUPPORTED(-Wno-parentheses)
+    fi
+
+    dnl and this one occurs in older Boost headers
+    LMI_CXX_ADD_IF_SUPPORTED(-Wno-unused-local-typedef)
 
     dnl Many instances of these warnings are given in Boost 1.33.1 headers, so
     dnl we unfortunately have to disable them even if they're potentially

--- a/getopt.cpp
+++ b/getopt.cpp
@@ -921,7 +921,7 @@ GetOpt::usage(std::ostream& os)
     str_vec_i d;
     for
         (n  = option_names.begin() ,d  = option_descriptions.begin()
-        ;n != option_names.end()   ,d != option_descriptions.end()
+        ;n != option_names.end()  &&d != option_descriptions.end()
         ;++n, ++d
         )
         {

--- a/getopt.cpp
+++ b/getopt.cpp
@@ -370,11 +370,13 @@ GetOpt::operator()()
       // If we have done all the ARGV-elements, stop the scan.
 
       if (optind == nargc)
+        {
           // Check if first LIST_ARG with no argument.
           if (list_option_first)
             return  List_No_Value ();
           else
             return EOF;
+        }
 
       if (list_option->valid == 0)
         {

--- a/multidimgrid_any.cpp
+++ b/multidimgrid_any.cpp
@@ -1416,7 +1416,7 @@ void MultiDimAxisAnyChoice::UponSelectionChange(wxCommandEvent&)
 void MultiDimAxisAnyChoice::SelectionChanged()
 {
     unsigned int const sel = GetSelection();
-    if(!(0 <= sel && sel < axis_.GetCardinality()))
+    if(sel >= axis_.GetCardinality())
         {
         fatal_error()
             << "The axis is inconsistent with its choice control."

--- a/progress_meter.cpp
+++ b/progress_meter.cpp
@@ -77,7 +77,6 @@ progress_meter::progress_meter
     :count_         (0)
     ,max_count_     (max_count)
     ,title_         (title)
-    ,display_mode_  (display_mode)
     ,was_cancelled_ (false)
 {
 }

--- a/progress_meter.hpp
+++ b/progress_meter.hpp
@@ -98,8 +98,6 @@
 ///
 /// title_: A string suitable (e.g.) as a message-box title.
 ///
-/// display_mode_: enum_display_mode value.
-///
 /// was_cancelled_: True iff the operation was cancelled.
 ///
 /// Nonmember functions.
@@ -237,7 +235,6 @@ class LMI_SO progress_meter
     int               count_;
     int               max_count_;
     std::string       title_;
-    enum_display_mode display_mode_;
     bool              was_cancelled_;
 };
 

--- a/tier_view_editor.cpp
+++ b/tier_view_editor.cpp
@@ -150,10 +150,10 @@ bool TierTableAdapter::DoApplyAxisAdjustment
     bool updated = false;
 
     TierBandAxis& ba = static_cast<TierBandAxis&>(axis);
-    if(ba.GetMinValue() != 0 || ba.GetMaxValue() < 0)
+    if(ba.GetMinValue() != 0)
         {
         fatal_error()
-            << "Band-axis adjuster has invalid limits."
+            << "Band-axis adjuster has invalid lower limit."
             << LMI_FLUSH
             ;
         }


### PR DESCRIPTION
Various fixes to allow building lmi with clang.

Notice that some of them (`_ISOC99_SOURCE` and `size_t` to `unsigned` warning/ambiguity) are also necessary for the native Linux build using g++ 4.9.2 or 5.3.