### PR TITLE
Allow selecting the skin to use during run time

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -290,6 +290,7 @@ liblmi_common_sources = \
     alert.cpp \
     calendar_date.cpp \
     ce_product_name.cpp \
+    ce_skin_name.cpp \
     configurable_settings.cpp \
     crc32.cpp \
     custom_io_0.cpp \
@@ -1046,6 +1047,7 @@ noinst_HEADERS = \
     callback.hpp \
     catch_exceptions.hpp \
     ce_product_name.hpp \
+    ce_skin_name.hpp \
     census_document.hpp \
     census_view.hpp \
     comma_punct.hpp \

--- a/ce_skin_name.cpp
+++ b/ce_skin_name.cpp
@@ -1,0 +1,194 @@
+// A value-Constrained Enumeration for skin names.
+//
+// Copyright (C) 2016 Gregory W. Chicares.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//
+// http://savannah.nongnu.org/projects/lmi
+// email: <gchicares@sbcglobal.net>
+// snail: Chicares, 186 Belle Woods Drive, Glastonbury CT 06033, USA
+
+// $Id$
+
+#include "ce_skin_name.hpp"
+
+#include "alert.hpp"
+#include "facets.hpp"
+#include "global_settings.hpp"
+#include "path_utility.hpp" // fs::path inserter
+
+#include <boost/filesystem/convenience.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+
+#include <algorithm>
+#include <cstring>
+
+namespace
+{
+std::string const& default_skin_name()
+{
+    static std::string const default_name("default");
+    return default_name;
+}
+
+std::vector<std::string> fetch_skin_names()
+{
+    fs::path path(global_settings::instance().data_directory());
+    std::vector<std::string> names;
+    fs::directory_iterator i(path);
+    fs::directory_iterator end_i;
+    for(; i != end_i; ++i)
+        {
+        if(is_directory(*i) || ".xrc" != fs::extension(*i))
+            {
+            continue;
+            }
+        std::string const name(i->leaf());
+        // Skin files are expected to be called "skin_something.xrc" with the
+        // exception of "skin.xrc".
+        static char const* skin_prefix = "skin";
+        static std::size_t const skin_prefix_len = std::strlen(skin_prefix);
+        if(name.compare(0, skin_prefix_len, skin_prefix) != 0)
+            {
+            continue;
+            }
+        if(fs::basename(*i).length() > skin_prefix_len && name[skin_prefix_len] != '_')
+            {
+            continue;
+            }
+
+        names.push_back(name);
+        }
+
+    if(names.empty())
+        {
+        fatal_error()
+            << "Data directory '"
+            << path
+            << "' contains no skin files."
+            << LMI_FLUSH
+            ;
+        }
+
+    return names;
+}
+} // Unnamed namespace.
+
+ce_skin_name::ce_skin_name()
+    :mc_enum_base(skin_names().size())
+    ,value_(default_skin_name())
+{}
+
+ce_skin_name::ce_skin_name(std::string const& s)
+    :mc_enum_base(skin_names().size())
+    ,value_(skin_names()[ordinal(s)])
+{}
+
+ce_skin_name& ce_skin_name::operator=(std::string const& s)
+{
+    value_ = skin_names()[ordinal(s)];
+    return *this;
+}
+
+bool ce_skin_name::operator==(ce_skin_name const& z) const
+{
+    return z.value_ == value_;
+}
+
+bool ce_skin_name::operator==(std::string const& s) const
+{
+    return s == str();
+}
+
+std::size_t ce_skin_name::ordinal(std::string const& s)
+{
+    std::size_t v =
+            std::find
+                (skin_names().begin()
+                ,skin_names().end()
+                ,s
+                )
+        -   skin_names().begin()
+        ;
+    if(v == skin_names().size())
+        {
+        fatal_error()
+            << "Value '"
+            << s
+            << "' invalid for type '"
+            << "ce_skin_name"
+            << "'."
+            << LMI_FLUSH
+            ;
+        }
+    return v;
+}
+
+std::vector<std::string> const& ce_skin_name::all_strings() const
+{
+    return skin_names();
+}
+
+std::size_t ce_skin_name::cardinality() const
+{
+    return skin_names().size();
+}
+
+/// No skin is ever proscribed.
+
+void ce_skin_name::enforce_proscription()
+{}
+
+std::size_t ce_skin_name::ordinal() const
+{
+    return ordinal(value_);
+}
+
+std::string ce_skin_name::str(int j) const
+{
+    return skin_names()[j];
+}
+
+std::string ce_skin_name::str() const
+{
+    return value_;
+}
+
+std::string ce_skin_name::value() const
+{
+    return value_;
+}
+
+std::vector<std::string> const& ce_skin_name::skin_names()
+{
+    static std::vector<std::string> const names(fetch_skin_names());
+    return names;
+}
+
+std::istream& ce_skin_name::read(std::istream& is)
+{
+    std::locale old_locale = is.imbue(blank_is_not_whitespace_locale());
+    std::string s;
+    is >> s;
+    operator=(s);
+    is.imbue(old_locale);
+    return is;
+}
+
+std::ostream& ce_skin_name::write(std::ostream& os) const
+{
+    return os << str();
+}
+

