### PR TITLE
Menu open events clean up

### DIFF
--- a/docmdichildframe_ex.cpp
+++ b/docmdichildframe_ex.cpp
@@ -49,10 +49,6 @@ DocMDIChildFrameEx::DocMDIChildFrameEx
 {
 }
 
-DocMDIChildFrameEx::~DocMDIChildFrameEx()
-{
-}
-
 wxStatusBar* DocMDIChildFrameEx::GetStatusBar() const
 {
     if(!status_bar_sought_from_menu_highlight_handler_)

--- a/docmdichildframe_ex.cpp
+++ b/docmdichildframe_ex.cpp
@@ -30,7 +30,6 @@
 IMPLEMENT_CLASS(DocMDIChildFrameEx, wxDocMDIChildFrame)
 
 BEGIN_EVENT_TABLE(DocMDIChildFrameEx, wxDocMDIChildFrame)
-    EVT_MENU_HIGHLIGHT_ALL(DocMDIChildFrameEx::UponMenuHighlight)
 END_EVENT_TABLE()
 
 DocMDIChildFrameEx::DocMDIChildFrameEx
@@ -45,52 +44,7 @@ DocMDIChildFrameEx::DocMDIChildFrameEx
     ,wxString   const& name
     )
     :wxDocMDIChildFrame(doc, view, parent, id, title, pos, size, style, name)
-    ,status_bar_sought_from_menu_highlight_handler_(false)
 {
-}
-
-wxStatusBar* DocMDIChildFrameEx::GetStatusBar() const
-{
-    if(!status_bar_sought_from_menu_highlight_handler_)
-        {
-        return wxDocMDIChildFrame::GetStatusBar();
-        }
-
-    wxStatusBar* status_bar = wxDocMDIChildFrame::GetStatusBar();
-    if(status_bar)
-        {
-        return status_bar;
-        }
-
-    wxFrame* parent_frame = dynamic_cast<wxFrame*>(GetParent());
-    if(parent_frame)
-        {
-        return parent_frame->GetStatusBar();
-        }
-
-    return 0;
-}
-
-/// This augments wxDocMDIChildFrame::OnMenuHighlight(), but isn't a
-/// complete replacement. It calls that base-class function explicitly
-/// because Skip() wouldn't work here.
-
-void DocMDIChildFrameEx::UponMenuHighlight(wxMenuEvent& event)
-{
-    try
-        {
-        status_bar_sought_from_menu_highlight_handler_ = true;
-        if(GetStatusBar())
-            {
-            wxDocMDIChildFrame::OnMenuHighlight(event);
-            }
-        status_bar_sought_from_menu_highlight_handler_ = false;
-        }
-    catch(...)
-        {
-        status_bar_sought_from_menu_highlight_handler_ = false;
-        throw;
-        }
 }
 
 #if !wxCHECK_VERSION(2,5,4)

--- a/docmdichildframe_ex.hpp
+++ b/docmdichildframe_ex.hpp
@@ -86,11 +86,6 @@ class DocMDIChildFrameEx
         ,long int          style  = wxDEFAULT_FRAME_STYLE
         ,wxString   const& name   = "child frame"
         );
-    // WX !! Base class wxDocMDIChildFrame's dtor is virtual, but isn't
-    // explicitly marked that way--though it seems that it should be,
-    // for consistency with the style of the rest of the library.
-    //
-    virtual ~DocMDIChildFrameEx();
 
   private:
     // WX !! Shouldn't OnMenuHighlight() be virtual?

--- a/docmdichildframe_ex.hpp
+++ b/docmdichildframe_ex.hpp
@@ -88,14 +88,6 @@ class DocMDIChildFrameEx
         );
 
   private:
