### PR TITLE
Census view optimizations

### DIFF
--- a/any_member.hpp
+++ b/any_member.hpp
@@ -287,7 +287,6 @@ class any_member
     // any_entity required implementation.
     virtual any_member& assign(std::string const&);
 
-    ClassType* object_;
     placeholder* content_;
 };
 
@@ -295,15 +294,13 @@ class any_member
 
 template<typename ClassType>
 any_member<ClassType>::any_member()
-    :object_(0)
-    ,content_(0)
+    :content_(0)
 {}
 
 template<typename ClassType>
 any_member<ClassType>::any_member(any_member const& other)
     :obstruct_slicing<any_member<ClassType> >()
     ,any_entity (other)
-    ,object_    (other.object_)
     ,content_   (other.content_ ? other.content_->clone() : 0)
 {}
 
@@ -316,8 +313,7 @@ any_member<ClassType>::~any_member()
 template<typename ClassType>
 template<typename ValueType>
 any_member<ClassType>::any_member(ClassType* object, ValueType const& value)
-    :object_(object)
-    ,content_(new holder<ClassType,ValueType>(object, value))
+    :content_(new holder<ClassType,ValueType>(object, value))
 {}
 
 template<typename ClassType>
@@ -390,9 +386,10 @@ ExactMemberType* any_member<ClassType>::exact_cast()
     typedef holder<ClassType,pmd_type> holder_type;
     LMI_ASSERT(content_);
 #if !defined LMI_MSC
-    pmd_type pmd = static_cast<holder_type*>(content_)->held_;
-    LMI_ASSERT(object_);
-    return &(object_->*pmd);
+    holder_type* const holder = static_cast<holder_type*>(content_);
+    pmd_type pmd = holder->held_;
+    LMI_ASSERT(holder->object_);
+    return &(holder->object_->*pmd);
 #else  // defined LMI_MSC
     return static_cast<ExactMemberType*>(content_->defraud());
 #endif // defined LMI_MSC

--- a/any_member.hpp
+++ b/any_member.hpp
@@ -568,6 +568,9 @@ class MemberSymbolTable
     bool equals(MemberSymbolTable<ClassType> const&) const;
     std::vector<std::string> const& member_names() const;
 
+    size_t get_member_index(std::string const&) const;
+    any_member<ClassType> const& get_member_by_index(size_t) const;
+
   protected:
     MemberSymbolTable();
 
@@ -636,17 +639,30 @@ void MemberSymbolTable<ClassType>::complain_that_no_such_member_is_ascribed
 }
 
 template<typename ClassType>
-any_member<ClassType>& MemberSymbolTable<ClassType>::operator[]
-    (std::string const& s
-    )
+size_t MemberSymbolTable<ClassType>::get_member_index(std::string const& s) const
 {
-    typedef std::vector<std::string>::iterator svi;
-    svi i = std::lower_bound(member_names_.begin(), member_names_.end(), s);
+    typedef std::vector<std::string>::const_iterator svci;
+    svci i = std::lower_bound(member_names_.begin(), member_names_.end(), s);
     if(member_names_.end() == i || s != *i)
         {
         complain_that_no_such_member_is_ascribed(s);
         }
-    return member_values_[i - member_names_.begin()];
+    return i - member_names_.begin();
+}
+
+template<typename ClassType>
+any_member<ClassType> const&
+MemberSymbolTable<ClassType>::get_member_by_index(size_t n) const
+{
+    return member_values_[n];
+}
+
+template<typename ClassType>
+any_member<ClassType>& MemberSymbolTable<ClassType>::operator[]
+    (std::string const& s
+    )
+{
+    return member_values_[get_member_index(s)];
 }
 
 template<typename ClassType>

--- a/any_member.hpp
+++ b/any_member.hpp
@@ -403,6 +403,16 @@ any_member<ClassType>& any_member<ClassType>::assign(std::string const& s)
     return *this;
 }
 
+/// The standard implementation of swap() doesn't work for any_member<> as it
+/// doesn't allow swapping the members of different types, so this is more than
+/// optimization: providing this specialization is required for e.g. storing
+/// the objects of this class in standard containers.
+template <typename ClassType>
+void swap(any_member<ClassType>& left, any_member<ClassType>& right)
+{
+    left.swap(right);
+}
+
 /// Definition of class template reconstitutor.
 ///
 /// Class template reconstitutor matches pointer-to-member types.

--- a/any_member_test.cpp
+++ b/any_member_test.cpp
@@ -108,7 +108,7 @@ std::ostream& operator<<(std::ostream& os, X const& x) {return os << x.str() << 
 class S
     :public MemberSymbolTable<S>
 {
-    friend class any_member_test;
+    friend struct any_member_test;
 
   public:
     S();

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -972,10 +972,12 @@ bool CensusView::column_value_varies_across_cells
     ,std::vector<Input> const& cells
     ) const
 {
+    const any_member<Input>& case_value = case_parms()[0][header];
+
     typedef std::vector<Input>::const_iterator ici;
     for(ici j = cells.begin(); j != cells.end(); ++j)
         {
-        if(!((*j)[header] == case_parms()[0][header]))
+        if(!((*j)[header] == case_value))
             {
             return true;
             }

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -975,9 +975,12 @@ bool CensusView::column_value_varies_across_cells
     const any_member<Input>& case_value = case_parms()[0][header];
 
     typedef std::vector<Input>::const_iterator ici;
-    for(ici j = cells.begin(); j != cells.end(); ++j)
+    ici j = cells.begin();
+    size_t const header_index = j->get_member_index(header);
+
+    for(; j != cells.end(); ++j)
         {
-        if(!((*j)[header] == case_value))
+        if(!(j->get_member_by_index(header_index) == case_value))
             {
             return true;
             }

--- a/census_view.hpp
+++ b/census_view.hpp
@@ -60,7 +60,7 @@ class CensusView
     CensusView();
 
   private:
-    void update_visible_columns();
+    bool update_visible_columns();
 
     CensusDocument& document() const;
 
@@ -91,7 +91,7 @@ class CensusView
 
     bool DoAllCells(mcenum_emission);
 
-    void Update();
+    bool Update();
     void ViewOneCell(int);
     void ViewComposite();
 
@@ -133,6 +133,9 @@ class CensusView
 
     wxDataViewCtrl* list_window_;
     wxObjectDataPtr<CensusViewDataViewModel> list_model_;
+
+    std::vector<std::string> all_headers_;
+    std::vector<bool> headers_show_;
 
     DECLARE_DYNAMIC_CLASS(CensusView)
     DECLARE_EVENT_TABLE()


### PR DESCRIPTION
These changes are described in details in this [mailing list post](http://lists.nongnu.org/archive/html/lmi/2015-02/msg00019.html). Quoting from there:

> The conclusion is that the final version is more than 10 times faster than the original one in the fixed width case and more than 25 times faster in the variable width one, when using gcc.

Because of this, I think it would be nice to apply this as it will result in direct user-visible improvements.