--- a/ce_skin_name.hpp
+++ b/ce_skin_name.hpp
@@ -1,0 +1,82 @@
+// A value-Constrained Enumeration for skin names.
+//
+// Copyright (C) 2016 Gregory W. Chicares.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//
+// http://savannah.nongnu.org/projects/lmi
+// email: <gchicares@sbcglobal.net>
+// snail: Chicares, 186 Belle Woods Drive, Glastonbury CT 06033, USA
+
+// $Id$
+
+#ifndef ce_skin_name_hpp
+#define ce_skin_name_hpp
+
+#include "config.hpp"
+
+#include "mc_enum.hpp"
+
+#include <cstddef> // std::size_t
+#include <string>
+#include <vector>
+
+/// This class encapsulates skin names. It is similar to ce_product_name in
+/// that its values are only available at run time, so there can be no compile
+/// time enum to represent them.
+///
+/// Valid values are the base names of 'skin*.xrc' product files found
+/// in the (configurable) data directory. As with ce_product_name, the valid
+/// values never change during the program lifetime and it needs to be
+/// restarted to "notice" the new skins.
+
+class ce_skin_name
+    :public mc_enum_base
+    ,private boost::equality_comparable<ce_skin_name, ce_skin_name>
+    ,private boost::equality_comparable<ce_skin_name, std::string>
+{
+  public:
+    ce_skin_name();
+    explicit ce_skin_name(std::string const&);
+
+    ce_skin_name& operator=(std::string const&);
+
+    bool operator==(ce_skin_name const&) const;
+    bool operator==(std::string const&) const;
+
+    static std::size_t ordinal(std::string const&);
+
+    // mc_enum_base required implementation.
+    virtual std::vector<std::string> const& all_strings() const;
+    virtual std::size_t cardinality() const;
+    virtual void enforce_proscription();
+    virtual std::size_t ordinal() const;
+    virtual std::string str(int) const;
+
+    std::string str() const;
+    std::string value() const;
+
+  private:
+    static std::vector<std::string> const& skin_names();
+
+    // datum_base required implementation.
+    // TODO ?? Consider moving the implementation into the base class.
+    virtual std::istream& read (std::istream&);
+    virtual std::ostream& write(std::ostream&) const;
+
+    std::string value_;
+};
+
+#endif // ce_skin_name_hpp
+

--- a/configurable_settings.cpp
+++ b/configurable_settings.cpp
@@ -424,6 +424,11 @@ int configurable_settings::seconds_to_pause_between_printouts() const
 
 /// Name of '.xrc' interface skin.
 
