### PR TITLE
Use a single file menu adjusted in the code

### DIFF
--- a/census_view.hpp
+++ b/census_view.hpp
@@ -65,6 +65,7 @@ class CensusView
     CensusDocument& document() const;
 
     // ViewEx required implementation.
+    virtual bool CanBePrinted() const { return true; }
     virtual wxWindow* CreateChildWindow();
     virtual char const* icon_xrc_resource   () const;
     virtual char const* menubar_xrc_resource() const;

--- a/gpt_view.hpp
+++ b/gpt_view.hpp
@@ -80,6 +80,7 @@ class gpt_view
     void Run();
 
     // ViewEx required implementation.
+    virtual bool CanBePrinted() const { return true; }
     virtual wxWindow* CreateChildWindow();
     virtual char const* icon_xrc_resource   () const;
     virtual char const* menubar_xrc_resource() const;

--- a/illustration_view.hpp
+++ b/illustration_view.hpp
@@ -80,6 +80,7 @@ class IllustrationView
     void emit_pdf(mcenum_emission);
 
     // ViewEx required implementation.
+    virtual bool CanBePrinted() const { return true; }
     virtual wxWindow* CreateChildWindow();
     virtual char const* icon_xrc_resource   () const;
     virtual char const* menubar_xrc_resource() const;

--- a/mec_view.hpp
+++ b/mec_view.hpp
@@ -80,6 +80,7 @@ class mec_view
     void Run();
 
     // ViewEx required implementation.
+    virtual bool CanBePrinted() const { return true; }
     virtual wxWindow* CreateChildWindow();
     virtual char const* icon_xrc_resource   () const;
     virtual char const* menubar_xrc_resource() const;

--- a/menus.xrc
+++ b/menus.xrc
@@ -30,11 +30,12 @@
 <!-- reusable menus -->
 
 <!--
-  This 'File' menu includes commands to save, close, and print documents.
-  Use it when the current document uses these print commands.
+  The fill 'File' menu includes commands to save, close, and print documents.
+  Some of these commands are deleted from the menu in the code when it is used
+  with the documents for which they don't make sense.
 -->
 
-<object class="wxMenu" name="file_menu_with_print_ref">
+<object class="wxMenu" name="file_menu_ref">
     <label>_File</label>
     <object class="wxMenuItem" name="wxID_NEW">
         <label>_New...\tCtrl-N</label>
@@ -82,94 +83,6 @@
         <label>Pr_int to PDF\tCtrl-I</label>
         <bitmap platform="win" stock_id="save-pdf"/>
         <help>Print this document to a PDF file</help>
-    </object>
-    <object class="separator"/>
-    <object class="wxMenuItem" name="edit_default_cell">
-        <label>Defaul_t...\tCtrl-T</label>
-        <bitmap platform="win" stock_id="default-cell"/>
-        <help>Edit default cell</help>
-    </object>
-    <object class="wxMenuItem" name="wxID_PREFERENCES">
-        <label>Pre_ferences...\tCtrl-F</label>
-        <bitmap platform="win" stock_id="preferences"/>
-        <help>Manage preferences</help>
-    </object>
-    <object class="separator"/>
-    <object class="wxMenuItem" name="wxID_EXIT">
-        <label>E_xit</label>
-        <bitmap platform="win" stock_id="wxART_QUIT"/>
-        <help>Exit this program</help>
-    </object>
-</object>
-
-<!--
-  This 'File' menu excludes commands to print documents.
-  Use it when the current document does not use these print commands.
--->
-
-<object class="wxMenu" name="file_menu_without_print_ref">
-    <label>_File</label>
-    <object class="wxMenuItem" name="wxID_NEW">
-        <label>_New...\tCtrl-N</label>
-        <bitmap platform="win" stock_id="wxART_NEW"/>
-        <help>Create a new document</help>
-    </object>
-    <object class="wxMenuItem" name="wxID_OPEN">
-        <label>_Open...\tCtrl-O</label>
-        <bitmap platform="win" stock_id="wxART_FILE_OPEN"/>
-        <help>Open an existing document</help>
-    </object>
-    <object class="wxMenuItem" name="wxID_CLOSE">
-        <label>C_lose\tCtrl-L</label>
-        <bitmap platform="win" stock_id="close"/>
-        <help>Close this document</help>
-    </object>
-    <object class="separator"/>
-    <object class="wxMenuItem" name="wxID_SAVE">
-        <label>_Save\tCtrl-S</label>
-        <bitmap platform="win" stock_id="wxART_FILE_SAVE"/>
-        <help>Save this document</help>
-    </object>
-    <object class="wxMenuItem" name="wxID_SAVEAS">
-        <label>Save _as...\tCtrl-A</label>
-        <bitmap platform="win" stock_id="wxART_FILE_SAVE_AS"/>
-        <help>Save this document under a new name</help>
-    </object>
-    <object class="separator"/>
-    <object class="wxMenuItem" name="edit_default_cell">
-        <label>Defaul_t...\tCtrl-T</label>
-        <bitmap platform="win" stock_id="default-cell"/>
-        <help>Edit default cell</help>
-    </object>
-    <object class="wxMenuItem" name="wxID_PREFERENCES">
-        <label>Pre_ferences...\tCtrl-F</label>
-        <bitmap platform="win" stock_id="preferences"/>
-        <help>Manage preferences</help>
-    </object>
-    <object class="separator"/>
-    <object class="wxMenuItem" name="wxID_EXIT">
-        <label>E_xit</label>
-        <bitmap platform="win" stock_id="wxART_QUIT"/>
-        <help>Exit this program</help>
-    </object>
-</object>
-
-<!--
-  This 'File' menu excludes commands to save, close, and print documents.
-  Use it when no document is open in a child window.
--->
-
-<object class="wxMenu" name="file_menu_without_child_ref">
-    <label>_File</label>
-    <object class="wxMenuItem" name="wxID_NEW">
-        <label>_New...\tCtrl-N</label>
-        <bitmap platform="win" stock_id="wxART_NEW"/>
-        <help>Create a new document</help>
-    </object>
-    <object class="wxMenuItem" name="wxID_OPEN">
-        <label>_Open...\tCtrl-O</label>
-        <bitmap platform="win" stock_id="wxART_FILE_OPEN"/>
-        <help>Open an existing document</help>
     </object>
     <object class="separator"/>
     <object class="wxMenuItem" name="edit_default_cell">
