### PR TITLE
Use TransferDataFromWindow() to get data from InputSequenceEditor.

### DIFF
--- a/input_sequence_entry.cpp
+++ b/input_sequence_entry.cpp
@@ -202,7 +202,7 @@ class InputSequenceEditor
     void sequence(InputSequence const& s);
     std::string sequence_string();
 
-    virtual void EndModal(int retCode);
+    virtual bool TransferDataFromWindow();
 
   private:
     void add_row();
@@ -1165,14 +1165,17 @@ void InputSequenceEditor::UponAddRow(wxCommandEvent& event)
     update_diagnostics();
 }
 
-void InputSequenceEditor::EndModal(int retCode)
+bool InputSequenceEditor::TransferDataFromWindow()
 {
+    if(!wxDialog::TransferDataFromWindow())
+        return false;
+
     // We need to set the value as soon as possible -- when used in wxDataViewCtrl, the value
     // is read from editor control as soon as focus changes, which is before ShowModal() returns.
-    if(associated_text_ctrl_ && retCode == wxID_OK)
+    if(associated_text_ctrl_)
         associated_text_ctrl_->SetValue(sequence_string());
 
-    wxDialog::EndModal(retCode);
+    return true;
 }
 
 class InputSequenceTextCtrl


### PR DESCRIPTION
This is much cleaner than the EndModal() hack.

---
This trivial patch was originally posted to the list in 2011 and then [resubmitted](http://lists.nongnu.org/archive/html/lmi/2014-12/msg00031.html) 2+ years ago. It was deferred then and it's still not really important, but it's so simple that I hope it can be applied, perhaps while testing PR #25.