+void configurable_settings::skin_filename(std::string const& skin_filename)
+{
+    skin_filename_ = skin_filename;
+}
+
 std::string const& configurable_settings::skin_filename() const
 {
     return skin_filename_;

--- a/configurable_settings.hpp
+++ b/configurable_settings.hpp
@@ -58,6 +58,7 @@ class LMI_SO configurable_settings
 
     void calculation_summary_columns(std::string const&);
     void use_builtin_calculation_summary(bool);
+    void skin_filename(std::string const&);
 
     std::string const& calculation_summary_columns        () const;
     std::string const& cgi_bin_log_filename               () const;

--- a/group_values.cpp
+++ b/group_values.cpp
@@ -316,7 +316,7 @@ census_run_result run_census_in_parallel::operator()
             }
         } // End for.
     meter->culminate();
-    if(0 == cell_values.size())
+    if(cell_values.empty())
         {
         // Make sure it's safe to dereference cell_values[0] later.
         fatal_error()

--- a/ihs_mortal.cpp
+++ b/ihs_mortal.cpp
@@ -219,7 +219,7 @@ void MortalityRates::SetOtherRates()
     // TODO ?? TAXATION !! Do this only if DB_Irc7702NspWhence is 2
     // (which should be an enum). This probably should have its own
     // rounding rule.
-    LMI_ASSERT(0 == CvatNspRates_.size());
+    LMI_ASSERT(CvatNspRates_.empty());
     for(int j = 0; j < Length_; ++j)
         {
         LMI_ASSERT(0.0 < CvatCorridorFactors_[j]);

--- a/input_sequence.cpp
+++ b/input_sequence.cpp
@@ -708,7 +708,7 @@ void InputSequence::value()
         case e_keyword:
             {
             current_interval.value_is_keyword = true;
-            if(0 == extra_keywords.size())
+            if(extra_keywords.empty())
                 {
                 diagnostics << "Expected number. ";
                 mark_diagnostic_context();

--- a/objects.make
+++ b/objects.make
@@ -183,6 +183,7 @@ common_common_objects := \
   alert.o \
   calendar_date.o \
   ce_product_name.o \
+  ce_skin_name.o \
   configurable_settings.o \
   crc32.o \
   custom_io_0.o \

--- a/preferences_model.cpp
+++ b/preferences_model.cpp
@@ -54,6 +54,16 @@ namespace
 // whole issue would vanish.
 
 std::string magic_null_column_name("[none]");
+
+// Check if the given PreferencesModel class member name is one of the
+// calculation summary columns.
+bool is_calculation_summary_column_member(std::string const& member)
+{
+    static char const* summary_column_prefix = "CalculationSummaryColumn";
+    static std::size_t summary_column_prefix_len = strlen(summary_column_prefix);
+
+    return member.compare(0, summary_column_prefix_len, summary_column_prefix) == 0;
+}
 }
 
 PreferencesModel::PreferencesModel()
@@ -216,11 +226,14 @@ void PreferencesModel::Load()
     bool b = z.use_builtin_calculation_summary();
     UseBuiltinCalculationSummary = b ? "Yes" : "No";
 
-    // TODO ?? CALCULATION_SUMMARY '-1 +' is a poor way of ignoring
-    // 'UseBuiltinCalculationSummary'.
-    for(std::size_t i = 0; i < -1 + member_names().size(); ++i)
+    for(std::size_t i = 0; i < member_names().size(); ++i)
         {
         std::string const& name = member_names()[i];
+
+        if(!is_calculation_summary_column_member(name))
+            {
+            continue;
+            }
         if(columns.size() <= i)
             {
             operator[](name) = magic_null_column_name;
@@ -238,8 +251,7 @@ std::string PreferencesModel::string_of_column_names() const
     std::vector<std::string>::const_iterator i;
     for(i = member_names().begin(); i != member_names().end(); ++i)
         {
-        // TODO ?? CALCULATION_SUMMARY This is poor.
-        if("UseBuiltinCalculationSummary" == *i)
+        if(!is_calculation_summary_column_member(*i))
             {
             continue;
             }

--- a/preferences_model.cpp
+++ b/preferences_model.cpp
@@ -92,6 +92,8 @@ void PreferencesModel::AscribeMembers()
     ascribe("CalculationSummaryColumn09"  , &PreferencesModel::CalculationSummaryColumn09);
     ascribe("CalculationSummaryColumn10"  , &PreferencesModel::CalculationSummaryColumn10);
     ascribe("CalculationSummaryColumn11"  , &PreferencesModel::CalculationSummaryColumn11);
+
+    ascribe("SkinFileName"                , &PreferencesModel::SkinFileName);
 }
 
 void PreferencesModel::DoAdaptExternalities()
@@ -243,6 +245,8 @@ void PreferencesModel::Load()
             operator[](name) = columns[i];
             }
         }
+
+    SkinFileName = z.skin_filename();
 }
 
 std::string PreferencesModel::string_of_column_names() const
@@ -277,5 +281,6 @@ void PreferencesModel::Save() const
     configurable_settings& z = configurable_settings::instance();
     z.calculation_summary_columns(s);
     z.use_builtin_calculation_summary("Yes" == UseBuiltinCalculationSummary);
+    z.skin_filename(SkinFileName.value());
 }
 

--- a/preferences_model.hpp
+++ b/preferences_model.hpp
@@ -29,6 +29,7 @@
 #include "mvc_model.hpp"
 
 #include "any_member.hpp"
+#include "ce_skin_name.hpp"
 #include "mc_enum.hpp"
 #include "mc_enum_types.hpp"
 #include "obstruct_slicing.hpp"
@@ -80,6 +81,8 @@ class LMI_SO PreferencesModel
     mce_report_column CalculationSummaryColumn09;
     mce_report_column CalculationSummaryColumn10;
     mce_report_column CalculationSummaryColumn11;
+
+    ce_skin_name      SkinFileName;
 };
 
 /// Specialization of struct template reconstitutor for this Model