@@ -301,7 +214,7 @@
 
 <object class="wxMenuBar" name="main_menu">
 <style>wxMB_DOCKABLE</style>
-    <object_ref name="file_menu" ref="file_menu_without_child_ref"/>
+    <object_ref name="file_menu" ref="file_menu_ref"/>
     <object_ref name="test_menu" ref="test_menu_ref"/>
     <object_ref name="wxID_HELP" ref="help_menu_ref"/>
 </object>
@@ -397,7 +310,7 @@
 
 <object class="wxMenuBar" name="census_view_menu">
 <style>wxMB_DOCKABLE</style>
-    <object_ref name="file_menu" ref="file_menu_with_print_ref"/>
+    <object_ref name="file_menu" ref="file_menu_ref"/>
     <object_ref name="census_menu" ref="census_menu_ref"/>
     <object_ref name="test_menu" ref="test_menu_ref"/>
     <object_ref name="window_menu" ref="window_menu_ref"/>
@@ -410,7 +323,7 @@
 
 <object class="wxMenuBar" name="illustration_view_menu">
 <style>wxMB_DOCKABLE</style>
-    <object_ref name="file_menu" ref="file_menu_with_print_ref"/>
+    <object_ref name="file_menu" ref="file_menu_ref"/>
     <object class="wxMenu" name="illustration_menu">
         <label>_Illustration</label>
         <object class="wxMenuItem" name="edit_cell">
@@ -441,7 +354,7 @@
 
 <object class="wxMenuBar" name="database_view_menu">
 <style>wxMB_DOCKABLE</style>
-    <object_ref name="file_menu" ref="file_menu_without_print_ref"/>
+    <object_ref name="file_menu" ref="file_menu_ref"/>
 <!-- No menuitems yet.
     <object class="wxMenu" name="database_menu">
         <label>_Database</label>
@@ -458,7 +371,7 @@
 
 <object class="wxMenuBar" name="policy_view_menu">
 <style>wxMB_DOCKABLE</style>
-    <object_ref name="file_menu" ref="file_menu_without_print_ref"/>
+    <object_ref name="file_menu" ref="file_menu_ref"/>
 <!-- No menuitems yet.
     <object class="wxMenu" name="policy_menu">
         <label>P_olicy</label>
@@ -475,7 +388,7 @@
 
 <object class="wxMenuBar" name="rounding_view_menu">
 <style>wxMB_DOCKABLE</style>
-    <object_ref name="file_menu" ref="file_menu_without_print_ref"/>
+    <object_ref name="file_menu" ref="file_menu_ref"/>
 <!-- No menuitems yet.
     <object class="wxMenu" name="rounding_menu">
         <label>_Rounding</label>
