### PR TITLE
Define operator<<() for fs::path in the right namespace

### DIFF
--- a/path_utility.hpp
+++ b/path_utility.hpp
@@ -61,10 +61,18 @@ void LMI_SO validate_filepath
     ,std::string const& context
     );
 
+namespace boost
+{
+namespace filesystem
+{
+
 inline std::ostream& operator<<(std::ostream& os, fs::path const& z)
 {
     return os << z.string();
 }
+
+} // namespace filesystem
+} // namespace boost
 
 #endif // path_utility_hpp
 


### PR DESCRIPTION
To be usable even in the code not in the global namespace, this operator()
needs to be defined in the namespace of one of its arguments, so define it in
boost::filesystem namespace.

---
Previously [posted to the list](http://lists.nongnu.org/archive/html/lmi/2016-02/msg00030.html)