@@ -91,6 +94,7 @@ template<> struct reconstitutor<datum_base, PreferencesModel>
     static DesiredType* reconstitute(any_member<PreferencesModel>& m)
         {
         DesiredType* z = 0;
+        z = exact_cast<ce_skin_name     >(m); if(z) return z;
         z = exact_cast<mce_report_column>(m); if(z) return z;
         z = exact_cast<mce_yes_or_no    >(m); if(z) return z;
         return z;

--- a/preferences_view.xrc
+++ b/preferences_view.xrc
@@ -216,6 +216,27 @@
     </object>
 </object>
 
+<object class="wxPanel" name="parameters_editor_panel">
+    <object class="wxBoxSizer">
+        <orient>wxVERTICAL</orient>
+        <object class="sizeritem">
+            <flag>wxALL</flag>
+            <border>5</border>
+            <object class="wxStaticText">
+                <label>Choose the skin to use for the parameters editor:</label>
+            </object>
+        </object>
+        <object class="sizeritem">
+            <option>1</option>
+            <flag>wxGROW|wxALL</flag>
+            <border>5</border>
+            <object class="wxListBox" name="SkinFileName">
+                <style>wxLB_SINGLE</style>
+            </object>
+        </object>
+    </object>
+</object>
+
 <object class="wxDialog" name="dialog_containing_preferences_notebook">
     <title>Preferences</title>
     <style>wxCAPTION|wxRESIZE_BORDER|wxSYSTEM_MENU</style>
@@ -235,6 +256,10 @@
                 <object class="notebookpage">
                     <label>Calculation summary columns</label>
                     <object_ref ref="calculation_summary_panel"/>
+                </object>
+                <object class="notebookpage">
+                    <label>Parameters editor appearance</label>
+                    <object_ref ref="parameters_editor_panel"/>
                 </object>
             </object>
         </object>

--- a/product_names.cpp
+++ b/product_names.cpp
@@ -59,7 +59,7 @@ std::vector<std::string> fetch_product_names()
         names.push_back(name);
         }
 
