### PR TITLE
Detect unused parameters in configure builds too

### DIFF
--- a/census_document.cpp
+++ b/census_document.cpp
@@ -110,7 +110,7 @@ bool CensusDocument::OnNewDocument()
 
 /// See documentation for IllustrationDocument::DoOpenDocument().
 
-bool CensusDocument::DoOpenDocument(wxString const& filename)
+bool CensusDocument::DoOpenDocument(wxString const& /* filename */)
 {
     return true;
 }

--- a/configure.ac
+++ b/configure.ac
@@ -532,6 +532,7 @@ if test "$GCC" == "yes"; then
         -pedantic-errors \
         -Werror \
         -Wall \
+        -Wextra \
         -Wundef"
 
     if test "$CLANG" = "yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -589,9 +589,6 @@ if test "x$GXX" == "xyes"; then
         LMI_CXX_ADD_IF_SUPPORTED(-Wno-parentheses)
     fi
 
-    dnl and this one occurs in older Boost headers
-    LMI_CXX_ADD_IF_SUPPORTED(-Wno-unused-local-typedef)
-
     dnl Many instances of these warnings are given in Boost 1.33.1 headers, so
     dnl we unfortunately have to disable them even if they're potentially
     dnl useful, especially the latter one.

--- a/gpt_document.cpp
+++ b/gpt_document.cpp
@@ -111,7 +111,7 @@ bool gpt_document::OnNewDocument()
 
 /// See the documentation for similar class IllustrationDocument.
 
-bool gpt_document::DoOpenDocument(wxString const& filename)
+bool gpt_document::DoOpenDocument(wxString const& /* filename */)
 {
     return true;
 }

--- a/illustration_document.cpp
+++ b/illustration_document.cpp
@@ -161,7 +161,7 @@ bool IllustrationDocument::OnNewDocument()
 /// Override DoOpenDocument() instead of OnOpenDocument(): the latter
 /// doesn't permit customizing its diagnostic messages.
 
-bool IllustrationDocument::DoOpenDocument(wxString const& filename)
+bool IllustrationDocument::DoOpenDocument(wxString const& /* filename */)
 {
     return true;
 }

--- a/mec_document.cpp
+++ b/mec_document.cpp
@@ -111,7 +111,7 @@ bool mec_document::OnNewDocument()
 
 /// See the documentation for similar class IllustrationDocument.
 
-bool mec_document::DoOpenDocument(wxString const& filename)
+bool mec_document::DoOpenDocument(wxString const& /* filename */)
 {
     return true;
 }

--- a/msw_workarounds.cpp
+++ b/msw_workarounds.cpp
@@ -28,6 +28,8 @@
 
 #include "msw_workarounds.hpp"
 
+#ifdef LMI_MSW
+
 #include "alert.hpp"
 #include "configurable_settings.hpp"
 #include "fenv_lmi.hpp"
@@ -35,9 +37,7 @@
 
 #include <boost/functional.hpp>
 
-#ifdef LMI_MSW
-#   include <windows.h>
-#endif // LMI_MSW defined.
+#include <windows.h>
 
 #include <algorithm>
 #include <functional>
@@ -87,7 +87,6 @@ void MswDllPreloader::PreloadDesignatedDlls()
 
 void MswDllPreloader::PreloadOneDll(std::string const& dll_name)
 {
-#ifdef LMI_MSW
     fenv_initialize();
 
     if(0 == ::LoadLibraryA(dll_name.c_str()))
@@ -109,16 +108,14 @@ void MswDllPreloader::PreloadOneDll(std::string const& dll_name)
                 ;
             }
         }
-#endif // LMI_MSW defined.
 }
 
 void MswDllPreloader::UnloadOneDll(std::string const& dll_name)
 {
-#ifdef LMI_MSW
     if(0 == ::FreeLibrary(::GetModuleHandleA(dll_name.c_str())))
         {
         warning() << "Failed to unload '" << dll_name << "'." << LMI_FLUSH;
         }
-#endif // LMI_MSW defined.
 }
 
+#endif // LMI_MSW defined.