-    // WX !! Shouldn't OnMenuHighlight() be virtual?
-    void UponMenuHighlight(wxMenuEvent&);
-
-    // wxDocMDIChildFrame overrides.
-    virtual wxStatusBar* GetStatusBar() const;
-
-    bool status_bar_sought_from_menu_highlight_handler_;
-
     DECLARE_CLASS(DocMDIChildFrameEx)
     DECLARE_EVENT_TABLE()
 };

--- a/skeleton.cpp
+++ b/skeleton.cpp
@@ -145,7 +145,6 @@ BEGIN_EVENT_TABLE(Skeleton, wxApp)
     EVT_MENU(XRCID("window_previous"                 ),Skeleton::UponWindowPrevious               )
     EVT_MENU(XRCID("window_tile_horizontally"        ),Skeleton::UponWindowTileHorizontally       )
     EVT_MENU(XRCID("window_tile_vertically"          ),Skeleton::UponWindowTileVertically         )
-    EVT_MENU_OPEN(                                     Skeleton::UponMenuOpen                     )
     EVT_UPDATE_UI(XRCID("print_pdf"                  ),Skeleton::UponUpdateInapplicable           )
     EVT_UPDATE_UI(XRCID("edit_cell"                  ),Skeleton::UponUpdateInapplicable           )
     EVT_UPDATE_UI(XRCID("edit_class"                 ),Skeleton::UponUpdateInapplicable           )
@@ -786,6 +785,8 @@ bool Skeleton::OnInit()
         InitMenuBar();
         InitToolBar();
         frame_->CreateStatusBar();
+
+        frame_->Bind(wxEVT_MENU_OPEN, &Skeleton::UponMenuOpen, this);
 #if defined LMI_MSW || wxCHECK_VERSION(2,8,10)
         frame_->DragAcceptFiles(true);
 #endif // defined LMI_MSW || wxCHECK_VERSION(2,8,10)

--- a/skeleton.cpp
+++ b/skeleton.cpp
@@ -848,22 +848,27 @@ void Skeleton::UponMenuOpen(wxMenuEvent& event)
 {
     event.Skip();
 
-    int child_frame_count = 0;
-    wxWindowList const& wl = frame_->GetChildren();
-    for(wxWindowList::const_iterator i = wl.begin(); i != wl.end(); ++i)
-        {
-        child_frame_count += !!dynamic_cast<wxMDIChildFrame*>(*i);
-        }
-
     wxMDIChildFrame* child_frame = frame_->GetActiveChild();
     if(child_frame)
         {
+        bool has_another_child = false;
+        wxWindowList const& wl = frame_->GetChildren();
+        for(wxWindowList::const_iterator i = wl.begin(); i != wl.end(); ++i)
+            {
+            wxMDIChildFrame* const child = dynamic_cast<wxMDIChildFrame*>(*i);
+            if(child && child != child_frame)
+                {
+                has_another_child = true;
+                break;
+                }
+            }
+
         wxMenuItem* window_next = child_frame->GetMenuBar()->FindItem
             (XRCID("window_next")
             );
         if(window_next)
             {
-            window_next->Enable(1 < child_frame_count);
+            window_next->Enable(has_another_child);
             }
 
         wxMenuItem* window_previous = child_frame->GetMenuBar()->FindItem
@@ -871,7 +876,7 @@ void Skeleton::UponMenuOpen(wxMenuEvent& event)
             );
         if(window_previous)
             {
-            window_previous->Enable(1 < child_frame_count);
+            window_previous->Enable(has_another_child);
             }
         }
     // (else) Parent menu enablement could be handled here, but, for


### PR DESCRIPTION
This series of patches from November 2014 is related to the problem originally [reported here](http://lists.nongnu.org/archive/html/lmi/2014-10/msg00084.html) and [posted to the list](http://lists.nongnu.org/archive/html/lmi/2014-11/msg00062.html) slightly later. The mailing list message provides further information about these patches.

This PR is not the most urgent one as nothing else depends on it but I still think it makes sense to apply it as it's always nice to remove unnecessary code.