-    if(0 == names.size())
+    if(names.empty())
         {
         fatal_error()
             << "Data directory '"

--- a/skeleton.cpp
+++ b/skeleton.cpp
@@ -899,8 +899,21 @@ void Skeleton::UponPreferences(wxCommandEvent&)
     int const rc = controller.ShowModal();
     if(wxID_OK == rc && preferences.IsModified())
         {
+        configurable_settings& z = configurable_settings::instance();
+        std::string const orig_skin_filename = z.skin_filename();
         preferences.Save();
-        configurable_settings::instance().save();
+        z.save();
+        if(z.skin_filename() != orig_skin_filename)
+            {
+            // If the default skin file name has changed, we need to explicitly
+            // re-load the corresponding file, otherwise the old definitions of
+            // the objects defined in it would be still used when they're
+            // needed the next time.
+            wxXmlResource& res = *wxXmlResource::Get();
+            res.Unload(AddDataDir(orig_skin_filename));
+            load_xrc_file_from_data_directory(res, DefaultView().ResourceFileName());
+            }
+
         UpdateViews();
         }
 }

--- a/skeleton.cpp
+++ b/skeleton.cpp
@@ -108,6 +108,26 @@
 #include <stdexcept>
 #include <string>
 
+namespace
+{
+// Load the XRC file with the given base name from the data directory and call
+// fatal_error() if loading it failed.
+void load_xrc_file_from_data_directory
+    (wxXmlResource& xml_resources
+    ,char const* xrc_filename
+    )
+{
+#if wxCHECK_VERSION(2,9,0)
+    if(!xml_resources.LoadFile(wxFileName(AddDataDir(xrc_filename))))
+#else  // !wxCHECK_VERSION(2,9,0)
+    if(!xml_resources.Load(AddDataDir(xrc_filename)))
+#endif // !wxCHECK_VERSION(2,9,0)
+        {
+        fatal_error() << "Unable to load xml resources." << LMI_FLUSH;
+        }
+}
+} // Unnamed namespace.
+
 // Where a builtin wxID_X identifier exists, use it as such, even if
 // it's used as the 'name=' attribute of an entity in an '.xrc' file.
 // For example, write 'wxID_SAVE' here, not 'XRCID("wxID_SAVE")'.
@@ -690,81 +710,14 @@ bool Skeleton::OnInit()
         xml_resources.AddHandler(new(wx) RoundingButtonsXmlHandler);
         xml_resources.AddHandler(new(wx) InputSequenceEntryXmlHandler);
 