--- a/msw_workarounds.hpp
+++ b/msw_workarounds.hpp
@@ -26,6 +26,8 @@
 
 #include "config.hpp"
 
+#ifdef LMI_MSW
+
 #include "obstruct_slicing.hpp"
 #include "uncopyable_lmi.hpp"
 
@@ -66,6 +68,8 @@ class MswDllPreloader
 
     std::deque<std::string> SuccessfullyPreloadedDlls_;
 };
+
+#endif // LMI_MSW defined.
 
 #endif // msw_workarounds_hpp
 

--- a/multidimgrid_any.cpp
+++ b/multidimgrid_any.cpp
@@ -47,8 +47,8 @@
 /// --------------------------------------
 
 wxWindow* MultiDimAxisAny::CreateAdjustControl
-    (MultiDimGrid& grid
-    ,MultiDimTableAny& table
+    (MultiDimGrid& /* grid */
+    ,MultiDimTableAny& /* table */
     )
 {
     return NULL;
@@ -66,7 +66,7 @@ bool MultiDimAxisAny::RefreshAdjustment(wxWindow&, unsigned int)
 
 MultiDimAxisAnyChoice* MultiDimAxisAny::CreateChoiceControl
     (MultiDimGrid& grid
-    ,MultiDimTableAny& table
+    ,MultiDimTableAny& /* table */
     )
 {
     return new(wx) MultiDimAxisAnyChoice(*this, grid);
@@ -81,16 +81,16 @@ void MultiDimAxisAny::UpdateChoiceControl(MultiDimAxisAnyChoice& choice) const
 /// ---------------------------------------
 
 bool MultiDimTableAny::DoApplyAxisAdjustment
-    (MultiDimAxisAny& axis
-    ,unsigned int n
+    (MultiDimAxisAny& /* axis */
+    ,unsigned int /* n */
     )
 {
     return false;
 }
 
 bool MultiDimTableAny::DoRefreshAxisAdjustment
-    (MultiDimAxisAny& axis
-    ,unsigned int n
+    (MultiDimAxisAny& /* axis */
+    ,unsigned int /* n */
     )
 {
     return false;
@@ -1106,7 +1106,7 @@ unsigned int MultiDimGrid::DoGetNumberCols() const
     return axis_[first_grid_axis_]->GetCardinality();
 }
 
-bool MultiDimGrid::IsEmptyCell(int row, int col)
+bool MultiDimGrid::IsEmptyCell(int /* row */, int /* col */)
 {
     return false;
 }

--- a/multidimgrid_tools.hpp
+++ b/multidimgrid_tools.hpp
@@ -378,7 +378,7 @@ template<typename Integral>
 typename AdjustableMaxBoundAxis<Integral>::Adjuster*
 AdjustableMaxBoundAxis<Integral>::DoCreateAdjustControl
     (MultiDimGrid& grid
-    ,MultiDimTableAny& table
+    ,MultiDimTableAny& /* table */
     )
 {
     // called only once
@@ -392,7 +392,7 @@ AdjustableMaxBoundAxis<Integral>::DoCreateAdjustControl
 template<typename Integral>
 bool AdjustableMaxBoundAxis<Integral>::DoApplyAdjustment
     (Adjuster& adjust_window
-    ,unsigned int axis_id
+    ,unsigned int /* axis_id */
     )
 {
     Integral const new_max_value = adjust_window.GetMaximumAxisValue();
@@ -411,7 +411,7 @@ bool AdjustableMaxBoundAxis<Integral>::DoApplyAdjustment
 template<typename Integral>
 bool AdjustableMaxBoundAxis<Integral>::DoRefreshAdjustment
     (Adjuster& adjust_window
-    ,unsigned int axis_id
+    ,unsigned int /* axis_id */
     )
 {
     Integral const max_value = adjust_window.GetMaximumAxisValue();


### PR DESCRIPTION
This required fixing a few of unused parameters in the code compiled without `-Wextra` in the makefile builds and also not compiling `MswDllPreloader` (which would otherwise result in a couple of `-Wunused-parameter` warnings which would be inconvenient to fix as parameters were only unused under non-MSW) at all when not using MSW.