### PR TITLE
Preload designated DLLs after parsing the command line

### DIFF
--- a/configurable_settings.cpp
+++ b/configurable_settings.cpp
@@ -92,9 +92,9 @@ fs::path const& configuration_filepath()
     std::string filename = "/etc/opt/lmi/" + configuration_filename();
     if(0 != access(filename.c_str(), R_OK))
         {
-        // TODO ?? At this point, AddDataDir() refers to the directory
-        // where the wx binary resides. A configurable_settings object
-        // apparently exists before ProcessCommandLine() is called.
+        // TODO ?? At this point, AddDataDir() might refer to the directory
+        // where the wx binary resides if ProcessCommandLine() hadn't been
+        // called yet. We should arguably detect this case and give an error.
         filename = AddDataDir(configuration_filename());
         if(0 != access(filename.c_str(), R_OK))
             {

--- a/main_wx.cpp
+++ b/main_wx.cpp
@@ -39,7 +39,6 @@
 #include "force_linking.hpp"
 #include "handle_exceptions.hpp"
 #include "main_common.hpp"              // initialize_application()
-#include "msw_workarounds.hpp"
 #include "path_utility.hpp"             // initialize_filesystem()
 #include "skeleton.hpp"
 
@@ -95,7 +94,6 @@ int WINAPI WinMain
 #ifndef LMI_MSW
         result = wxEntry(argc, argv);
 #else // LMI_MSW defined.
-        MswDllPreloader::instance().PreloadDesignatedDlls();
         result = wxEntry(hInstance, hPrevInstance, lpCmdLine, nCmdShow);
 #endif // LMI_MSW defined.
         }

--- a/skeleton.cpp
+++ b/skeleton.cpp
@@ -66,6 +66,7 @@
 #include "mec_document.hpp"
 #include "mec_view.hpp"
 #include "miscellany.hpp"
+#include "msw_workarounds.hpp"
 #include "mvc_controller.hpp"
 #include "policy_document.hpp"
 #include "policy_view.hpp"
@@ -691,6 +692,11 @@ bool Skeleton::OnInit()
             }
 
         authenticate_system();
+
+        // It is important for this line to be after ProcessCommandLine() call
+        // as it uses configurable_settings which is loaded from the file whose
+        // location can be specified using a command line option.
+        MswDllPreloader::instance().PreloadDesignatedDlls();
 
         wxInitAllImageHandlers();
 


### PR DESCRIPTION
This ensures that configurable_settings::instance() is called after the
command line is parsed and so the settings file is loaded from the directory
specified using --data_path command line option (if any), whereas previously
the settings file was loaded from the program directory if it didn't exist in
the standard global location because configurable_settings::instance() was
called from MswDllPreloader::PreloadDesignatedDlls() before parsing the
command line.

---

See [this post](http://lists.nongnu.org/archive/html/lmi/2016-05/msg00123.html)