### PR TITLE
Take std::string and not wxString in HTML helper functions

### DIFF
--- a/group_quote_pdf_gen_wx.cpp
+++ b/group_quote_pdf_gen_wx.cpp
@@ -157,7 +157,7 @@ wxString wrap_if_not_empty(wxString const& html)
 
 /// Transform 'html' -> '<br><br>html', but return empty string unchanged.
 
-wxString brbr(wxString const& html)
+wxString brbr(std::string const& html)
 {
     return
         wrap_if_not_empty<html::tag::br>
@@ -169,7 +169,7 @@ wxString brbr(wxString const& html)
 
 /// Transform 'html' -> '<br><br><b>html</b>', but return empty string unchanged.
 
-wxString brbrb(wxString const& html)
+wxString brbrb(std::string const& html)
 {
     return
         wrap_if_not_empty<html::tag::br>


### PR DESCRIPTION
Respect the convention that plain text is represented by std::string while
wxString contains (already escaped) HTML text.

Also fixes compilation with wxUSE_STL=0 build of wxWidgets as a side effect.

---
This has been [posted to the list](http://lists.nongnu.org/archive/html/lmi/2016-02/msg00091.html) and is relatively high priority for me because it prevents me from building lmi against the official build of wxWidgets.