### PR TITLE
Center dollar amounts in the group quote report header too

### DIFF
--- a/group_quote_pdf_gen_wx.cpp
+++ b/group_quote_pdf_gen_wx.cpp
@@ -1446,21 +1446,19 @@ void group_quote_pdf_generator_wx::output_aggregate_values
         table_gen.output_highlighted_cell
             (col
             ,y
-            ,"$"
-            ,ledger_format(totals_.total(col), f)
+            ,'$' + ledger_format(totals_.total(col), f)
             );
 
         // Only premium columns have averages, but we must output something for
         // all cells to ensure that we use homogeneous background.
         double const average = averages_.mean(col);
-        std::string lhs, rhs;
+        std::string average_text;
         if(average != 0.0)
             {
-            lhs = "$";
-            rhs = ledger_format(average, f);
+            average_text = '$' + ledger_format(average, f);
             }
 
-        table_gen.output_highlighted_cell(col, y_next, lhs, rhs);
+        table_gen.output_highlighted_cell(col, y_next, average_text);
         }
 
     table_gen.output_vert_separator(e_col_max, y);

--- a/wx_table_generator.cpp
+++ b/wx_table_generator.cpp
@@ -354,8 +354,7 @@ void wx_table_generator::output_row
 void wx_table_generator::output_highlighted_cell
     (std::size_t        column
     ,int                y
-    ,std::string const& lhs
-    ,std::string const& rhs
+    ,std::string const& value
     )
 {
     if(columns_.at(column).is_hidden())
@@ -369,9 +368,7 @@ void wx_table_generator::output_highlighted_cell
     dc_.DrawRectangle(cell_rect(column, y));
     }
 
-    wxRect const r = text_rect(column, y);
-    dc_.DrawLabel(lhs, r, wxALIGN_LEFT);
-    dc_.DrawLabel(rhs, r, wxALIGN_RIGHT);
+    dc_.DrawLabel(value, text_rect(column, y), wxALIGN_CENTER_HORIZONTAL);
 
     output_vert_separator(column, y);
 }

--- a/wx_table_generator.hpp
+++ b/wx_table_generator.hpp
@@ -74,14 +74,11 @@ class wx_table_generator
     void output_row(int* pos_y, std::string const* values);
 
     // Render a single highlighted (by shading its background) cell with the
-    // given strings displayed in it left and right-aligned respectively.
-    // This is used for aggregate amounts display currently, so the LHS string
-    // is always just "$" currently.
+    // given string displayed in it (always centered).
     void output_highlighted_cell
         (std::size_t        column
         ,int                y
-        ,std::string const& lhs
-        ,std::string const& rhs
+        ,std::string const& value
         );
 
     // Return the height of a single table row.


### PR DESCRIPTION
Don't go out of our way to left-align "$" and right-align the amount itself,
just center them both together instead as is already done for the values in
the columns themselves.