-        DefaultView const v0;
-#if wxCHECK_VERSION(2,9,0)
-        if(!xml_resources.LoadFile(wxFileName(AddDataDir(v0.ResourceFileName()))))
-#else  // !wxCHECK_VERSION(2,9,0)
-        if(!xml_resources.Load(AddDataDir(v0.ResourceFileName())))
-#endif // !wxCHECK_VERSION(2,9,0)
-            {
-            fatal_error() << "Unable to load xml resources." << LMI_FLUSH;
-            }
-
-        PreferencesView const v1;
-#if wxCHECK_VERSION(2,9,0)
-        if(!xml_resources.LoadFile(wxFileName(AddDataDir(v1.ResourceFileName()))))
-#else  // !wxCHECK_VERSION(2,9,0)
-        if(!xml_resources.Load(AddDataDir(v1.ResourceFileName())))
-#endif // !wxCHECK_VERSION(2,9,0)
-            {
-            fatal_error() << "Unable to load xml resources." << LMI_FLUSH;
-            }
-
-        mec_mvc_view const v2;
-#if wxCHECK_VERSION(2,9,0)
-        if(!xml_resources.LoadFile(wxFileName(AddDataDir(v2.ResourceFileName()))))
-#else  // !wxCHECK_VERSION(2,9,0)
-        if(!xml_resources.Load(AddDataDir(v2.ResourceFileName())))
-#endif // !wxCHECK_VERSION(2,9,0)
-            {
-            fatal_error() << "Unable to load xml resources." << LMI_FLUSH;
-            }
-
-        gpt_mvc_view const v3;
-#if wxCHECK_VERSION(2,9,0)
-        if(!xml_resources.LoadFile(wxFileName(AddDataDir(v3.ResourceFileName()))))
-#else  // !wxCHECK_VERSION(2,9,0)
-        if(!xml_resources.Load(AddDataDir(v3.ResourceFileName())))
-#endif // !wxCHECK_VERSION(2,9,0)
-            {
-            fatal_error() << "Unable to load xml resources." << LMI_FLUSH;
-            }
-
-#if wxCHECK_VERSION(2,9,0)
-        if(!xml_resources.LoadFile(wxFileName(AddDataDir("menus.xrc"))))
-#else  // !wxCHECK_VERSION(2,9,0)
-        if(!xml_resources.Load(AddDataDir("menus.xrc")))
-#endif // !wxCHECK_VERSION(2,9,0)
-            {
-            fatal_error() << "Unable to load menubar." << LMI_FLUSH;
-            }
-
-#if wxCHECK_VERSION(2,9,0)
-        if(!xml_resources.LoadFile(wxFileName(AddDataDir("toolbar.xrc"))))
-#else  // !wxCHECK_VERSION(2,9,0)
-        if(!xml_resources.Load(AddDataDir("toolbar.xrc")))
-#endif // !wxCHECK_VERSION(2,9,0)
-            {
-            fatal_error() << "Unable to load toolbar." << LMI_FLUSH;
-            }
-
-#if wxCHECK_VERSION(2,9,0)
-        if(!xml_resources.LoadFile(wxFileName(AddDataDir(PolicyView::resource_file_name()))))
-#else  // !wxCHECK_VERSION(2,9,0)
-        if(!xml_resources.Load(AddDataDir(PolicyView::resource_file_name())))
-#endif // !wxCHECK_VERSION(2,9,0)
-            {
-            fatal_error() << "Unable to load Policy resources." << LMI_FLUSH;
-            }
-
-#if wxCHECK_VERSION(2,9,0)
-        if(!xml_resources.LoadFile(wxFileName(AddDataDir(RoundingView::resource_file_name()))))
-#else  // !wxCHECK_VERSION(2,9,0)
-        if(!xml_resources.Load(AddDataDir(RoundingView::resource_file_name())))
-#endif // !wxCHECK_VERSION(2,9,0)
-            {
-            fatal_error() << "Unable to load Rounding resources." << LMI_FLUSH;
-            }
+        load_xrc_file_from_data_directory(xml_resources, DefaultView().ResourceFileName());
+        load_xrc_file_from_data_directory(xml_resources, PreferencesView().ResourceFileName());
+        load_xrc_file_from_data_directory(xml_resources, mec_mvc_view().ResourceFileName());
+        load_xrc_file_from_data_directory(xml_resources, gpt_mvc_view().ResourceFileName());
+        load_xrc_file_from_data_directory(xml_resources, "menus.xrc");
+        load_xrc_file_from_data_directory(xml_resources, "toolbar.xrc");
+        load_xrc_file_from_data_directory(xml_resources, PolicyView::resource_file_name());
+        load_xrc_file_from_data_directory(xml_resources, RoundingView::resource_file_name());
 
         InitDocManager();
 


### PR DESCRIPTION
This allows to change the skin being used without restarting the program.

The main commit is the last one, but all but the (trivial) first one are required for it to compile and/or work correctly. The first one is just for consistency.

Further improvements are possible, see the [mailing list message about this PR](http://lists.nongnu.org/archive/html/lmi/2016-05/msg00000.html), but I believe this can already be merged.