@@ -492,7 +405,7 @@
 
 <object class="wxMenuBar" name="tier_view_menu">
 <style>wxMB_DOCKABLE</style>
-    <object_ref name="file_menu" ref="file_menu_without_print_ref"/>
+    <object_ref name="file_menu" ref="file_menu_ref"/>
 <!-- No menuitems yet.
     <object class="wxMenu" name="tier_menu">
         <label>_Tier</label>
@@ -509,7 +422,7 @@
 
 <object class="wxMenuBar" name="text_view_menu">
 <style>wxMB_DOCKABLE</style>
-    <object_ref name="file_menu" ref="file_menu_without_print_ref"/>
+    <object_ref name="file_menu" ref="file_menu_ref"/>
 <!-- No menuitems yet.
     <object class="wxMenu" name="text_menu">
         <label>Te_xt</label>
@@ -526,7 +439,7 @@
 
 <object class="wxMenuBar" name="mec_view_menu">
 <style>wxMB_DOCKABLE</style>
-    <object_ref name="file_menu" ref="file_menu_with_print_ref"/>
+    <object_ref name="file_menu" ref="file_menu_ref"/>
     <object class="wxMenu" name="mec_menu">
         <label>_MEC</label>
         <object class="wxMenuItem" name="edit_cell">
@@ -546,7 +459,7 @@
 
 <object class="wxMenuBar" name="gpt_view_menu">
 <style>wxMB_DOCKABLE</style>
-    <object_ref name="file_menu" ref="file_menu_with_print_ref"/>
+    <object_ref name="file_menu" ref="file_menu_ref"/>
     <object class="wxMenu" name="gpt_menu">
         <label>_GPT</label>
         <object class="wxMenuItem" name="edit_cell">

--- a/product_editor.hpp
+++ b/product_editor.hpp
@@ -79,6 +79,10 @@ class ProductEditorView
     ProductEditorView();
     virtual ~ProductEditorView();
 
+    // None of the product documents is currently printable, so provide a
+    // common implementation of this ViewEx method for all our subclasses.
+    virtual bool CanBePrinted() const { return false; }
+
   protected:
     virtual bool IsModified() const = 0;
     virtual void DiscardEdits() = 0;

--- a/skeleton.cpp
+++ b/skeleton.cpp
@@ -220,7 +220,7 @@ wxMDIChildFrame* Skeleton::CreateChildFrame
         ,"Loading..."
         );
     child_frame->SetIcon(view->Icon());
-    child_frame->SetMenuBar(AdjustMenus(view->MenuBar()));
+    child_frame->SetMenuBar(AdjustMenus(view->MenuBar(), view));
 
     // Style flag wxMAXIMIZE could have been used instead, but that
     // seems to work only with the msw platform.
@@ -231,6 +231,30 @@ wxMDIChildFrame* Skeleton::CreateChildFrame
 
     return child_frame;
 }
+
+namespace
+{
+
+/// Delete the item with the given ID from the menu bar if it exists.
+
+void DeleteItemFromMenuBar(wxMenuBar& menu_bar, int item_id)
+{
+    wxMenuItem* const item = menu_bar.FindItem(item_id);
+    if(!item)
+        {
+        // We could complain about the item not being there, but this doesn't
+        // seem to be all that useful and there is no real harm done in trying
+        // to delete an already non-existent item, so just ignore it silently.
+        return;
+        }
+
+    wxMenu* const menu = item->GetMenu();
+    LMI_ASSERT(menu);
+
+    menu->Delete(item);
+}
+
+} // Unnamed namespace.
 
 /// Adjust menus read from wxxrc resources.
 ///
@@ -244,11 +268,97 @@ wxMDIChildFrame* Skeleton::CreateChildFrame
 /// resource and conditionally inserted here, but that would be less
 /// flexible: e.g., menu order couldn't be controlled completely in
 /// the wxxrc file.
+///
+/// In addition, some items in the common "File" menu don't make sense
+/// for all views. If there is no view at all, as indicated by the
+/// corresponding argument being NULL, commands for closing and saving
+/// it shouldn't be proposed. And if there is a view, but printing it
+/// is not supported, then all printing-related commands are hidden too.
 
