### PR TITLE
Avoid static analyzer warnings

### DIFF
--- a/ihs_crc_comp.cpp
+++ b/ihs_crc_comp.cpp
@@ -317,11 +317,13 @@ void f_3(std::string const& line1, std::string const& line2)
     std::cout
         << current_name
         << '\n';
+    std::streamsize const original_precision = std::cout.precision();
     std::cout
         << std::setprecision(20)
         << rel_err
         << "  " << d1
         << " vs. " << d2
+        << std::setprecision(original_precision)
         << '\n';
 }
 

--- a/interest_rates.cpp
+++ b/interest_rates.cpp
@@ -192,8 +192,8 @@ void convert_interest_rates
     annual_net_rate .resize(length);
     monthly_net_rate.resize(length);
 
-    double cached_annual_net_rate;
-    double cached_monthly_net_rate;
+    double cached_annual_net_rate     = 0.0;
+    double cached_monthly_net_rate    = 0.0;
 
     double previous_annual_gross_rate = 0.0;
     double previous_spread            = 0.0;


### PR DESCRIPTION
Some time ago I tried using lmi with Coverity and, among the warnings it generated, there were a couple of harmless ones that can be easily fixed and I'm submitting the patches to do it. The main benefit of applying them is that this will make it simpler for me to use Coverity or clang static analyzer in the future.

The one about uninitialized variables would be nice to fix as it happens in the MSVS build as well.