### PR TITLE
Harmonize test classes full and forward declarations

### DIFF
--- a/any_member_test.cpp
+++ b/any_member_test.cpp
@@ -108,7 +108,7 @@ std::ostream& operator<<(std::ostream& os, X const& x) {return os << x.str() << 
 class S
     :public MemberSymbolTable<S>
 {
-    friend class any_member_test;
+    friend struct any_member_test;
 
   public:
     S();

--- a/loads_test.cpp
+++ b/loads_test.cpp
@@ -66,8 +66,9 @@ double premium_tax::load_rate        () const {return 0.0;}
 double premium_tax::maximum_load_rate() const {return 0.0;}
 double premium_tax::minimum_load_rate() const {return 0.0;}
 
-struct LoadsTest
+class LoadsTest
 {
+public:
     LoadsTest(load_details const& details)
         :details_ (details)
         ,database_(details.length_)

--- a/mc_enum_test.cpp
+++ b/mc_enum_test.cpp
@@ -37,8 +37,9 @@
 // Enumerative types 'e_holiday' and 'e_island' are explicitly
 // instantiated in a different translation unit.
 
-struct mc_enum_test
+class mc_enum_test
 {
+public:
     static void test();
 };
 

--- a/rtti_lmi_test.cpp
+++ b/rtti_lmi_test.cpp
@@ -34,8 +34,9 @@
 #include <sstream>
 #include <vector>
 
-struct RttiLmiTest
+class RttiLmiTest
 {
+public:
     class X {};
     static void TestTypeInfo();
 };

--- a/timer_test.cpp
+++ b/timer_test.cpp
@@ -64,8 +64,9 @@ void goo(int i, X, X const&, X*)
         }
 }
 
-struct TimerTest
+class TimerTest
 {
+public:
     static void WaitTenMsec();
     static void SleepOneSec();
     static void TestResolution();

--- a/tn_range_test.cpp
+++ b/tn_range_test.cpp
@@ -112,8 +112,9 @@ class absurd
 template class tn_range<int, absurd<int> >;
 typedef tn_range<int, absurd<int> > r_absurd;
 
-struct tn_range_test
+class tn_range_test
 {
+public:
     template<typename T>
     static void test_auxiliary_functions(char const* file, int line);
 


### PR DESCRIPTION
Consistently use either "struct" or "class" in both forward declarations of
the test class and when defining it to avoid clang -Wmismatched-tags warning.

---
I'm not sure what was the intention here as some test classes are forward-declared as structs but defined as classes while it's the converse for the others. So I've just decided to not touch the existing forward declarations in the headers and adjust the classes declarations themselves to match. An alternative could be to standardize on using either `class` or `struct`, of course, but this would be slightly more time-consuming (I'd need to check all these classes manually as clang wouldn't give me any warnings if there is no mismatch) and I didn't want to do it needlessly. Of course, yet another alternative would be to just disable the corresponding clang warning, but I think fixing it is better, if only because MSVC gives it as well (but I don't use `-Werror` with MSVC, so I had never bothered to make such a patch before).