### PR TITLE
Avoid unused parameter warnings in PETE code

### DIFF
--- a/tools/pete-2.1.1/PETE/Combiners.h
+++ b/tools/pete-2.1.1/PETE/Combiners.h
@@ -166,7 +166,7 @@ struct Combine1<A, Op, TreeCombine >
 {
   typedef UnaryNode<Op, A> Type_t;
   inline static
-  Type_t combine(const A &a, const TreeCombine &t)
+  Type_t combine(const A &a, const TreeCombine &)
   {
     return Type_t(a);
   }
@@ -177,7 +177,7 @@ struct Combine2<A, B, Op, TreeCombine >
 {
   typedef BinaryNode<Op, A, B> Type_t;
   inline static
-  Type_t combine(const A &a, const B &b, const TreeCombine &t)
+  Type_t combine(const A &a, const B &b, const TreeCombine &)
   {
     return Type_t(a, b);
   }
@@ -188,7 +188,7 @@ struct Combine3<A, B, C, Op, TreeCombine >
 {
   typedef TrinaryNode<Op, A, B, C> Type_t;
   inline static
-  Type_t combine(const A &a, const B &b, const C &c, const TreeCombine &t)
+  Type_t combine(const A &a, const B &b, const C &c, const TreeCombine &)
   {
     return Type_t(a, b, c);
   }


### PR DESCRIPTION
Just don't use the variable names for the unused variables.

---
Somehow I didn't have this problem before, but there is another warning which prevents a clean build with clang out of the box: it (correctly) complains about the unused parameters in PETE code. Instead of disabling this warning in configure, I think it would be better to fix it in PETE, as the warning can be occasionally useful.