### PR TITLE
Enhancements to input sequence editor dialog UI

### DIFF
--- a/input_sequence_entry.cpp
+++ b/input_sequence_entry.cpp
@@ -554,11 +554,9 @@ std::string InputSequenceEditor::sequence_string()
     return s;
 }
 
-void SizeWinForText(wxWindow* win, wxString const& text, int extra = 0)
+void SizeWinForText(wxControl* win, wxString const& text)
 {
-    int x, y;
-    win->GetTextExtent(text, &x, &y);
-    win->SetMinSize(wxSize(x + extra, -1));
+    win->SetMinSize(win->GetSizeFromTextSize(win->GetTextExtent(text).x));
 }
 
 void InputSequenceEditor::add_row()
@@ -638,7 +636,7 @@ void InputSequenceEditor::insert_row(int new_row)
     sizer_->wxSizer::Insert(insert_pos++, duration_mode, flags);
     wxSpinCtrl* duration_num = new(wx) wxSpinCtrl(rows_area_, wxID_ANY, "");
     sizer_->wxSizer::Insert(insert_pos++, duration_num, flags);
-    SizeWinForText(duration_num, "9999", 20);
+    SizeWinForText(duration_num, "9999");
     wxStaticText* then_label = new(wx) wxStaticText
         (rows_area_
         ,wxID_ANY

--- a/input_sequence_entry.cpp
+++ b/input_sequence_entry.cpp
@@ -1186,7 +1186,14 @@ class InputSequenceTextCtrl
 };
 
 InputSequenceTextCtrl::InputSequenceTextCtrl(wxWindow* parent, wxWindowID id)