-wxMenuBar* Skeleton::AdjustMenus(wxMenuBar* argument)
+wxMenuBar* Skeleton::AdjustMenus(wxMenuBar* argument, ViewEx* view)
 {
     LMI_ASSERT(argument);
     wxMenuBar& menu_bar = *argument;
+
+    // Don't bother doing anything if we don't need to adjust the menu at all.
+    if(!view || !view->CanBePrinted())
+        {
+        // Delete the items pertaining to the current view if we don't have it
+        // at all.
+        if(!view)
+            {
+            // Unlike with the printing items below, we delete just the few
+            // well-known items as it seems unwise to assume that all the items
+            // added after "Close" will always need to be deleted.
+            DeleteItemFromMenuBar(menu_bar, wxID_CLOSE);
+            DeleteItemFromMenuBar(menu_bar, wxID_SAVE);
+            DeleteItemFromMenuBar(menu_bar, wxID_SAVEAS);
+
+            // Notice that after doing the above we can (and currently do) end
+            // up with two consecutive separators, but we rely on the loop
+            // below to clean this up.
+            }
+
+        // Delete all printing-related items in any case. We assume that all
+        // these items are in their own section of the menu, delimited by
+        // separators and starting with the "Print" item, so we just delete
+        // everything from it and up to and including the next separator so
+        // that if any new printing commands are added in the future, they will
+        // still be handled correctly by this code.
+        wxMenuItem* print_item = menu_bar.FindItem(wxID_PRINT);
+        if(!print_item)
+            {
+            warning() << "'Print' menu item not found.";
+            }
+        else
+            {
+            wxMenu* const menu = print_item->GetMenu();
+            LMI_ASSERT(menu);
+
+            bool last_was_separator = false;
+            bool inside_print_section = false;
+            wxMenuItemList& items = menu->GetMenuItems();
+
+            // Notice that the iterator is not incremented in the loop as we
+            // must update it before deleting the item it refers to.
+            for(wxMenuItemList::iterator i = items.begin(); i != items.end(); )
+                {
+                wxMenuItem* const item = *i;
+                bool const is_separator = item->IsSeparator();
+                if(last_was_separator && is_separator)
+                    {
+                    // Eliminate consecutive separators if the code deleting
+                    // the view-related items above created them.
+                    ++i;
+                    menu->Delete(item);
+                    continue;
+                    }
+
+                last_was_separator = is_separator;
+
+                // Check if we found the first item to delete.
+                if(!inside_print_section && *i == print_item)
+                    {
+                    inside_print_section = true;
+                    }
+
+                if(inside_print_section)
+                    {
+                    ++i;
+                    menu->Delete(item);
+                    if (is_separator)
+                        {
+                        // We consider this to be the end of the print section.
+                        break;
+                        }
+                    }
+                else
+                    {
+                    ++i;
+                    }
+                }
+            }
+        }
 
     if(!global_settings::instance().ash_nazg())
         {

--- a/skeleton.hpp
+++ b/skeleton.hpp
@@ -80,7 +80,7 @@ class Skeleton
     virtual bool OnInit                ();
 
   private:
-    wxMenuBar* AdjustMenus(wxMenuBar*);
+    wxMenuBar* AdjustMenus(wxMenuBar*, ViewEx* = NULL);
 
     void InitDocManager ();
     void InitHelp       ();

--- a/text_view.hpp
+++ b/text_view.hpp
@@ -64,6 +64,7 @@ class TextEditView
 
   private:
     // ViewEx required implementation.
+    virtual bool CanBePrinted() const { return false; }
     virtual wxWindow* CreateChildWindow();
     virtual char const* icon_xrc_resource   () const;
     virtual char const* menubar_xrc_resource() const;

--- a/view_ex.hpp
+++ b/view_ex.hpp
@@ -92,6 +92,12 @@ class ViewEx
   public:
     ViewEx();
 
+    // Return true if the documents shown by this view can be printed.
+    //
+    // As there is no obviously correct default, this method must be explicitly
+    // implemented in every derived class.
+    virtual bool CanBePrinted() const = 0;
+
     wxIcon     Icon   () const;
     wxMenuBar* MenuBar() const;
 


### PR DESCRIPTION
Instead of defining 3 different file menus in the XRC, and duplicating big
parts of the menu thrice, define only one menu with all the items and delete
those that are inappropriate for the current view when setting up the menu bar
in the code.

Reuse the existing Skeleton::AdjustMenus() to do it and pass an additional
pointer to the view to it to allow to decide which items to delete. The view
classes hierarchy has been modified to provide a CanBePrinted() method used
for this.

---

Patch previously [posted to the list](http://lists.nongnu.org/archive/html/lmi/2015-11/msg00010.html) to address the concern about duplicating "File" menu in the XRC.

