### PR TITLE
Fix harmless but breaking the build gcc/clang warnings

### DIFF
--- a/progress_meter.cpp
+++ b/progress_meter.cpp
@@ -72,12 +72,11 @@ bool set_progress_meter_creator(progress_meter_creator_type f)
 progress_meter::progress_meter
     (int                max_count
     ,std::string const& title
-    ,enum_display_mode  display_mode
+    ,enum_display_mode  /* display_mode */
     )
     :count_         (0)
     ,max_count_     (max_count)
     ,title_         (title)
-    ,display_mode_  (display_mode)
     ,was_cancelled_ (false)
 {
 }

--- a/progress_meter.hpp
+++ b/progress_meter.hpp
@@ -98,8 +98,6 @@
 ///
 /// title_: A string suitable (e.g.) as a message-box title.
 ///
-/// display_mode_: enum_display_mode value.
-///
 /// was_cancelled_: True iff the operation was cancelled.
 ///
 /// Nonmember functions.
@@ -237,7 +235,6 @@ class LMI_SO progress_meter
     int               count_;
     int               max_count_;
     std::string       title_;
-    enum_display_mode display_mode_;
     bool              was_cancelled_;
 };
 


### PR DESCRIPTION
This consists of the unapplied commits from #7, the latter one modified according to the mailing list discussion (although I'm not really sure if the new version is better).