-    :wxTextCtrl(parent, id)
+    :wxTextCtrl
+        (parent
+        ,id
+        ,wxString()
+        ,wxDefaultPosition
+        ,wxDefaultSize
+        ,wxTE_PROCESS_ENTER
+        )
 {
     ::Connect
             (this
@@ -1267,6 +1274,12 @@ bool InputSequenceEntry::Create
         ,NULL
         ,this
         );
+    text_->Connect
+        (wxEVT_TEXT_ENTER
+        ,wxCommandEventHandler(InputSequenceEntry::UponEnter)
+        ,NULL
+        ,this
+        );
 
     button_->Connect
         (wxEVT_KILL_FOCUS
@@ -1344,7 +1357,37 @@ void InputSequenceEntry::UponChildKillFocus(wxFocusEvent& event)
     event.Skip();
 }
 
+void InputSequenceEntry::UponEnter(wxCommandEvent& event)
+{
+    // Pressing Enter key without modifiers just accepts the changes, but we
+    // allow using Alt-Enter to open the input sequence editor dialog from
+    // keyboard.
+    if(!wxGetKeyState(WXK_ALT))
+        {
+        event.Skip();
+        return;
+        }
+
+    DoOpenEditor();
+
+    // Put focus back on the control itself as normal focus restoring logic
+    // doesn't work as we block some of the events in UponChildKillFocus().
+    text_->SetFocus();
+}
+
 void InputSequenceEntry::UponOpenEditor(wxCommandEvent&)
+{
+    DoOpenEditor();
+
+    // If this editor is used inside wxDataViewCtrl, don't keep focus after
+    // showing the dialog but give it to the parent to ensure that the editor
+    // is closed by it. Notice that there is no need to check if we actually
+    // are inside wxDataViewCtrl before doing it as otherwise our parent (e.g.
+    // a wxPanel) will just give focus back to us and nothing really happens.
+    GetParent()->SetFocus();
+}
+
+void InputSequenceEntry::DoOpenEditor()
 {
     Input const& in = input();
 
@@ -1396,13 +1439,6 @@ void InputSequenceEntry::UponOpenEditor(wxCommandEvent&)
     editor.CentreOnParent();
 
     editor.ShowModal();
-
-    // If this editor is used inside wxDataViewCtrl, don't keep focus after
-    // showing the dialog but give it to the parent to ensure that the editor
-    // is closed by it. Notice that there is no need to check if we actually
-    // are inside wxDataViewCtrl before doing it as otherwise our parent (e.g.
-    // a wxPanel) will just give focus back to us and nothing really happens.
-    GetParent()->SetFocus();
 }
 
 IMPLEMENT_DYNAMIC_CLASS(InputSequenceEntryXmlHandler, wxXmlResourceHandler)

--- a/input_sequence_entry.cpp
+++ b/input_sequence_entry.cpp
@@ -383,7 +383,14 @@ InputSequenceEditor::InputSequenceEditor(wxWindow* parent, wxString const& title
     sizer_ = new(wx) wxFlexGridSizer(Col_Max, sizerGap);
     rows_area_->SetSizer(sizer_);
 
-    diagnostics_ = new(wx) wxStaticText(this, wxID_ANY, "");
+    diagnostics_ = new(wx) wxStaticText
+        (this
+        ,wxID_ANY
+        ,""
+        ,wxDefaultPosition
+        ,wxDefaultSize
+        ,wxST_NO_AUTORESIZE
+        );
     top->Add(diagnostics_, wxSizerFlags().Expand().DoubleBorder(wxLEFT|wxRIGHT));
 
     wxStdDialogButtonSizer* buttons = new(wx) wxStdDialogButtonSizer();
@@ -617,7 +624,14 @@ void InputSequenceEditor::insert_row(int new_row)
         }
 
     sizer_->wxSizer::Insert(insert_pos++, value_ctrl, wxSizerFlags(flags).TripleBorder(wxRIGHT));
-    wxStaticText* from_label = new(wx) wxStaticText(rows_area_, wxID_ANY, LARGEST_FROM_TEXT);
+    wxStaticText* from_label = new(wx) wxStaticText
+        (rows_area_
+        ,wxID_ANY
+        ,LARGEST_FROM_TEXT
+        ,wxDefaultPosition
+        ,wxDefaultSize
+        ,wxST_NO_AUTORESIZE
+        );
     SizeWinForText(from_label, LARGEST_FROM_TEXT);
     sizer_->wxSizer::Insert(insert_pos++, from_label, flags);
     wxChoice* duration_mode = new(wx) DurationModeChoice(rows_area_);
@@ -625,7 +639,14 @@ void InputSequenceEditor::insert_row(int new_row)
     wxSpinCtrl* duration_num = new(wx) wxSpinCtrl(rows_area_, wxID_ANY, "");
     sizer_->wxSizer::Insert(insert_pos++, duration_num, flags);
     SizeWinForText(duration_num, "9999", 20);
-    wxStaticText* then_label = new(wx) wxStaticText(rows_area_, wxID_ANY, LARGEST_THEN_TEXT);
+    wxStaticText* then_label = new(wx) wxStaticText
+        (rows_area_
+        ,wxID_ANY
+        ,LARGEST_THEN_TEXT
+        ,wxDefaultPosition
+        ,wxDefaultSize
+        ,wxST_NO_AUTORESIZE
+        );
     sizer_->wxSizer::Insert(insert_pos++, then_label, flags);
     SizeWinForText(then_label, LARGEST_THEN_TEXT);
 

--- a/input_sequence_entry.cpp
+++ b/input_sequence_entry.cpp
@@ -51,6 +51,7 @@
 #include <wx/spinctrl.h>
 #include <wx/stattext.h>
 #include <wx/textctrl.h>
+#include <wx/wupdlock.h>
 #include <wx/valtext.h>
 
 #include <algorithm>              // std::copy()
@@ -94,10 +95,13 @@ DurationModeChoice::DurationModeChoice(wxWindow* parent)
 {
     Create(parent, wxID_ANY);
 
+    {
+    wxWindowUpdateLocker lock(this);
     for(unsigned int i = 0; i < duration_mode_choices; ++i)
         {
         Append(duration_mode_choice_values[i].label);
         }
+    }
 
     // "maturity" is the default
     value(e_maturity);
@@ -589,7 +593,10 @@ void InputSequenceEditor::insert_row(int new_row)
 
         wxArrayString kw;
         std::copy(keywords_.begin(), keywords_.end(), std::back_inserter(kw));
+        {
+        wxWindowUpdateLocker lock_combo(combo);
         combo->Append(kw);
+        }
 
         if(keywords_only_)
             {

--- a/input_sequence_entry.cpp
+++ b/input_sequence_entry.cpp
@@ -45,6 +45,8 @@
 #include <wx/combobox.h>
 #include <wx/dialog.h>
 #include <wx/display.h>
+#include <wx/scrolwin.h>
+#include <wx/settings.h>
 #include <wx/sizer.h>
 #include <wx/spinctrl.h>
 #include <wx/stattext.h>
@@ -289,6 +291,7 @@ class InputSequenceEditor
     std::string default_keyword_;
 
     int rows_count_;
+    wxScrolledWindow* rows_area_;
     wxFlexGridSizer* sizer_;
     wxButton* ok_button_;
     wxButton* cancel_button_;
@@ -318,8 +321,15 @@ InputSequenceEditor::InputSequenceEditor(wxWindow* parent, wxString const& title
 {
     wxSizer* top = new(wx) wxBoxSizer(wxVERTICAL);
 
-    sizer_ = new(wx) wxFlexGridSizer(Col_Max, 5, 5);
-    top->Add(sizer_, wxSizerFlags(1).Expand().DoubleBorder());
+    rows_area_ = new(wx) wxScrolledWindow(this);
+    top->Add(rows_area_, wxSizerFlags(1).Expand().DoubleBorder());
+
+    const wxSize sizerGap
+        (wxSizerFlags::GetDefaultBorder()
+        ,wxSizerFlags::GetDefaultBorder()
+        );
+    sizer_ = new(wx) wxFlexGridSizer(Col_Max, sizerGap);
+    rows_area_->SetSizer(sizer_);
 
     diagnostics_ = new(wx) wxStaticText(this, wxID_ANY, "");
     top->Add(diagnostics_, wxSizerFlags().Expand().DoubleBorder(wxLEFT|wxRIGHT));
@@ -335,6 +345,12 @@ InputSequenceEditor::InputSequenceEditor(wxWindow* parent, wxString const& title
     SetSizerAndFit(top);
 
     add_row();
+
+    // Now that we have a row, set up the row area to scroll by one its height
+    // (as we assume they all have the same size) vertically.
+    wxArrayInt const& row_heights = sizer_->GetRowHeights();
+    LMI_ASSERT(!row_heights.empty());
+    rows_area_->SetScrollRate(0, row_heights[0] + sizerGap.y);
 
     value_field_ctrl(0).SetFocus();
 }
@@ -506,7 +522,7 @@ void InputSequenceEditor::insert_row(int new_row)
     if(!keywords_.empty())
         {
         wxComboBox* combo = new(wx) wxComboBox
-            (this
+            (rows_area_
             ,wxID_ANY
             ,"0"
             ,wxDefaultPosition
@@ -535,20 +551,20 @@ void InputSequenceEditor::insert_row(int new_row)
     else
         {
         // No keywords, only numeric values
-        value_ctrl = new(wx) wxTextCtrl(this, wxID_ANY, "0");
+        value_ctrl = new(wx) wxTextCtrl(rows_area_, wxID_ANY, "0");
         value_ctrl->SetValidator(wxTextValidator(wxFILTER_NUMERIC));
         }
 
     sizer_->wxSizer::Insert(insert_pos++, value_ctrl, wxSizerFlags(flags).TripleBorder(wxRIGHT));
-    wxStaticText* from_label = new(wx) wxStaticText(this, wxID_ANY, LARGEST_FROM_TEXT);
+    wxStaticText* from_label = new(wx) wxStaticText(rows_area_, wxID_ANY, LARGEST_FROM_TEXT);
     SizeWinForText(from_label, LARGEST_FROM_TEXT);
     sizer_->wxSizer::Insert(insert_pos++, from_label, flags);
-    wxChoice* duration_mode = new(wx) DurationModeChoice(this);
+    wxChoice* duration_mode = new(wx) DurationModeChoice(rows_area_);
     sizer_->wxSizer::Insert(insert_pos++, duration_mode, flags);
-    wxSpinCtrl* duration_num = new(wx) wxSpinCtrl(this, wxID_ANY, "");
+    wxSpinCtrl* duration_num = new(wx) wxSpinCtrl(rows_area_, wxID_ANY, "");
     sizer_->wxSizer::Insert(insert_pos++, duration_num, flags);
     SizeWinForText(duration_num, "9999", 20);
-    wxStaticText* then_label = new(wx) wxStaticText(this, wxID_ANY, LARGEST_THEN_TEXT);
+    wxStaticText* then_label = new(wx) wxStaticText(rows_area_, wxID_ANY, LARGEST_THEN_TEXT);
     sizer_->wxSizer::Insert(insert_pos++, then_label, flags);
     SizeWinForText(then_label, LARGEST_THEN_TEXT);
 
@@ -559,7 +575,7 @@ void InputSequenceEditor::insert_row(int new_row)
     // there's more than one of them and the ID is used to distinguish between
     // them. Consequently, we have to add stock graphics manually under wxGTK.
     wxButton* remove = new(wx) wxButton
-        (this
+        (rows_area_
         ,wxID_ANY
         ,"Remove"
         ,wxDefaultPosition
@@ -581,7 +597,7 @@ void InputSequenceEditor::insert_row(int new_row)
     sizer_->wxSizer::Insert(insert_pos++, remove, wxSizerFlags(flags).TripleBorder(wxLEFT));
 
     wxButton* add = new(wx) wxButton
-        (this
+        (rows_area_
         ,wxID_ANY
         ,"Add"
         ,wxDefaultPosition
@@ -664,18 +680,19 @@ void InputSequenceEditor::insert_row(int new_row)
 
 void InputSequenceEditor::set_tab_order()
 {
-    // The desired tab order is as follows:
+    // The desired tab order for the items inside the row area is as follows:
     // 1. data entry fields from left to right, top to bottom:
     //      Col_Value
     //      Col_From
     //      Col_DurationMode
     //      Col_DurationNum
     //      Col_Then
-    // 2. dialog's OK button
-    // 3. then Remove and Add buttons, top to bottom
+    // 2. then Remove and Add buttons, top to bottom
     //      Col_Remove
     //      Col_Add
-    // 4. dialog's Cancel button
+    //
+    // The "OK" and "Cancel" buttons are outside of the rows area and are not
+    // affected by this function.
 
     if(0 == rows_count_)
         return;
@@ -686,13 +703,11 @@ void InputSequenceEditor::set_tab_order()
         for (int col = Col_Value; col <= Col_Then; ++col)
             order.push_back(get_field_win(col, row));
         }
-    order.push_back(ok_button_);
     for(int row = 0; row < rows_count_; ++row)
         {
         order.push_back(get_field_win(Col_Remove, row));
         order.push_back(get_field_win(Col_Add, row));
         }
-    order.push_back(cancel_button_);
 
     for(size_t i = 1; i < order.size(); ++i)
         {
@@ -798,22 +813,42 @@ void InputSequenceEditor::update_row(int row)
 void InputSequenceEditor::redo_layout()
 {
     wxSizer* sizer = GetSizer();
+
+    // Try to avoid showing the vertical scrollbar by making the rows area as
+    // big as it needs to be. An explicit call to SetMinSize() is required for
+    // this because wxScrolledWindow ignores the best size of its contents in
+    // its scrollable direction.
+    //
+    // Notice that if this size is too big and the window wouldn't fit on the
+    // screen when using it, the size of the rows area will be adjusted down by
+    // exactly as much as necessary because it is the only element of the
+    // dialog with non-fixed size (i.e. proportion different from 0) and the
+    // sizer code correctly considers that if there is not enough space for
+    // everything, it's better to reduce the size of the variable size items
+    // rather than of the fixed size ones.
+    wxSize minRowsSize = sizer_->GetMinSize();
+    rows_area_->SetMinSize(minRowsSize);
+
+    // Now check if we're actually going to have a scrollbar or not by
+    // comparing our ideal minimum size with the size we would actually have.
+    if ( sizer->ComputeFittingClientSize(this) != sizer->GetMinSize() )
+        {
+        // The only possible reason for discrepancy is that the window would be
+        // too big to fit on the screen and so the actual size of the rows area
+        // will be smaller than its minimum size and hence the scrollbar will
+        // be shown and we need to account for it in our horizontal size by
+        // allocating enough space for the scrollbar itself and also an extra
+        // border between the controls and this scrollbar as things would look
+        // too cramped otherwise.
+        minRowsSize.x
+            += wxSizerFlags::GetDefaultBorder()
+            +  wxSystemSettings::GetMetric(wxSYS_HSCROLL_Y)
+            ;
+        rows_area_->SetMinSize(minRowsSize);
+        }
+
     sizer->Layout();
     sizer->Fit(this);
-    sizer->SetSizeHints(this);
-
-    // Make sure the editor is still fully visible and doesn't extend
-    // off-screen after being resized:
-    int display = wxDisplay::GetFromWindow(this);
-    wxDisplay dpy(display == wxNOT_FOUND ? 0 : display);
-    wxRect rect_display(dpy.GetClientArea());
-    wxRect rect_win(GetRect());
-
-    if(!rect_display.Contains(rect_win.GetBottomRight()))
-        {
-        rect_win.Offset(0, rect_display.GetBottom() - rect_win.GetBottom());
-        SetSize(rect_win);
-        }
 }
 
 wxString InputSequenceEditor::format_from_text(int row)

--- a/input_sequence_entry.hpp
+++ b/input_sequence_entry.hpp
@@ -56,6 +56,7 @@ class InputSequenceEntry
     void set_popup_title(wxString const& title) {title_ = title;}
 
   private:
+    void UponChildKillFocus(wxFocusEvent&);
     void UponOpenEditor(wxCommandEvent&);
 
     Input const* input_;

--- a/input_sequence_entry.hpp
+++ b/input_sequence_entry.hpp
@@ -57,7 +57,10 @@ class InputSequenceEntry
 
   private:
     void UponChildKillFocus(wxFocusEvent&);
+    void UponEnter(wxCommandEvent&);
     void UponOpenEditor(wxCommandEvent&);
+
+    void DoOpenEditor();
 
     Input const* input_;
     std::string field_name_;


### PR DESCRIPTION
The main change here is the commit adding a vertical scrollbar to the dialog (or, rather, the part of the dialog showing the sequence elements) if it would have been too tall to fit on the screen otherwise.

But the other changes are worth committing too IMO:

1. The focus loss one corrects a potential bug which became much less potential (in fact, impossible to avoid) with the changes of the next commit but which, I think, could happen even without them.
1. The "next commit", i.e. the one allowing opening the editor from keyboard is, IMHO, quite handy: pressing `Alt-Enter` to open the editor is much nicer than clicking on the small "..." button with the mouse and there is no other way to activate it from keyboard as `TAB` leaves (and hence closes) the entire editor instead of allowing to go to the button. The main problem here is that this is absolutely not discoverable, so I'm afraid it might not be very useful to the end users, but perhaps they could learn this in time. And it was definitely very, very useful to me while testing the changes here, I would have gone crazy from too much clicking otherwise.
1. The rest of the commits deal with another problem that simply couldn't be ignored while testing the main change: slowness. The dialog was horribly slow to open: with a long (~40 elements) sequence it took about 4 seconds. Avoiding multiple relayouts was the most important optimization, bringing the time down to ~800ms which is still noticeably slow, but much more bearable. The other optimizations shaved off another ~200ms from this and don't have much cost associated with them, so I think they should be applied as well.