### PR TITLE
Avoid variable shadowing warnings with MSVC14

### DIFF
--- a/account_value.hpp
+++ b/account_value.hpp
@@ -460,7 +460,7 @@ class LMI_SO AccountValue
 
     // Intermediate values within annual or monthly loop only.
     double      pmt;       // Antediluvian.
-    mcenum_mode mode;      // Antediluvian.
+    mcenum_mode pmt_mode;  // Antediluvian.
     int         ModeIndex; // Antediluvian.
 
     double  GenAcctIntCred;

--- a/accountvalue.cpp
+++ b/accountvalue.cpp
@@ -124,7 +124,7 @@ AccountValue::AccountValue(Input const& input)
     ,RunBasis_         (mce_run_gen_curr_sep_full)
     ,GenBasis_         (mce_gen_curr)
     ,SepBasis_         (mce_sep_full)
-    ,mode              (mce_annual)
+    ,pmt_mode          (mce_annual)
     ,OldDBOpt          (mce_option1)
     ,YearsDBOpt        (mce_option1)
 {
@@ -299,8 +299,8 @@ void AccountValue::DoYear
     ActualSpecAmt         = InvariantValues().SpecAmt[Year];
 
     // These variables are set for each pass independently.
-    mode            = InvariantValues().EeMode[Year].value();
-    ModeIndex       = get_mode_index(mode);
+    pmt_mode        = InvariantValues().EeMode[Year].value();
+    ModeIndex       = get_mode_index(pmt_mode);
     RequestedLoan   = Outlay_->new_cash_loans()[Year];
     wd              = Outlay_->withdrawals()[Year];
     mlyguarv        =
@@ -621,7 +621,7 @@ void AccountValue::PerformPmtStrategy(double* a_Pmt)
             {
             *a_Pmt = GetModalMinPrem
                 (Year
-                ,mode
+                ,pmt_mode
                 ,ActualSpecAmt
                 );
             }
@@ -630,7 +630,7 @@ void AccountValue::PerformPmtStrategy(double* a_Pmt)
             {
             *a_Pmt = GetModalTgtPrem
                 (Year
-                ,mode
+                ,pmt_mode
                 ,ActualSpecAmt
                 );
             }

--- a/assert_lmi.hpp
+++ b/assert_lmi.hpp
@@ -48,13 +48,13 @@
         {                                                       \
         if(!(condition))                                        \
             {                                                   \
-            std::ostringstream oss;                             \
-            oss                                                 \
+            std::ostringstream assert_message;                  \
+            assert_message                                      \
                 << "Assertion '" << (#condition) << "' failed." \
                 << "\n[file " << __FILE__                       \
                 << ", line " << __LINE__ << "]\n"               \
                 ;                                               \
-            throw std::runtime_error(oss.str());                \
+            throw std::runtime_error(assert_message.str());     \
             }                                                   \
         }                                                       \
     while(0)
@@ -70,14 +70,14 @@
         {                                                      \
         if(!(condition))                                       \
             {                                                  \
-            std::ostringstream oss;                            \
-            oss                                                \
+            std::ostringstream assert_message;                 \
+            assert_message                                     \
                 << "Assertion '" << (#condition) << "' failed" \
                 << "\n(" << message << ")."                    \
                 << "\n[file " << __FILE__                      \
                 << ", line " << __LINE__ << "]\n"              \
                 ;                                              \
-            throw std::runtime_error(oss.str());               \
+            throw std::runtime_error(assert_message.str());    \
             }                                                  \
         }                                                      \
     while(0)

--- a/dbdict.cpp
+++ b/dbdict.cpp
@@ -1111,9 +1111,9 @@ void print_databases()
         fs::ofstream os(out_file, ios_out_trunc_binary());
         DBDictionary const& z = DBDictionary::instance();
         typedef std::vector<std::string>::const_iterator svci;
-        for(svci i = z.member_names().begin(); i != z.member_names().end(); ++i)
+        for(svci j = z.member_names().begin(); j != z.member_names().end(); ++j)
             {
-            z.datum(*i).write(os);
+            z.datum(*j).write(os);
             }
         }
 }

--- a/group_values.cpp
+++ b/group_values.cpp
@@ -357,12 +357,10 @@ census_run_result run_census_in_parallel::operator()
             MaxYr = std::max(MaxYr, (*i)->GetLength());
             }
 
-        boost::shared_ptr<progress_meter> meter
-            (create_progress_meter
-                (MaxYr - first_cell_inforce_year
-                ,mc_str(*run_basis)
-                ,progress_meter_mode(emission)
-                )
+        meter = create_progress_meter
+            (MaxYr - first_cell_inforce_year
+            ,mc_str(*run_basis)
+            ,progress_meter_mode(emission)
             );
 
         // Variables to support tiering and experience rating.

--- a/ihs_acctval.cpp
+++ b/ihs_acctval.cpp
@@ -116,7 +116,7 @@ AccountValue::AccountValue(Input const& input)
     LapseYear                = 0;          // Antediluvian.
     AVUnloaned               = 0.0;        // Antediluvian.
     pmt                      = 0.0;        // Antediluvian.
-    mode                     = mce_annual; // Antediluvian.
+    pmt_mode                 = mce_annual; // Antediluvian.
     ModeIndex                = 0;          // Antediluvian.
     wd                       = 0.0;        // Antediluvian.
     mlyguarv                 = 0.0;        // Antediluvian.

--- a/ledger_xml_io.cpp
+++ b/ledger_xml_io.cpp
@@ -717,7 +717,7 @@ void Ledger::write(xml::element& x) const
 
     // First we'll get the invariant stuff--the copy we made,
     // along with all the stuff we plugged into it above.
-
+    {
     std::string suffix = "";
     for
         (scalar_map::const_iterator j = scalars.begin()
@@ -745,6 +745,7 @@ void Ledger::write(xml::element& x) const
         if(format_exists(j->first, suffix, format_map))
             stringvectors[j->first + suffix] = ledger_format(*j->second, format_map[j->first]);
         }
+    }
 
 //    stringscalars["GuarMaxMandE"] = ledger_format(*scalars["GuarMaxMandE"], 2, true);
 //    stringvectors["CorridorFactor"] = ledger_format(*vectors["CorridorFactor"], 0, true);
@@ -753,8 +754,8 @@ void Ledger::write(xml::element& x) const
     // That was the tricky part. Now it's all downhill.
 
     ledger_map_t const& l_map_rep = ledger_map_->held();
-    ledger_map_t::const_iterator i = l_map_rep.begin();
-    for(;i != l_map_rep.end(); i++)
+    using lmci = ledger_map_t::const_iterator;
+    for(lmci i = l_map_rep.begin();i != l_map_rep.end(); i++)
         {
         std::string suffix = suffixes[i->first];
         for

--- a/xml_lmi.cpp
+++ b/xml_lmi.cpp
@@ -241,7 +241,6 @@ std::string xml_lmi::xml_document::str()
 
 void xml_lmi::xml_document::add_comment(std::string const& s)
 {
-    xml::node::iterator i = document_->begin();
     for(xml::node::iterator i = document_->begin(); i != document_->end(); ++i)
         {
         if(xml::node::type_element == i->get_type())


### PR DESCRIPTION
Suppress several instances of the following warnings when building with MSVC14:

warning C4456: declaration of 'xxx' hides previous local declaration
warning C4458: declaration of 'xxx' hides class member

(the latter for AccountValue::mode member only).

---

This patch was previously [posted to the list](http://lists.nongnu.org/archive/html/lmi/2016-02/msg00017.html).