### PR TITLE
Use nullptr instead of 0 or NULL

### DIFF
--- a/alert.cpp
+++ b/alert.cpp
@@ -46,33 +46,33 @@
 namespace
 {
 typedef void (*alert_function_pointer)(std::string const&);
-alert_function_pointer status_alert_function         = 0;
-alert_function_pointer warning_alert_function        = 0;
-alert_function_pointer hobsons_choice_alert_function = 0;
-alert_function_pointer fatal_error_alert_function    = 0;
+alert_function_pointer status_alert_function         = nullptr;
+alert_function_pointer warning_alert_function        = nullptr;
+alert_function_pointer hobsons_choice_alert_function = nullptr;
+alert_function_pointer fatal_error_alert_function    = nullptr;
 
 typedef void (*message_function_pointer)(char const*);
-message_function_pointer safe_message_alert_function = 0;
+message_function_pointer safe_message_alert_function = nullptr;
 
 inline bool all_function_pointers_have_been_set()
 {
     return
-            0 != status_alert_function
-        &&  0 != warning_alert_function
-        &&  0 != hobsons_choice_alert_function
-        &&  0 != fatal_error_alert_function
-        &&  0 != safe_message_alert_function
+            nullptr != status_alert_function
+        &&  nullptr != warning_alert_function
+        &&  nullptr != hobsons_choice_alert_function
+        &&  nullptr != fatal_error_alert_function
+        &&  nullptr != safe_message_alert_function
         ;
 }
 
 inline bool any_function_pointer_has_been_set()
 {
     return
-            0 != status_alert_function
-        ||  0 != warning_alert_function
-        ||  0 != hobsons_choice_alert_function
-        ||  0 != fatal_error_alert_function
-        ||  0 != safe_message_alert_function
+            nullptr != status_alert_function
+        ||  nullptr != warning_alert_function
+        ||  nullptr != hobsons_choice_alert_function
+        ||  nullptr != fatal_error_alert_function
+        ||  nullptr != safe_message_alert_function
         ;
 }
 
@@ -233,7 +233,7 @@ std::ostream& fatal_error()
 
 void safely_show_message(char const* message)
 {
-    if(0 == safe_message_alert_function)
+    if(nullptr == safe_message_alert_function)
         {
         report_catastrophe
             ("No function defined for reporting a problem safely."

--- a/alert_wx.cpp
+++ b/alert_wx.cpp
@@ -71,7 +71,7 @@ void status_alert(std::string const& s)
 
 void warning_alert(std::string const& s)
 {
-    wxMessageBox(s, "Warning", wxOK, wxTheApp ? wxTheApp->GetTopWindow() : 0);
+    wxMessageBox(s, "Warning", wxOK, wxTheApp ? wxTheApp->GetTopWindow() : nullptr);
 }
 
 /// It seems silly to offer an option that should never be declined,
@@ -84,7 +84,7 @@ void warning_alert(std::string const& s)
 
 void hobsons_choice_alert(std::string const& s)
 {
-    wxWindow* w = 0;
+    wxWindow* w = nullptr;
     if(wxTheApp)
         {
         w = wxTheApp->GetTopWindow();

--- a/any_member.hpp
+++ b/any_member.hpp
@@ -293,7 +293,7 @@ class any_member
 
 template<typename ClassType>
 any_member<ClassType>::any_member()
-    :object_(0)
+    :object_(nullptr)
     ,content_(nullptr)
 {}
 

--- a/any_member.hpp
+++ b/any_member.hpp
@@ -294,7 +294,7 @@ class any_member
 template<typename ClassType>
 any_member<ClassType>::any_member()
     :object_(0)
-    ,content_(0)
+    ,content_(nullptr)
 {}
 
 template<typename ClassType>
@@ -302,7 +302,7 @@ any_member<ClassType>::any_member(any_member const& other)
     :obstruct_slicing<any_member<ClassType> >()
     ,any_entity (other)
     ,object_    (other.object_)
-    ,content_   (other.content_ ? other.content_->clone() : 0)
+    ,content_   (other.content_ ? other.content_->clone() : nullptr)
 {}
 
 template<typename ClassType>
@@ -383,7 +383,7 @@ ExactMemberType* any_member<ClassType>::exact_cast()
     typedef ExactMemberType ClassType::* pmd_type;
     if(type() != typeid(pmd_type))
         {
-        return 0;
+        return nullptr;
         }
     typedef holder<ClassType,pmd_type> holder_type;
     LMI_ASSERT(content_);
@@ -444,7 +444,7 @@ struct reconstitutor
 {
     static MemberType* reconstitute(any_member<ClassType> const&)
         {
-        return 0;
+        return nullptr;
         }
 };
 
@@ -458,7 +458,7 @@ struct reconstitutor
 template<typename MemberType, typename ClassType>
 bool is_reconstitutable_as(any_member<ClassType>& member)
 {
-    return 0 != reconstitutor<MemberType,ClassType>::reconstitute(member);
+    return nullptr != reconstitutor<MemberType,ClassType>::reconstitute(member);
 }
 
 template<typename MemberType, typename ClassType>

--- a/any_member_test.cpp
+++ b/any_member_test.cpp
@@ -213,7 +213,7 @@ template<> struct reconstitutor<base_datum, S>
     typedef base_datum DesiredType;
     static DesiredType* reconstitute(any_member<S>& m)
         {
-        DesiredType* z = 0;
+        DesiredType* z = nullptr;
         z = exact_cast<DesiredType  >(m); if(z) return z;
         z = exact_cast<derived_datum>(m); if(z) return z;
         return z;

--- a/bcc_ar.cpp
+++ b/bcc_ar.cpp
@@ -52,15 +52,15 @@ int try_main(int argc, char* argv[])
     // librarian. TRICKY !! They are aliased to unlikely octal values.
     static Option long_options[] =
       {
-        {"help",         NO_ARG,   0, 001, 0, "display this help and exit"},
-        {"license",      NO_ARG,   0, 002, 0, "display license and exit"},
-        {"accept",       NO_ARG,   0, 003, 0, "accept license (-l to display)"},
-        {"program",      REQD_ARG, 0, 004, 0, "librarian's filepath"},
-        {"r",            REQD_ARG, 0, 'r', 0, "see inline documentation"},
-        {"s",            REQD_ARG, 0, 's', 0, "see inline documentation"},
-        {"u",            REQD_ARG, 0, 'u', 0, "see inline documentation"},
-        {"v",            REQD_ARG, 0, 'v', 0, "see inline documentation"},
-        {0,              NO_ARG,   0,   0, 0, ""}
+        {"help",         NO_ARG,   nullptr, 001, nullptr, "display this help and exit"},
+        {"license",      NO_ARG,   nullptr, 002, nullptr, "display license and exit"},
+        {"accept",       NO_ARG,   nullptr, 003, nullptr, "accept license (-l to display)"},
+        {"program",      REQD_ARG, nullptr, 004, nullptr, "librarian's filepath"},
+        {"r",            REQD_ARG, nullptr, 'r', nullptr, "see inline documentation"},
+        {"s",            REQD_ARG, nullptr, 's', nullptr, "see inline documentation"},
+        {"u",            REQD_ARG, nullptr, 'u', nullptr, "see inline documentation"},
+        {"v",            REQD_ARG, nullptr, 'v', nullptr, "see inline documentation"},
+        {nullptr,              NO_ARG,   nullptr,   0, nullptr, ""}
       };
 
     bool license_accepted = false;

--- a/bcc_ar.cpp
+++ b/bcc_ar.cpp
@@ -60,7 +60,7 @@ int try_main(int argc, char* argv[])
         {"s",            REQD_ARG, nullptr, 's', nullptr, "see inline documentation"},
         {"u",            REQD_ARG, nullptr, 'u', nullptr, "see inline documentation"},
         {"v",            REQD_ARG, nullptr, 'v', nullptr, "see inline documentation"},
-        {nullptr,              NO_ARG,   nullptr,   0, nullptr, ""}
+        {nullptr,        NO_ARG,   nullptr,   0, nullptr, ""}
       };
 
     bool license_accepted = false;

--- a/bcc_cc.cpp
+++ b/bcc_cc.cpp
@@ -35,13 +35,13 @@ int try_main(int argc, char* argv[])
     // compiler. TRICKY !! They are aliased to unlikely octal values.
     static Option long_options[] =
       {
-        {"help",         NO_ARG,   0, 001, 0, "display this help and exit"},
-        {"license",      NO_ARG,   0, 002, 0, "display license and exit"},
-        {"accept",       NO_ARG,   0, 003, 0, "accept license (-l to display)"},
-        {"program",      REQD_ARG, 0, 004, 0, "compiler's filepath"},
-        {"include",      REQD_ARG, 0, 'I', 0, "include path"},
-        {"out-file",     REQD_ARG, 0, 'o', 0, "output object file"},
-        {0,              NO_ARG,   0,   0, 0, ""}
+        {"help",         NO_ARG,   nullptr, 001, nullptr, "display this help and exit"},
+        {"license",      NO_ARG,   nullptr, 002, nullptr, "display license and exit"},
+        {"accept",       NO_ARG,   nullptr, 003, nullptr, "accept license (-l to display)"},
+        {"program",      REQD_ARG, nullptr, 004, nullptr, "compiler's filepath"},
+        {"include",      REQD_ARG, nullptr, 'I', nullptr, "include path"},
+        {"out-file",     REQD_ARG, nullptr, 'o', nullptr, "output object file"},
+        {nullptr,              NO_ARG,   nullptr,   0, nullptr, ""}
       };
 
     bool license_accepted = false;

--- a/bcc_cc.cpp
+++ b/bcc_cc.cpp
@@ -41,7 +41,7 @@ int try_main(int argc, char* argv[])
         {"program",      REQD_ARG, nullptr, 004, nullptr, "compiler's filepath"},
         {"include",      REQD_ARG, nullptr, 'I', nullptr, "include path"},
         {"out-file",     REQD_ARG, nullptr, 'o', nullptr, "output object file"},
-        {nullptr,              NO_ARG,   nullptr,   0, nullptr, ""}
+        {nullptr,        NO_ARG,   nullptr,   0, nullptr, ""}
       };
 
     bool license_accepted = false;

--- a/bcc_ld.cpp
+++ b/bcc_ld.cpp
@@ -112,17 +112,17 @@ int try_main(int argc, char* argv[])
     // as you use '/' rather than '-' to introduce borland options.
     static Option long_options[] =
       {
-        {"help",         NO_ARG,   0, 001, 0, "display this help and exit"},
-        {"license",      NO_ARG,   0, 002, 0, "display license and exit"},
-        {"accept",       NO_ARG,   0, 003, 0, "accept license (-l to display)"},
-        {"def-file",     REQD_ARG, 0, 004, 0, "module definition file"},
-        {"map-file",     REQD_ARG, 0, 005, 0, "map file"},
-        {"program",      REQD_ARG, 0, 007, 0, "linker's filepath"},
-        {"startup-file", REQD_ARG, 0, 010, 0, "startup file"},
-        {"lib-path",     REQD_ARG, 0, 'L', 0, "library path"},
-        {"out-file",     REQD_ARG, 0, 'o', 0, "output executable file"},
-        {"/",            REQD_ARG, 0, '/', 0, "linker option"},
-        {0,              NO_ARG,   0,   0, 0, ""}
+        {"help",         NO_ARG,   nullptr, 001, nullptr, "display this help and exit"},
+        {"license",      NO_ARG,   nullptr, 002, nullptr, "display license and exit"},
+        {"accept",       NO_ARG,   nullptr, 003, nullptr, "accept license (-l to display)"},
+        {"def-file",     REQD_ARG, nullptr, 004, nullptr, "module definition file"},
+        {"map-file",     REQD_ARG, nullptr, 005, nullptr, "map file"},
+        {"program",      REQD_ARG, nullptr, 007, nullptr, "linker's filepath"},
+        {"startup-file", REQD_ARG, nullptr, 010, nullptr, "startup file"},
+        {"lib-path",     REQD_ARG, nullptr, 'L', nullptr, "library path"},
+        {"out-file",     REQD_ARG, nullptr, 'o', nullptr, "output executable file"},
+        {"/",            REQD_ARG, nullptr, '/', nullptr, "linker option"},
+        {nullptr,              NO_ARG,   nullptr,   0, nullptr, ""}
       };
 
     bool license_accepted = false;

--- a/bcc_ld.cpp
+++ b/bcc_ld.cpp
@@ -122,7 +122,7 @@ int try_main(int argc, char* argv[])
         {"lib-path",     REQD_ARG, nullptr, 'L', nullptr, "library path"},
         {"out-file",     REQD_ARG, nullptr, 'o', nullptr, "output executable file"},
         {"/",            REQD_ARG, nullptr, '/', nullptr, "linker option"},
-        {nullptr,              NO_ARG,   nullptr,   0, nullptr, ""}
+        {nullptr,        NO_ARG,   nullptr,   0, nullptr, ""}
       };
 
     bool license_accepted = false;

--- a/bcc_rc.cpp
+++ b/bcc_rc.cpp
@@ -35,17 +35,17 @@ int try_main(int argc, char* argv[])
     // compiler. TRICKY !! They are aliased to unlikely octal values.
     static Option long_options[] =
       {
-        {"help",         NO_ARG,   0, 001, 0, "display this help and exit"},
-        {"license",      NO_ARG,   0, 002, 0, "display license and exit"},
-        {"accept",       NO_ARG,   0, 003, 0, "accept license (-l to display)"},
-        {"program",      REQD_ARG, 0, 004, 0, "resource compiler's filepath"},
+        {"help",         NO_ARG,   nullptr, 001, nullptr, "display this help and exit"},
+        {"license",      NO_ARG,   nullptr, 002, nullptr, "display license and exit"},
+        {"accept",       NO_ARG,   nullptr, 003, nullptr, "accept license (-l to display)"},
+        {"program",      REQD_ARG, nullptr, 004, nullptr, "resource compiler's filepath"},
 // TRICKY !! '-i' is ambiguous:
 //   for windres, it means 'input file'
 //   for borland, it means 'include path'
 //        {"in-file",      REQD_ARG, 0, 'i', 0, "input .rc text file"},
-        {"include",      REQD_ARG, 0, 'i', 0, "include path"},
-        {"out-file",     REQD_ARG, 0, 'o', 0, "output binary resource file"},
-        {0,              NO_ARG,   0,   0, 0, ""}
+        {"include",      REQD_ARG, nullptr, 'i', nullptr, "include path"},
+        {"out-file",     REQD_ARG, nullptr, 'o', nullptr, "output binary resource file"},
+        {nullptr,              NO_ARG,   nullptr,   0, nullptr, ""}
       };
 
     bool license_accepted = false;

--- a/bcc_rc.cpp
+++ b/bcc_rc.cpp
@@ -45,7 +45,7 @@ int try_main(int argc, char* argv[])
 //        {"in-file",      REQD_ARG, 0, 'i', 0, "input .rc text file"},
         {"include",      REQD_ARG, nullptr, 'i', nullptr, "include path"},
         {"out-file",     REQD_ARG, nullptr, 'o', nullptr, "output binary resource file"},
-        {nullptr,              NO_ARG,   nullptr,   0, nullptr, ""}
+        {nullptr,        NO_ARG,   nullptr,   0, nullptr, ""}
       };
 
     bool license_accepted = false;

--- a/calendar_date.cpp
+++ b/calendar_date.cpp
@@ -788,9 +788,9 @@ calendar_date const& last_yyyy_date()
 
 calendar_date today()
 {
-    std::time_t const t0 = std::time(0);
+    std::time_t const t0 = std::time(nullptr);
     std::tm const*const t1 = std::localtime(&t0);
-    LMI_ASSERT(NULL != t1);
+    LMI_ASSERT(nullptr != t1);
     return calendar_date
         (1900 + t1->tm_year
         ,   1 + t1->tm_mon

--- a/callback.hpp
+++ b/callback.hpp
@@ -123,7 +123,7 @@ class LMI_SO callback
 template<typename FunctionPointer>
 FunctionPointer callback<FunctionPointer>::operator()() const
 {
-    if(0 == function_pointer_)
+    if(nullptr == function_pointer_)
         {
         throw std::logic_error("Callback pointer is null.");
         }
@@ -133,11 +133,11 @@ FunctionPointer callback<FunctionPointer>::operator()() const
 template<typename FunctionPointer>
 void callback<FunctionPointer>::initialize(FunctionPointer concrete_pointer)
 {
-    if(0 != function_pointer_)
+    if(nullptr != function_pointer_)
         {
         throw std::logic_error("Callback pointer already initialized.");
         }
-    if(0 == concrete_pointer)
+    if(nullptr == concrete_pointer)
         {
         throw std::logic_error("Attempt to reset callback pointer to null.");
         }

--- a/callback_test.cpp
+++ b/callback_test.cpp
@@ -63,7 +63,7 @@ namespace shared_library
 } // namespace shared_library
 
 typedef shared_library::adder_fp_type FunctionPointer;
-template<> FunctionPointer callback<FunctionPointer>::function_pointer_ = 0;
+template<> FunctionPointer callback<FunctionPointer>::function_pointer_ = nullptr;
 
 namespace application
 {

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -394,7 +394,7 @@ class DatumSequenceRenderer
 
 DatumSequenceRenderer::DatumSequenceRenderer()
     :wxDataViewCustomRenderer(typeid(input_sequence_variant_data).name(), wxDATAVIEW_CELL_EDITABLE, wxDVR_DEFAULT_ALIGNMENT)
-    ,m_input(0)
+    ,m_input(nullptr)
 {
 }
 
@@ -877,7 +877,7 @@ END_EVENT_TABLE()
 CensusView::CensusView()
     :ViewEx                          ()
     ,autosize_columns_               (false)
-    ,list_window_                    (0)
+    ,list_window_                    (nullptr)
     ,list_model_                     (new(wx) CensusViewDataViewModel(*this))
 {
 }
@@ -957,7 +957,7 @@ Input* CensusView::class_parms_from_class_name(std::string const& class_name)
             }
         ++i;
         }
-    return 0;
+    return nullptr;
 }
 
 /// Determine which columns need to be displayed because their rows
@@ -1061,7 +1061,7 @@ void CensusView::update_class_names()
     while(n != unique_class_names.end())
         {
         Input* parms = class_parms_from_class_name(*n);
-        if(0 != parms)
+        if(nullptr != parms)
             {
             // If we already have default parameters for the class,
             // insert them into the rebuilt vector.

--- a/contains.hpp
+++ b/contains.hpp
@@ -62,11 +62,11 @@ struct has_member_find
     template<typename PMF, PMF pmf> struct spoiler;
 
     template<typename D>
-    static nay_t deduce(D*, spoiler<void (Mixin::*)(), &D::find>* = 0);
+    static nay_t deduce(D*, spoiler<void (Mixin::*)(), &D::find>* = nullptr);
 
     static yea_t deduce(...);
 
-    static bool const value = sizeof(yea_t) == sizeof deduce((Derived*)(0));
+    static bool const value = sizeof(yea_t) == sizeof deduce((Derived*)nullptr);
 };
 
 /// Ascertain whether a "container" includes a given element.
@@ -82,7 +82,7 @@ template<typename T>
 bool contains
     (T const& t
     ,typename T::value_type const& element
-    ,typename boost::disable_if<has_member_find<T> >::type* = 0
+    ,typename boost::disable_if<has_member_find<T> >::type* = nullptr
     )
 {
     return t.end() != std::find(t.begin(), t.end(), element);
@@ -98,7 +98,7 @@ template<typename T>
 bool contains
     (T const& t
     ,T const& element
-    ,typename T::traits_type::char_type const* = 0
+    ,typename T::traits_type::char_type const* = nullptr
     )
 {
     return T::npos != t.find(element);

--- a/cpp_main.cpp
+++ b/cpp_main.cpp
@@ -157,7 +157,7 @@ int main(int argc, char* argv[])
         {"help",         NO_ARG,   nullptr, 001, nullptr, "display this help and exit"},
         {"license",      NO_ARG,   nullptr, 002, nullptr, "display license and exit"},
         {"accept",       NO_ARG,   nullptr, 003, nullptr, "accept license (-l to display)"},
-        {nullptr,              NO_ARG,   nullptr,   0, nullptr, ""}
+        {nullptr,        NO_ARG,   nullptr,   0, nullptr, ""}
       };
 
     bool license_accepted = false;

--- a/cpp_main.cpp
+++ b/cpp_main.cpp
@@ -149,15 +149,15 @@ int main(int argc, char* argv[])
     // This line forces mpatrol to link when it otherwise might not.
     // It has no other effect according to C99 7.20.3.2/2, second
     // sentence.
-    std::free(0);
+    std::free(nullptr);
 
     // TRICKY !! Some long options are aliased to unlikely octal values.
     static Option long_options[] =
       {
-        {"help",         NO_ARG,   0, 001, 0, "display this help and exit"},
-        {"license",      NO_ARG,   0, 002, 0, "display license and exit"},
-        {"accept",       NO_ARG,   0, 003, 0, "accept license (-l to display)"},
-        {0,              NO_ARG,   0,   0, 0, ""}
+        {"help",         NO_ARG,   nullptr, 001, nullptr, "display this help and exit"},
+        {"license",      NO_ARG,   nullptr, 002, nullptr, "display license and exit"},
+        {"accept",       NO_ARG,   nullptr, 003, nullptr, "accept license (-l to display)"},
+        {nullptr,              NO_ARG,   nullptr,   0, nullptr, ""}
       };
 
     bool license_accepted = false;

--- a/database_view_editor.cpp
+++ b/database_view_editor.cpp
@@ -294,7 +294,7 @@ unsigned int DatabaseTableAdapter::DoGetDimension() const
 
 bool DatabaseTableAdapter::IsVoid() const
 {
-    return db_value_ == NULL;
+    return db_value_ == nullptr;
 }
 
 double DatabaseTableAdapter::DoGetValue(Coords const& coords) const

--- a/database_view_editor.hpp
+++ b/database_view_editor.hpp
@@ -70,7 +70,7 @@ class DatabaseTableAdapter
         == static_cast<int>(e_number_of_axes)
         );
   public:
-    DatabaseTableAdapter(database_entity* db_value = NULL);
+    DatabaseTableAdapter(database_entity* db_value = nullptr);
 
     virtual ~DatabaseTableAdapter();
 

--- a/docmanager_ex.cpp
+++ b/docmanager_ex.cpp
@@ -268,7 +268,7 @@ wxDocTemplate* DocManagerEx::SelectDocumentType
     {
         case 0:
             // no visible templates, hence nothing to choose from
-            theTemplate = NULL;
+            theTemplate = nullptr;
             break;
 
         case 1:
@@ -290,7 +290,7 @@ wxDocTemplate* DocManagerEx::SelectDocumentType
                           );
 */
             int selection = SingleChoicePopupMenu(strings).Choose();
-            theTemplate = 0;
+            theTemplate = nullptr;
             if(-1 != selection)
                 {
                 theTemplate = data[selection];

--- a/file_command.cpp
+++ b/file_command.cpp
@@ -34,7 +34,7 @@ namespace
 }
 
 typedef file_command_fp_type FunctionPointer;
-template<> FunctionPointer callback<FunctionPointer>::function_pointer_ = 0;
+template<> FunctionPointer callback<FunctionPointer>::function_pointer_ = nullptr;
 
 bool file_command_initialize(file_command_fp_type f)
 {

--- a/generate_passkey.cpp
+++ b/generate_passkey.cpp
@@ -47,7 +47,7 @@ int try_main(int, char*[])
     char c_passkey[md5len];
     unsigned char u_passkey[md5len];
     std::FILE* md5sums_file = std::fopen(md5sum_file(), "rb");
-    if(0 == md5sums_file)
+    if(nullptr == md5sums_file)
         {
         std::cerr << "File '" << md5sum_file() << "' not found.\n";
         return EXIT_FAILURE;

--- a/getopt.cpp
+++ b/getopt.cpp
@@ -112,20 +112,20 @@
 // GWC added this.
 #include <vector>
 
-char* GetOpt::nextchar = 0;
+char* GetOpt::nextchar = nullptr;
 int GetOpt::first_nonopt = 0;
 int GetOpt::last_nonopt = 0;
 
 GetOpt::GetOpt (int argc, char** argv, char const* optstring)
- :list_option (0)
+ :list_option (nullptr)
  ,list_option_first (0)
  ,optindvalue (EOF)
  ,opterr (true)
  ,nargc (argc)
  ,nargv (argv)
  ,noptstring (optstring)
- ,nlongopts (0)
- ,nlongind (0)
+ ,nlongopts (nullptr)
+ ,nlongind (nullptr)
  ,nlong_only (0)
 {
     Initialize (noptstring);
@@ -133,7 +133,7 @@ GetOpt::GetOpt (int argc, char** argv, char const* optstring)
 
 GetOpt::GetOpt (int argc, char** argv, char const* optstring,
                 Option const* longopts, int* longind, int long_only)
- :list_option (0)
+ :list_option (nullptr)
  ,list_option_first (0)
  ,optindvalue (EOF)
  ,opterr (true)
@@ -145,7 +145,7 @@ GetOpt::GetOpt (int argc, char** argv, char const* optstring,
  ,nlong_only (long_only)
 {
     // Automatically register any short-option alii for long options.
-    for(Option const* i = nlongopts; 0 != i->name; ++i)
+    for(Option const* i = nlongopts; nullptr != i->name; ++i)
         {
         if(!i->val)
             {
@@ -178,11 +178,11 @@ GetOpt::Initialize  (std::string const& a_optstring)
   // non-option ARGV-elements is empty.
 
   first_nonopt = last_nonopt = optind = 1;
-  optarg = nextchar = 0;
+  optarg = nextchar = nullptr;
 
   // Determine how to handle the ordering of options and nonoptions.
 
-  if (0 == a_optstring.c_str())
+  if (nullptr == a_optstring.c_str())
     {
       noptstring = "";
       if (std::getenv ("_POSIX_OPTION_ORDER"))
@@ -205,7 +205,7 @@ GetOpt::exchange (char** argv)
 // GWC substituted std::malloc() for alloca() and added call to std::free() below.
 //  char** temp = static_cast<char**>(alloca (nonopts_size));
   char** temp = static_cast<char**>(std::malloc (nonopts_size));
-  if(0 == temp)
+  if(nullptr == temp)
     {
     throw std::runtime_error("Out of memory.");
     }
@@ -233,9 +233,9 @@ GetOpt::List_Value  (int i)
 
   list_option_first = 0;
   optarg = nargv[i];
-  nextchar = 0;
+  nextchar = nullptr;
   if (list_option->has_arg != LIST_ARG)
-    list_option = 0;
+    list_option = nullptr;
   if (x->flag)
     {
       *(x->flag) = x->val;
@@ -250,10 +250,10 @@ GetOpt::List_No_Value  ()
   Option const* x = list_option;
 
   list_option_first = 0;
-  list_option = 0;
+  list_option = nullptr;
   optindvalue = EOF;
-  optarg = 0;
-  nextchar = 0;
+  optarg = nullptr;
+  nextchar = nullptr;
   if (x->flag)
     {
       *(x->flag) = x->val;
@@ -375,7 +375,7 @@ GetOpt::operator()()
             return EOF;
         }
 
-      if (list_option->valid == 0)
+      if (list_option->valid == nullptr)
         {
           // If there isn't a valid list of values,
           // try to see if current argument isn't an option.
@@ -393,7 +393,7 @@ GetOpt::operator()()
 
           char const** v;
 
-          for (v = list_option->valid, optindvalue = 0;  *v != 0; v++, optindvalue++)
+          for (v = list_option->valid, optindvalue = 0;  *v != nullptr; v++, optindvalue++)
             if (std::strcmp (*v, nargv[optind]) == 0)
               return  List_Value (optind++);
           optindvalue = EOF;
@@ -403,11 +403,11 @@ GetOpt::operator()()
 
           if (list_option_first)
             return  List_No_Value ();
-          list_option = 0;
+          list_option = nullptr;
         }
     }
 
-  if (nextchar == 0 || *nextchar == 0)
+  if (nextchar == nullptr || *nextchar == 0)
     {
       if (ordering == PERMUTE)
         {
@@ -456,7 +456,7 @@ GetOpt::operator()()
 
           if (list_option_first)
             return  List_No_Value ();
-          list_option = 0;
+          list_option = nullptr;
 
           // Set the next-arg-index to point at the non-options
           // that we previously skipped, so the caller will digest them.
@@ -476,7 +476,7 @@ GetOpt::operator()()
 
           if (list_option_first)
             return  List_No_Value ();
-          list_option = 0;
+          list_option = nullptr;
 
           if (ordering == REQUIRE_ORDER)
             return EOF;
@@ -521,7 +521,7 @@ GetOpt::operator()()
     {
       char* nameend;
       Option const* p;
-      Option const* pfound = 0;
+      Option const* pfound = nullptr;
       int exact = 0;
       int ambig = 0;
       int indfound = 0;
@@ -543,7 +543,7 @@ GetOpt::operator()()
                 exact = 1;
                 break;
               }
-            else if (pfound == 0)
+            else if (pfound == nullptr)
               {
                 // First nonexact match found.
                 pfound = p;
@@ -574,7 +574,7 @@ GetOpt::operator()()
 
           if (list_option_first)
             return  List_No_Value ();
-          list_option = 0;
+          list_option = nullptr;
 
           option_index = indfound;
           optind++;
@@ -639,7 +639,7 @@ GetOpt::operator()()
                 break;
 
               default:
-                optarg = 0;
+                optarg = nullptr;
                 break;
 
              }
@@ -667,7 +667,7 @@ GetOpt::operator()()
               {
                 char const** v;
 
-                for (v = pfound->valid, optindvalue = 0;  *v != 0; v++, optindvalue++)
+                for (v = pfound->valid, optindvalue = 0;  *v != nullptr; v++, optindvalue++)
                   if (std::strcmp (*v, optarg) == 0)
                     return  result;
                 optindvalue = EOF;
@@ -701,7 +701,7 @@ GetOpt::operator()()
       // option, then it's an error.
       // Otherwise interpret it as a short option.
 
-      if (!nlong_only || nargv[optind][1] == '-' || std::strchr (noptstring.c_str(), *nextchar) == 0)
+      if (!nlong_only || nargv[optind][1] == '-' || std::strchr (noptstring.c_str(), *nextchar) == nullptr)
         {
           if (list_option)
             // It is not a long option, but it is a value for LIST_ARG
@@ -740,7 +740,7 @@ GetOpt::operator()()
     if (*nextchar == 0)
       optind++;
 
-    if (temp == 0 || c == ':')
+    if (temp == nullptr || c == ':')
       {
         if (opterr)
           {
@@ -751,7 +751,7 @@ GetOpt::operator()()
 
                 if (list_option_first)
                   return  List_No_Value ();
-                list_option = 0;
+                list_option = nullptr;
 
                 std::fprintf (stderr, "%s: unrecognized option, character code 0%o\n",
                          nargv[0], c);
@@ -774,7 +774,7 @@ GetOpt::operator()()
 
     if (list_option_first)
       return  List_No_Value ();
-    list_option = 0;
+    list_option = nullptr;
 
     if (temp[1] == ':')
       {
@@ -787,8 +787,8 @@ GetOpt::operator()()
                 optind++;
               }
             else
-              optarg = 0;
-            nextchar = 0;
+              optarg = nullptr;
+            nextchar = nullptr;
           }
         else
           {
@@ -812,7 +812,7 @@ GetOpt::operator()()
               // We already incremented 'optind' once;
               // increment it again when taking next ARGV-elt as argument.
               optarg = nargv[optind++];
-            nextchar = 0;
+            nextchar = nullptr;
           }
       }
     return c;
@@ -826,7 +826,7 @@ GetOpt::next_arg (int& i)
 
   // Terminates LIST_ARG processing.
 
-  list_option = 0;
+  list_option = nullptr;
 
   if (0 < std::sscanf (nargv[optind], "%d", &tmp))
     {
@@ -845,7 +845,7 @@ GetOpt::next_arg (double& d)
 
   // Terminates LIST_ARG processing.
 
-  list_option = 0;
+  list_option = nullptr;
 
   if (0 < std::sscanf (nargv[optind], "%lf", &tmp))
     {
@@ -863,7 +863,7 @@ GetOpt::next_arg (std::string& s)
 {
   // Terminates LIST_ARG processing.
 
-  list_option = 0;
+  list_option = nullptr;
 
   if ('-' != nargv[optind][0])
     {
@@ -888,7 +888,7 @@ GetOpt::usage(std::ostream& os)
     typedef str_vec::iterator str_vec_i;
     str_vec option_names;
     str_vec option_descriptions;
-    for(Option const* i = nlongopts; 0 != i->name; ++i)
+    for(Option const* i = nlongopts; nullptr != i->name; ++i)
         {
         int const c = i->val;
         std::string s;
@@ -898,7 +898,7 @@ GetOpt::usage(std::ostream& os)
             // Don't show options with intentionally-bizarre 'val'.
             continue;
             }
-        else if(0 == i->flag && std::isalpha(c))
+        else if(nullptr == i->flag && std::isalpha(c))
             {
             s += '-';
             s += static_cast<char>(c);

--- a/getopt_test.cpp
+++ b/getopt_test.cpp
@@ -80,11 +80,11 @@ std::string getopt_test::test(int argc, char* argv[])
             {"list"    ,LIST_ARG ,nullptr ,  0 ,nullptr     ,""},
             {"opt"     ,OPT_ARG  ,nullptr ,  0 ,nullptr     ,""},
             {"alt"     ,ALT_ARG  ,nullptr ,  0 ,nullptr     ,""},
-            {"vfile"   ,REQD_ARG ,nullptr ,  0 ,vfile ,""},
-            {"vlist"   ,LIST_ARG ,nullptr ,  0 ,vlist ,""},
-            {"vopt"    ,OPT_ARG  ,nullptr ,  0 ,vopt  ,""},
-            {"valt"    ,ALT_ARG  ,nullptr ,  0 ,vopt  ,""},
-            {nullptr         ,NO_ARG   ,nullptr ,  0 ,nullptr     ,""}
+            {"vfile"   ,REQD_ARG ,nullptr ,  0 ,vfile       ,""},
+            {"vlist"   ,LIST_ARG ,nullptr ,  0 ,vlist       ,""},
+            {"vopt"    ,OPT_ARG  ,nullptr ,  0 ,vopt        ,""},
+            {"valt"    ,ALT_ARG  ,nullptr ,  0 ,vopt        ,""},
+            {nullptr   ,NO_ARG   ,nullptr ,  0 ,nullptr     ,""}
         };
     int option_index = 0;
     GetOpt getopt_long

--- a/getopt_test.cpp
+++ b/getopt_test.cpp
@@ -62,29 +62,29 @@ std::string getopt_test::test(int argc, char* argv[])
     // These preconditions are required by C++98 3.6.1/2 and also by
     // C99 5.1.2.2.1; violating them could cause a crash.
     LMI_ASSERT(0 <= argc);
-    LMI_ASSERT(0 == argv[argc]);
+    LMI_ASSERT(nullptr == argv[argc]);
 
     std::ostringstream oss;
 
-    static char const* vfile[] = {"file", "archive", 0};
-    static char const* vlist[] = {"one", "two", "three", 0};
-    static char const* vopt [] = {"optional", "alternative", 0};
+    static char const* vfile[] = {"file", "archive", nullptr};
+    static char const* vlist[] = {"one", "two", "three", nullptr};
+    static char const* vopt [] = {"optional", "alternative", nullptr};
     static Option long_options[] =
         {
-            {"add"     ,REQD_ARG ,0 ,  0 ,0     ,""},
-            {"append"  ,NO_ARG   ,0 ,  0 ,0     ,""},
-            {"delete"  ,REQD_ARG ,0 ,  0 ,0     ,""},
-            {"verbose" ,NO_ARG   ,0 ,  0 ,0     ,""},
-            {"create"  ,NO_ARG   ,0 ,  0 ,0     ,""},
-            {"file"    ,REQD_ARG ,0 ,  0 ,0     ,""},
-            {"list"    ,LIST_ARG ,0 ,  0 ,0     ,""},
-            {"opt"     ,OPT_ARG  ,0 ,  0 ,0     ,""},
-            {"alt"     ,ALT_ARG  ,0 ,  0 ,0     ,""},
-            {"vfile"   ,REQD_ARG ,0 ,  0 ,vfile ,""},
-            {"vlist"   ,LIST_ARG ,0 ,  0 ,vlist ,""},
-            {"vopt"    ,OPT_ARG  ,0 ,  0 ,vopt  ,""},
-            {"valt"    ,ALT_ARG  ,0 ,  0 ,vopt  ,""},
-            {0         ,NO_ARG   ,0 ,  0 ,0     ,""}
+            {"add"     ,REQD_ARG ,nullptr ,  0 ,nullptr     ,""},
+            {"append"  ,NO_ARG   ,nullptr ,  0 ,nullptr     ,""},
+            {"delete"  ,REQD_ARG ,nullptr ,  0 ,nullptr     ,""},
+            {"verbose" ,NO_ARG   ,nullptr ,  0 ,nullptr     ,""},
+            {"create"  ,NO_ARG   ,nullptr ,  0 ,nullptr     ,""},
+            {"file"    ,REQD_ARG ,nullptr ,  0 ,nullptr     ,""},
+            {"list"    ,LIST_ARG ,nullptr ,  0 ,nullptr     ,""},
+            {"opt"     ,OPT_ARG  ,nullptr ,  0 ,nullptr     ,""},
+            {"alt"     ,ALT_ARG  ,nullptr ,  0 ,nullptr     ,""},
+            {"vfile"   ,REQD_ARG ,nullptr ,  0 ,vfile ,""},
+            {"vlist"   ,LIST_ARG ,nullptr ,  0 ,vlist ,""},
+            {"vopt"    ,OPT_ARG  ,nullptr ,  0 ,vopt  ,""},
+            {"valt"    ,ALT_ARG  ,nullptr ,  0 ,vopt  ,""},
+            {nullptr         ,NO_ARG   ,nullptr ,  0 ,nullptr     ,""}
         };
     int option_index = 0;
     GetOpt getopt_long
@@ -206,14 +206,14 @@ int test_main(int, char*[])
     char arg0[] = {""};
     char arg1[] = {"--verbose"};
     char arg2[] = {"xyz"};
-    char* test_argv[] = {arg0, arg1, arg2, 0};
+    char* test_argv[] = {arg0, arg1, arg2, nullptr};
     int test_argc = -1 + static_cast<int>(lmi_array_size(test_argv));
     std::string s = getopt_test::test(test_argc, test_argv);
     BOOST_TEST_EQUAL(s, "option verbose\nnon-option ARGV-elements: xyz\n");
     }
 
     {
-    char* test_argv[] = {0};
+    char* test_argv[] = {nullptr};
     int test_argc = -1 + static_cast<int>(lmi_array_size(test_argv));
     std::string s = getopt_test::test(test_argc, test_argv);
     BOOST_TEST_EQUAL(s, "");
@@ -223,7 +223,7 @@ int test_main(int, char*[])
     char arg0[] = {""};
     char arg1[] = {"-o"};
     char arg2[] = {"-d1,2,3"};
-    char* test_argv[] = {arg0, arg1, arg2, 0};
+    char* test_argv[] = {arg0, arg1, arg2, nullptr};
     int test_argc = -1 + static_cast<int>(lmi_array_size(test_argv));
     std::string s = getopt_test::test(test_argc, test_argv);
     BOOST_TEST_EQUAL(s, "option o\noption d with value '1,2,3'\n");

--- a/gpt_commutation_functions.cpp
+++ b/gpt_commutation_functions.cpp
@@ -268,7 +268,7 @@ double gpt_cf_triad::calculate_premium
         : (oe_gsp == glp_or_gsp                               ) ? &cf_gsp
         : throw std::runtime_error("Cannot determine GPT assumptions.")
         ;
-    LMI_ASSERT(0 != pcf); // Redundant: demonstrably cannot fail.
+    LMI_ASSERT(nullptr != pcf); // Redundant: demonstrably cannot fail.
     double const z = pcf->calculate_premium(glp_or_gsp, args);
     LMI_ASSERT(0.0 <= z);
     return z;

--- a/gpt_input.hpp
+++ b/gpt_input.hpp
@@ -227,7 +227,7 @@ template<> struct reconstitutor<datum_base, gpt_input>
     typedef datum_base DesiredType;
     static DesiredType* reconstitute(any_member<gpt_input>& m)
         {
-        DesiredType* z = 0;
+        DesiredType* z = nullptr;
         z = exact_cast<ce_product_name         >(m); if(z) return z;
         z = exact_cast<datum_string            >(m); if(z) return z;
         // Sequences.

--- a/gpt_test.cpp
+++ b/gpt_test.cpp
@@ -413,7 +413,7 @@ void gpt_test::test_invariants()
 
 /// The obsolescent GPT class more or less requires this ugliness.
 
-Irc7702* ugliness = 0;
+Irc7702* ugliness = nullptr;
 
 /// Instantiate obsolescent GPT class.
 

--- a/gpt_view.cpp
+++ b/gpt_view.cpp
@@ -90,7 +90,7 @@ END_EVENT_TABLE()
 gpt_view::gpt_view()
     :ViewEx       ()
     ,html_content_("Unable to display results.")
-    ,html_window_ (0)
+    ,html_window_ (nullptr)
 {
 }
 

--- a/group_quote_pdf_gen.cpp
+++ b/group_quote_pdf_gen.cpp
@@ -35,7 +35,7 @@ callback<group_quote_pdf_generator::creator_type>
 } // Unnnamed namespace.
 
 typedef group_quote_pdf_generator::creator_type FunctionPointer;
-template<> FunctionPointer callback<FunctionPointer>::function_pointer_ = 0;
+template<> FunctionPointer callback<FunctionPointer>::function_pointer_ = nullptr;
 
 bool group_quote_pdf_generator::set_creator(creator_type f)
 {

--- a/group_quote_pdf_gen_wx.cpp
+++ b/group_quote_pdf_gen_wx.cpp
@@ -933,7 +933,7 @@ void group_quote_pdf_generator_wx::do_generate_pdf(wxPdfDC& pdf_dc)
         );
 
     // Create an HTML parser to allow easily adding HTML contents to the output.
-    wxHtmlWinParser html_parser(NULL);
+    wxHtmlWinParser html_parser(nullptr);
     html_parser.SetDC(&pdf_dc);
     html_parser.SetStandardFonts
         (pdf_dc.GetFont().GetPointSize()

--- a/ihs_crc_comp.cpp
+++ b/ihs_crc_comp.cpp
@@ -387,12 +387,12 @@ typedef void(*pf)(std::string const& line1, std::string const& line2);
 pf const transition_functions[6][6] =
     {
     /*        to: 0     1     2     3     4     5 */
-    /* from 0 */ {0, &f01, &f02,    0,    0,    0,},
-    /* from 1 */ {0, &f11, &f12,    0,    0,    0,},
-    /* from 2 */ {0,    0, &f22, &f23, &f24, &f25,},
-    /* from 3 */ {0,    0, &f32, &f33, &f34,    0,},
-    /* from 4 */ {0,    0, &f42,    0, &f44,    0,},
-    /* from 5 */ {0,    0,    0,    0,    0,    0,},
+    /* from 0 */ {nullptr, &f01, &f02,    nullptr,    nullptr,    nullptr,},
+    /* from 1 */ {nullptr, &f11, &f12,    nullptr,    nullptr,    nullptr,},
+    /* from 2 */ {nullptr,    nullptr, &f22, &f23, &f24, &f25,},
+    /* from 3 */ {nullptr,    nullptr, &f32, &f33, &f34,    nullptr,},
+    /* from 4 */ {nullptr,    nullptr, &f42,    nullptr, &f44,    nullptr,},
+    /* from 5 */ {nullptr,    nullptr,    nullptr,    nullptr,    nullptr,    nullptr,},
     };
 
 //============================================================================

--- a/ihs_crc_comp.cpp
+++ b/ihs_crc_comp.cpp
@@ -386,13 +386,13 @@ void f25(std::string const& line1, std::string const& line2)
 typedef void(*pf)(std::string const& line1, std::string const& line2);
 pf const transition_functions[6][6] =
     {
-    /*        to: 0     1     2     3     4     5 */
-    /* from 0 */ {nullptr, &f01, &f02,    nullptr,    nullptr,    nullptr,},
-    /* from 1 */ {nullptr, &f11, &f12,    nullptr,    nullptr,    nullptr,},
-    /* from 2 */ {nullptr,    nullptr, &f22, &f23, &f24, &f25,},
-    /* from 3 */ {nullptr,    nullptr, &f32, &f33, &f34,    nullptr,},
-    /* from 4 */ {nullptr,    nullptr, &f42,    nullptr, &f44,    nullptr,},
-    /* from 5 */ {nullptr,    nullptr,    nullptr,    nullptr,    nullptr,    nullptr,},
+    /*        to: 0        1        2        3        4        5       */
+    /* from 0 */ {nullptr, &f01,    &f02,    nullptr, nullptr, nullptr,},
+    /* from 1 */ {nullptr, &f11,    &f12,    nullptr, nullptr, nullptr,},
+    /* from 2 */ {nullptr, nullptr, &f22,    &f23,    &f24,    &f25,   },
+    /* from 3 */ {nullptr, nullptr, &f32,    &f33,    &f34,    nullptr,},
+    /* from 4 */ {nullptr, nullptr, &f42,    nullptr, &f44,    nullptr,},
+    /* from 5 */ {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,},
     };
 
 //============================================================================

--- a/illustration_view.cpp
+++ b/illustration_view.cpp
@@ -101,7 +101,7 @@ END_EVENT_TABLE()
 
 IllustrationView::IllustrationView()
     :ViewEx                  ()
-    ,html_window_            (0)
+    ,html_window_            (nullptr)
     ,is_phony_               (false)
 {
 }
@@ -349,11 +349,11 @@ IllustrationView& MakeNewIllustrationDocAndView
     ,char const*   filename
     )
 {
-    LMI_ASSERT(0 != dm);
-    LMI_ASSERT(0 != filename);
+    LMI_ASSERT(nullptr != dm);
+    LMI_ASSERT(nullptr != filename);
 
     wxDocTemplate* dt = dm->FindTemplateForPath(filename);
-    LMI_ASSERT(0 != dt);
+    LMI_ASSERT(nullptr != dt);
 
     wxDocument* new_document = dt->CreateDocument
         (filename
@@ -398,7 +398,7 @@ bool custom_io_0_run_if_file_exists(wxDocManager* dm)
                 }
             else
                 {
-                LMI_ASSERT(0 != dm);
+                LMI_ASSERT(nullptr != dm);
                 IllustrationView& illview = MakeNewIllustrationDocAndView
                     (dm
                     ,(c.custom_output_0_filename() + ".ill").c_str()

--- a/illustration_view.hpp
+++ b/illustration_view.hpp
@@ -67,7 +67,7 @@ class IllustrationView
     // friend.
     //
     void DisplaySelectedValuesAsHtml();
-    void Run(Input* = 0);
+    void Run(Input* = nullptr);
     void SetLedger(boost::shared_ptr<Ledger const>);
 
   private:

--- a/input.hpp
+++ b/input.hpp
@@ -480,7 +480,7 @@ template<> struct reconstitutor<datum_sequence, Input>
     typedef datum_sequence DesiredType;
     static DesiredType* reconstitute(any_member<Input>& m)
         {
-        DesiredType* z = 0;
+        DesiredType* z = nullptr;
         z = exact_cast<dbo_sequence            >(m); if(z) return z;
         z = exact_cast<mode_sequence           >(m); if(z) return z;
         z = exact_cast<numeric_sequence        >(m); if(z) return z;
@@ -498,7 +498,7 @@ template<> struct reconstitutor<mc_enum_base, Input>
     typedef mc_enum_base DesiredType;
     static DesiredType* reconstitute(any_member<Input>& m)
         {
-        DesiredType* z = 0;
+        DesiredType* z = nullptr;
         z = exact_cast<ce_product_name         >(m); if(z) return z;
         z = exact_cast<mce_class               >(m); if(z) return z;
         z = exact_cast<mce_country             >(m); if(z) return z;
@@ -544,7 +544,7 @@ template<> struct reconstitutor<tn_range_base, Input>
     typedef tn_range_base DesiredType;
     static DesiredType* reconstitute(any_member<Input>& m)
         {
-        DesiredType* z = 0;
+        DesiredType* z = nullptr;
         z = exact_cast<tnr_age                 >(m); if(z) return z;
         z = exact_cast<tnr_corridor_factor     >(m); if(z) return z;
         z = exact_cast<tnr_date                >(m); if(z) return z;
@@ -566,7 +566,7 @@ template<> struct reconstitutor<datum_base, Input>
     typedef datum_base DesiredType;
     static DesiredType* reconstitute(any_member<Input>& m)
         {
-        DesiredType* z = 0;
+        DesiredType* z = nullptr;
         z = exact_cast<datum_string            >(m); if(z) return z;
         z = reconstitutor<datum_sequence,Input>::reconstitute(m); if(z) return z;
         z = reconstitutor<mc_enum_base  ,Input>::reconstitute(m); if(z) return z;

--- a/input_seq_helpers.hpp
+++ b/input_seq_helpers.hpp
@@ -109,7 +109,7 @@ namespace detail
 template<typename T>
 std::vector<T> convert_vector_type
     (std::vector<mc_enum<T> > const& ve
-    ,typename boost::enable_if<boost::is_enum<T> >::type* = 0
+    ,typename boost::enable_if<boost::is_enum<T> >::type* = nullptr
     )
 {
     std::vector<T> z;

--- a/input_seq_test.cpp
+++ b/input_seq_test.cpp
@@ -91,7 +91,7 @@ void check
     ,int n
     ,std::string const& e
     ,std::vector<std::string> const& k = std::vector<std::string>(0)
-    ,char const* const* c = 0
+    ,char const* const* c = nullptr
     ,std::string const& w = std::string("")
     )
 {
@@ -113,7 +113,7 @@ void check
     std::vector<std::string> s(seq.linear_keyword_representation());
     // Assert that std::equal() has defined behavior.
     assert(s.size() == static_cast<unsigned int>(n));
-    if((0 != c) && !std::equal(c, c + n, s.begin()))
+    if((nullptr != c) && !std::equal(c, c + n, s.begin()))
         {
         std::cout << "\nExpression: '" << e << '\'';
         std::cout << "\n  expected: ";

--- a/input_sequence_entry.cpp
+++ b/input_sequence_entry.cpp
@@ -589,7 +589,7 @@ void InputSequenceEditor::insert_row(int new_row)
             ,wxDefaultPosition
             ,wxDefaultSize
             ,0
-            ,NULL
+            ,nullptr
             ,keywords_only_ ? wxCB_READONLY : 0
             );
         value_ctrl = combo;
@@ -669,7 +669,7 @@ void InputSequenceEditor::insert_row(int new_row)
     remove->Connect
         (wxEVT_COMMAND_BUTTON_CLICKED
         ,wxCommandEventHandler(InputSequenceEditor::UponRemoveRow)
-        ,NULL
+        ,nullptr
         ,this
         );
     sizer_->wxSizer::Insert(insert_pos++, remove, wxSizerFlags(flags).TripleBorder(wxLEFT));
@@ -691,7 +691,7 @@ void InputSequenceEditor::insert_row(int new_row)
     add->Connect
         (wxEVT_COMMAND_BUTTON_CLICKED
         ,wxCommandEventHandler(InputSequenceEditor::UponAddRow)
-        ,NULL
+        ,nullptr
         ,this
         );
     sizer_->wxSizer::Insert(insert_pos++, add, wxSizerFlags(flags).Border(wxLEFT, 0).Right());
@@ -1379,7 +1379,7 @@ InputSequenceButton::InputSequenceButton(wxWindow* parent, wxWindowID id)
 } // Unnamed namespace.
 
 InputSequenceEntry::InputSequenceEntry()
-    :input_(0)
+    :input_(nullptr)
 {
 }
 
@@ -1388,7 +1388,7 @@ InputSequenceEntry::InputSequenceEntry
     ,wxWindowID         id
     ,wxString const&    name
     )
-    :input_(0)
+    :input_(nullptr)
 {
     Create(parent, id, name);
 }
@@ -1421,26 +1421,26 @@ bool InputSequenceEntry::Create
     text_->Connect
         (wxEVT_KILL_FOCUS
         ,wxFocusEventHandler(InputSequenceEntry::UponChildKillFocus)
-        ,NULL
+        ,nullptr
         ,this
         );
     text_->Connect
         (wxEVT_TEXT_ENTER
         ,wxCommandEventHandler(InputSequenceEntry::UponEnter)
-        ,NULL
+        ,nullptr
         ,this
         );
 
     button_->Connect
         (wxEVT_KILL_FOCUS
         ,wxFocusEventHandler(InputSequenceEntry::UponChildKillFocus)
-        ,NULL
+        ,nullptr
         ,this
         );
     button_->Connect
         (wxEVT_COMMAND_BUTTON_CLICKED
         ,wxCommandEventHandler(InputSequenceEntry::UponOpenEditor)
-        ,NULL
+        ,nullptr
         ,this
         );
 
@@ -1498,7 +1498,7 @@ void InputSequenceEntry::UponChildKillFocus(wxFocusEvent& event)
 {
     // Don't notify the parent (and thus wxDataViewCtrl) of focus change if its within this
     // InputSequenceEntry composite control or a InputSequenceEditor window opened from it.
-    if(0 == event.GetWindow() ||
+    if(nullptr == event.GetWindow() ||
        (event.GetWindow()->GetParent() != GetParent() &&
         wxGetTopLevelParent(event.GetWindow())->GetParent() != this))
         {

--- a/main_cli.cpp
+++ b/main_cli.cpp
@@ -161,21 +161,21 @@ void process_command_line(int argc, char* argv[])
     // TRICKY !! Some long options are aliased to unlikely octal values.
     static Option long_options[] =
       {
-        {"ash_nazg"  ,NO_ARG   ,0 ,001 ,0 ,"ash nazg durbatulûk"},
-        {"ash_naz"   ,NO_ARG   ,0 ,003 ,0 ,"fraud"},
-        {"mellon"    ,NO_ARG   ,0 ,002 ,0 ,"pedo mellon a minno"},
-        {"mello"     ,NO_ARG   ,0 ,003 ,0 ,"fraud"},
-        {"pyx"       ,REQD_ARG ,0 ,'x' ,0 ,"for docimasy"},
-        {"help"      ,NO_ARG   ,0 ,'h' ,0 ,"display this help and exit"},
-        {"license"   ,NO_ARG   ,0 ,'l' ,0 ,"display license and exit"},
-        {"accept"    ,NO_ARG   ,0 ,'a' ,0 ,"accept license (-l to display)"},
-        {"selftest"  ,NO_ARG   ,0 ,'s' ,0 ,"perform self test and exit"},
-        {"profile"   ,NO_ARG   ,0 ,'o' ,0 ,"set up for profiling and exit"},
-        {"emit"      ,REQD_ARG ,0 ,'e' ,0 ,"choose what output to emit"},
-        {"file"      ,REQD_ARG ,0 ,'f' ,0 ,"input file to run"},
-        {"data_path" ,REQD_ARG ,0 ,'d' ,0 ,"path to data files"},
-        {"print_db"  ,NO_ARG   ,0 ,'p' ,0 ,"print product databases and exit"},
-        {0           ,NO_ARG   ,0 ,0   ,0 ,""}
+        {"ash_nazg"  ,NO_ARG   ,nullptr ,001 ,nullptr ,"ash nazg durbatulûk"},
+        {"ash_naz"   ,NO_ARG   ,nullptr ,003 ,nullptr ,"fraud"},
+        {"mellon"    ,NO_ARG   ,nullptr ,002 ,nullptr ,"pedo mellon a minno"},
+        {"mello"     ,NO_ARG   ,nullptr ,003 ,nullptr ,"fraud"},
+        {"pyx"       ,REQD_ARG ,nullptr ,'x' ,nullptr ,"for docimasy"},
+        {"help"      ,NO_ARG   ,nullptr ,'h' ,nullptr ,"display this help and exit"},
+        {"license"   ,NO_ARG   ,nullptr ,'l' ,nullptr ,"display license and exit"},
+        {"accept"    ,NO_ARG   ,nullptr ,'a' ,nullptr ,"accept license (-l to display)"},
+        {"selftest"  ,NO_ARG   ,nullptr ,'s' ,nullptr ,"perform self test and exit"},
+        {"profile"   ,NO_ARG   ,nullptr ,'o' ,nullptr ,"set up for profiling and exit"},
+        {"emit"      ,REQD_ARG ,nullptr ,'e' ,nullptr ,"choose what output to emit"},
+        {"file"      ,REQD_ARG ,nullptr ,'f' ,nullptr ,"input file to run"},
+        {"data_path" ,REQD_ARG ,nullptr ,'d' ,nullptr ,"path to data files"},
+        {"print_db"  ,NO_ARG   ,nullptr ,'p' ,nullptr ,"print product databases and exit"},
+        {nullptr           ,NO_ARG   ,nullptr ,0   ,nullptr ,""}
       };
 
     bool license_accepted    = false;
@@ -274,7 +274,7 @@ void process_command_line(int argc, char* argv[])
 
             case 'e':
                 {
-                LMI_ASSERT(NULL != getopt_long.optarg);
+                LMI_ASSERT(nullptr != getopt_long.optarg);
                 std::string const s(getopt_long.optarg);
                 std::istringstream iss(s);
                 for(;EOF != iss.peek();)
@@ -306,7 +306,7 @@ void process_command_line(int argc, char* argv[])
 
             case 'f':
                 {
-                LMI_ASSERT(NULL != getopt_long.optarg);
+                LMI_ASSERT(nullptr != getopt_long.optarg);
                 std::string const s(getopt_long.optarg);
                 std::string const e = fs::extension(s);
                 if(".cns" == e || ".ill" == e || ".ini" == e || ".inix" == e)

--- a/main_cli.cpp
+++ b/main_cli.cpp
@@ -175,7 +175,7 @@ void process_command_line(int argc, char* argv[])
         {"file"      ,REQD_ARG ,nullptr ,'f' ,nullptr ,"input file to run"},
         {"data_path" ,REQD_ARG ,nullptr ,'d' ,nullptr ,"path to data files"},
         {"print_db"  ,NO_ARG   ,nullptr ,'p' ,nullptr ,"print product databases and exit"},
-        {nullptr           ,NO_ARG   ,nullptr ,0   ,nullptr ,""}
+        {nullptr     ,NO_ARG   ,nullptr ,0   ,nullptr ,""}
       };
 
     bool license_accepted    = false;

--- a/main_common.cpp
+++ b/main_common.cpp
@@ -68,7 +68,7 @@ void initialize_application()
         // This line forces mpatrol to link when it otherwise might not.
         // It has no other effect according to C99 7.20.3.2/2, second
         // sentence.
-        std::free(0);
+        std::free(nullptr);
 
         fenv_initialize();
 

--- a/main_wx_test.cpp
+++ b/main_wx_test.cpp
@@ -316,7 +316,7 @@ bool application_test::process_command_line(int& argc, char* argv[])
     // This variable is used both as a flag indicating that the last option was
     // the one selecting the test to run and so must be followed by the test
     // name, but also for the diagnostic message at the end of this function.
-    char const* last_test_option = 0;
+    char const* last_test_option = nullptr;
 
     char const* opt_gui_test_path = "--gui_test_path";
     int const opt_gui_test_path_length = strlen(opt_gui_test_path);
@@ -327,7 +327,7 @@ bool application_test::process_command_line(int& argc, char* argv[])
 
         if (last_test_option)
             {
-            last_test_option = 0;
+            last_test_option = nullptr;
             process_test_name(arg);
             remove_arg(n, argc, argv);
             continue;

--- a/mec_input.hpp
+++ b/mec_input.hpp
@@ -195,7 +195,7 @@ template<> struct reconstitutor<datum_base, mec_input>
     typedef datum_base DesiredType;
     static DesiredType* reconstitute(any_member<mec_input>& m)
         {
-        DesiredType* z = 0;
+        DesiredType* z = nullptr;
         z = exact_cast<ce_product_name         >(m); if(z) return z;
         z = exact_cast<datum_string            >(m); if(z) return z;
         // Sequences.

--- a/mec_view.cpp
+++ b/mec_view.cpp
@@ -90,7 +90,7 @@ END_EVENT_TABLE()
 mec_view::mec_view()
     :ViewEx       ()
     ,html_content_("Unable to display results.")
-    ,html_window_ (0)
+    ,html_window_ (nullptr)
 {
 }
 

--- a/miscellany.cpp
+++ b/miscellany.cpp
@@ -173,9 +173,9 @@ void rtrim(std::string& s, char const* superfluous)
 std::string iso_8601_datestamp_verbose()
 {
     std::size_t const len = sizeof "CCYY-MM-DDTHH:MM:SSZ";
-    std::time_t const t0 = std::time(0);
+    std::time_t const t0 = std::time(nullptr);
     std::tm const*const t1 = std::gmtime(&t0);
-    LMI_ASSERT(NULL != t1);
+    LMI_ASSERT(nullptr != t1);
     char s[len];
     std::size_t rc = std::strftime(s, len, "%Y-%m-%dT%H:%M:%SZ", t1);
     LMI_ASSERT(0 != rc);
@@ -185,9 +185,9 @@ std::string iso_8601_datestamp_verbose()
 std::string iso_8601_datestamp_terse()
 {
     std::size_t const len = sizeof "CCYYMMDDTHHMMSSZ";
-    std::time_t const t0 = std::time(0);
+    std::time_t const t0 = std::time(nullptr);
     std::tm const*const t1 = std::gmtime(&t0);
-    LMI_ASSERT(NULL != t1);
+    LMI_ASSERT(nullptr != t1);
     char s[len];
     std::size_t rc = std::strftime(s, len, "%Y%m%dT%H%M%SZ", t1);
     LMI_ASSERT(0 != rc);

--- a/multidimgrid_any.cpp
+++ b/multidimgrid_any.cpp
@@ -49,7 +49,7 @@ wxWindow* MultiDimAxisAny::CreateAdjustControl
     ,MultiDimTableAny& // unused: table
     )
 {
-    return NULL;
+    return nullptr;
 }
 
 bool MultiDimAxisAny::ApplyAdjustment(wxWindow&, unsigned int)
@@ -291,8 +291,8 @@ void MultiDimGrid::Init()
     table_data_refresh_counter_ = 0;
 
     // These pointers are used in IsFullyConstructed.
-    first_axis_choice_ = NULL;
-    second_axis_choice_ = NULL;
+    first_axis_choice_ = nullptr;
+    second_axis_choice_ = nullptr;
 }
 
 MultiDimGrid::~MultiDimGrid()
@@ -309,7 +309,7 @@ MultiDimGrid::~MultiDimGrid()
     // so that wxGridTableBase part is destroyed _after_ wxPanel base.
     // But it is not a good idea to depend on the base classes order,
     // especially when a change would lead to non-obvious crashes.
-    grid().SetTable(NULL);
+    grid().SetTable(nullptr);
 }
 
 bool MultiDimGrid::Create

--- a/multidimgrid_tools.hpp
+++ b/multidimgrid_tools.hpp
@@ -382,7 +382,7 @@ AdjustableMaxBoundAxis<Integral>::DoCreateAdjustControl
     // called only once
     if(lower_bound_ == upper_bound_)
         {
-        return NULL;
+        return nullptr;
         }
     return new Adjuster(*this, grid, lower_bound_, upper_bound_);
 }

--- a/mvc_controller.cpp
+++ b/mvc_controller.cpp
@@ -107,7 +107,7 @@ MvcController::MvcController
     wxBusyCursor wait;
 
     char const* resource_file_name = view_.ResourceFileName();
-    LMI_ASSERT(0 != resource_file_name && 0 != std::strlen(resource_file_name));
+    LMI_ASSERT(nullptr != resource_file_name && 0 != std::strlen(resource_file_name));
 
     if(!wxXmlResource::Get()->LoadDialog(this, parent, view_.MainDialogName()))
         {
@@ -222,7 +222,7 @@ void MvcController::ConditionallyEnable()
     for(wvci i = page_lineage.begin(); i != page_lineage.end(); ++i)
         {
         wxWindow* pw = *i;
-        LMI_ASSERT(0 != pw);
+        LMI_ASSERT(nullptr != pw);
         Transferor* t = dynamic_cast<Transferor*>(pw->GetValidator());
         if(t)
             {
@@ -252,7 +252,7 @@ void MvcController::ConditionallyEnable()
     for(wvci i = lineage_.begin(); i != lineage_.end(); ++i)
         {
         wxWindow* pw = *i;
-        LMI_ASSERT(0 != pw);
+        LMI_ASSERT(nullptr != pw);
         Transferor* t = dynamic_cast<Transferor*>(pw->GetValidator());
         if(t)
             {
@@ -467,7 +467,7 @@ void MvcController::Initialize()
     for(wvci i = lineage_.begin(); i != lineage_.end(); ++i)
         {
         wxWindow* pw = *i;
-        LMI_ASSERT(0 != pw);
+        LMI_ASSERT(nullptr != pw);
         Transferor* t = dynamic_cast<Transferor*>(pw->GetValidator());
         if(t)
             {
@@ -495,7 +495,7 @@ bool MvcController::ModelAndViewValuesEquivalent(std::string const& name) const
     std::string const& model_value = model_.Entity(name).str();
     bool equal = view_value == model_value;
     bool equivalent = equal;
-    if(!equal && 0 != ModelPointer<tn_range_base>(name))
+    if(!equal && nullptr != ModelPointer<tn_range_base>(name))
         {
         equivalent =
                 value_cast<double>(view_value)
@@ -513,9 +513,9 @@ std::string MvcController::NameOfControlToDeferEvaluating() const
     if(!w)    w = dynamic_cast<wxSpinCtrl      *>(last_focused_window_);
     if(!w)    w = dynamic_cast<wxDatePickerCtrl*>(last_focused_window_);
 
-    wxValidator const* v = w ? w->GetValidator() : 0;
+    wxValidator const* v = w ? w->GetValidator() : nullptr;
     Transferor  const* t = dynamic_cast<Transferor const*>(v);
-    return (t && 0 != ModelPointer<tn_range_base>(t->name())) ? t->name() : "";
+    return (t && nullptr != ModelPointer<tn_range_base>(t->name())) ? t->name() : "";
 }
 
 void MvcController::RefocusLastFocusedWindow()

--- a/numeric_io_cast.hpp
+++ b/numeric_io_cast.hpp
@@ -207,7 +207,7 @@ struct numeric_converter<To, char const*>
     typedef char const* From;
     To operator()(From from) const
         {
-        if(0 == from)
+        if(nullptr == from)
             {
             throw std::runtime_error
                 ("Cannot convert (char const*)(0) to number."
@@ -356,7 +356,7 @@ struct numeric_converter<std::string, char const*>
     typedef std::string To;
     To operator()(From from) const
         {
-        if(0 == from)
+        if(nullptr == from)
             {
             throw std::runtime_error
                 ("Cannot convert (char const*)(0) to std::string."

--- a/numeric_io_test.cpp
+++ b/numeric_io_test.cpp
@@ -310,12 +310,12 @@ int test_main(int, char*[])
 //    BOOST_TEST_THROW(numeric_io_cast<double*>("0"), std::invalid_argument, "");
 
     BOOST_TEST_THROW
-        (numeric_io_cast<std::string>((char const*)(0))
+        (numeric_io_cast<std::string>((char const*)nullptr)
         ,std::runtime_error
         ,"Cannot convert (char const*)(0) to std::string."
         );
     BOOST_TEST_THROW
-        (numeric_io_cast<unsigned int>((char const*)(0))
+        (numeric_io_cast<unsigned int>((char const*)nullptr)
         ,std::runtime_error
         ,"Cannot convert (char const*)(0) to number."
         );

--- a/preferences_model.hpp
+++ b/preferences_model.hpp
@@ -97,7 +97,7 @@ template<> struct reconstitutor<datum_base, PreferencesModel>
     typedef datum_base DesiredType;
     static DesiredType* reconstitute(any_member<PreferencesModel>& m)
         {
-        DesiredType* z = 0;
+        DesiredType* z = nullptr;
         z = exact_cast<ce_skin_name            >(m); if(z) return z;
         z = exact_cast<datum_string            >(m); if(z) return z;
         z = exact_cast<mce_report_column       >(m); if(z) return z;

--- a/product_editor.cpp
+++ b/product_editor.cpp
@@ -124,9 +124,9 @@ ProductEditorView::~ProductEditorView()
 
 TreeGridViewBase::TreeGridViewBase()
     :ProductEditorView()
-    ,grid_(NULL)
-    ,grid_label_(NULL)
-    ,tree_(NULL)
+    ,grid_(nullptr)
+    ,grid_label_(nullptr)
+    ,tree_(nullptr)
 {
 }
 

--- a/progress_meter.cpp
+++ b/progress_meter.cpp
@@ -37,7 +37,7 @@ std::ostringstream& progress_meter_unit_test_stream()
     return oss;
 }
 
-progress_meter_creator_type progress_meter_creator = 0;
+progress_meter_creator_type progress_meter_creator = nullptr;
 
 boost::shared_ptr<progress_meter> create_progress_meter
     (int                               max_count
@@ -45,7 +45,7 @@ boost::shared_ptr<progress_meter> create_progress_meter
     ,progress_meter::enum_display_mode display_mode
     )
 {
-    if(0 == progress_meter_creator)
+    if(nullptr == progress_meter_creator)
         {
         fatal_error() << "Function pointer not yet initialized." << LMI_FLUSH;
         }
@@ -55,7 +55,7 @@ boost::shared_ptr<progress_meter> create_progress_meter
 
 bool set_progress_meter_creator(progress_meter_creator_type f)
 {
-    if(0 != progress_meter_creator)
+    if(nullptr != progress_meter_creator)
         {
         // TODO ?? Use 'callback.hpp' instead, and consider whether
         // this message can ever actually be displayed--either in its

--- a/progress_meter_cli.cpp
+++ b/progress_meter_cli.cpp
@@ -37,7 +37,7 @@ namespace
 {
 std::streambuf* select_streambuf(progress_meter::enum_display_mode display_mode)
 {
-    std::streambuf* z = 0;
+    std::streambuf* z = nullptr;
     switch(display_mode)
         {
         case progress_meter::e_normal_display:

--- a/rate_table_tool.cpp
+++ b/rate_table_tool.cpp
@@ -392,19 +392,19 @@ int try_main(int argc, char* argv[])
     int option_index = 0;
     static struct Option long_options[] =
       {
-        {"help"           , NO_ARG,   0, 'h', 0    , "display this help and exit"},
-        {"delete"         , REQD_ARG, 0, 'd', 0    , "delete table #n from database"},
-        {"license"        , NO_ARG,   0, 'l', 0    , "display license and exit"},
-        {"accept"         , NO_ARG,   0, 'a', 0    , "accept license (-l to display)"},
-        {"file=FILE"      , REQD_ARG, 0, 'f', 0    , "use database FILE"},
-        {"crc"            , NO_ARG,   0, 'c', 0    , "show CRCs of all tables"},
-        {"list"           , NO_ARG,   0, 't', 0    , "list all tables"},
-        {"merge=TEXTFILE" , REQD_ARG, 0, 'm', 0    , "merge TEXTFILE into database"},
-        {"extract=n"      , REQD_ARG, 0, 'e', 0    , "extract table #n into n.txt"},
-        {"extract-all"    , NO_ARG,   0, 'x', 0    , "extract all tables to text files"},
-        {"rename=NAMEFILE", REQD_ARG, 0, 'r', 0    , "rename tables from NAMEFILE"},
-        {"verify"         , NO_ARG,   0, 'v', 0    , "verify integrity of all tables"},
-        {0                , NO_ARG,   0,   0, 0    , ""}
+        {"help"           , NO_ARG,   nullptr, 'h', nullptr    , "display this help and exit"},
+        {"delete"         , REQD_ARG, nullptr, 'd', nullptr    , "delete table #n from database"},
+        {"license"        , NO_ARG,   nullptr, 'l', nullptr    , "display license and exit"},
+        {"accept"         , NO_ARG,   nullptr, 'a', nullptr    , "accept license (-l to display)"},
+        {"file=FILE"      , REQD_ARG, nullptr, 'f', nullptr    , "use database FILE"},
+        {"crc"            , NO_ARG,   nullptr, 'c', nullptr    , "show CRCs of all tables"},
+        {"list"           , NO_ARG,   nullptr, 't', nullptr    , "list all tables"},
+        {"merge=TEXTFILE" , REQD_ARG, nullptr, 'm', nullptr    , "merge TEXTFILE into database"},
+        {"extract=n"      , REQD_ARG, nullptr, 'e', nullptr    , "extract table #n into n.txt"},
+        {"extract-all"    , NO_ARG,   nullptr, 'x', nullptr    , "extract all tables to text files"},
+        {"rename=NAMEFILE", REQD_ARG, nullptr, 'r', nullptr    , "rename tables from NAMEFILE"},
+        {"verify"         , NO_ARG,   nullptr, 'v', nullptr    , "verify integrity of all tables"},
+        {nullptr                , NO_ARG,   nullptr,   0, nullptr    , ""}
       };
     bool license_accepted = false;
     bool show_license     = false;

--- a/rate_table_tool.cpp
+++ b/rate_table_tool.cpp
@@ -404,7 +404,7 @@ int try_main(int argc, char* argv[])
         {"extract-all"    , NO_ARG,   nullptr, 'x', nullptr    , "extract all tables to text files"},
         {"rename=NAMEFILE", REQD_ARG, nullptr, 'r', nullptr    , "rename tables from NAMEFILE"},
         {"verify"         , NO_ARG,   nullptr, 'v', nullptr    , "verify integrity of all tables"},
-        {nullptr                , NO_ARG,   nullptr,   0, nullptr    , ""}
+        {nullptr          , NO_ARG,   nullptr,   0, nullptr    , ""}
       };
     bool license_accepted = false;
     bool show_license     = false;

--- a/regex_test.cpp
+++ b/regex_test.cpp
@@ -204,7 +204,7 @@ void mete()
         :1 == Function ? contains_regex1
         :2 == Function ? contains_regex2
         :3 == Function ? contains_regex3
-        :0
+        :nullptr
         ;
     f(Regex);
 }

--- a/rtti_lmi.hpp
+++ b/rtti_lmi.hpp
@@ -53,7 +53,7 @@ namespace lmi
     inline std::string Demangle(char const* mangled_name)
     {
         int status = 0;
-        char* demangled_name = abi::__cxa_demangle(mangled_name, 0, 0, &status);
+        char* demangled_name = abi::__cxa_demangle(mangled_name, nullptr, nullptr, &status);
         std::string s = (0 == status) ? demangled_name : mangled_name;
         std::free(demangled_name);
         return s;

--- a/safely_dereference_as_test.cpp
+++ b/safely_dereference_as_test.cpp
@@ -58,7 +58,7 @@ int test_main(int, char*[])
     diagnostic0 += lmi::TypeInfo(typeid(D*)).Name();
     diagnostic0 += "'.";
 
-    D* null_pointer = 0;
+    D* null_pointer = nullptr;
     BOOST_TEST_THROW
         (safely_dereference_as<D>(null_pointer)
         ,std::runtime_error

--- a/skeleton.cpp
+++ b/skeleton.cpp
@@ -1206,7 +1206,7 @@ bool Skeleton::ProcessCommandLine(int argc, char* argv[])
         {"data_path"    ,REQD_ARG ,nullptr ,'d' ,nullptr ,"path to data files"},
         {"print_db"     ,NO_ARG   ,nullptr ,'p' ,nullptr ,"print product databases"},
         {"prospicience" ,REQD_ARG ,nullptr ,004 ,nullptr ,"validation date"},
-        {nullptr              ,NO_ARG   ,nullptr ,0   ,nullptr ,""}
+        {nullptr        ,NO_ARG   ,nullptr ,0   ,nullptr ,""}
       };
 
     bool show_help        = false;

--- a/skeleton.cpp
+++ b/skeleton.cpp
@@ -200,9 +200,9 @@ END_EVENT_TABLE()
 ///     the "AppName" (but not the "AppDisplayName").
 
 Skeleton::Skeleton()
-    :config_          (0)
-    ,doc_manager_     (0)
-    ,frame_           (0)
+    :config_          (nullptr)
+    ,doc_manager_     (nullptr)
+    ,frame_           (nullptr)
     ,timer_           (this)
 {
     SetAppName("lmi_wx");
@@ -728,7 +728,7 @@ bool Skeleton::OnInit()
 
         frame_ = new(wx) wxDocMDIParentFrame
             (doc_manager_
-            ,NULL
+            ,nullptr
             ,wxID_ANY
             ,"lmi"
             ,wxDefaultPosition
@@ -1196,17 +1196,17 @@ bool Skeleton::ProcessCommandLine(int argc, char* argv[])
     // TRICKY !! Some long options are aliased to unlikely octal values.
     static Option long_options[] =
       {
-        {"ash_nazg"     ,NO_ARG   ,0 ,001 ,0 ,"ash nazg durbatulûk"},
-        {"ash_naz"      ,NO_ARG   ,0 ,003 ,0 ,"fraud"},
-        {"help"         ,NO_ARG   ,0 ,'h' ,0 ,"display this help and exit"},
-        {"mellon"       ,NO_ARG   ,0 ,002 ,0 ,"pedo mellon a minno"},
-        {"mello"        ,NO_ARG   ,0 ,003 ,0 ,"fraud"},
-        {"pyx"          ,REQD_ARG ,0 ,'x' ,0 ,"for docimasy"},
-        {"file"         ,REQD_ARG ,0 ,'f' ,0 ,"input file to run"},
-        {"data_path"    ,REQD_ARG ,0 ,'d' ,0 ,"path to data files"},
-        {"print_db"     ,NO_ARG   ,0 ,'p' ,0 ,"print product databases"},
-        {"prospicience" ,REQD_ARG ,0 ,004 ,0 ,"validation date"},
-        {0              ,NO_ARG   ,0 ,0   ,0 ,""}
+        {"ash_nazg"     ,NO_ARG   ,nullptr ,001 ,nullptr ,"ash nazg durbatulûk"},
+        {"ash_naz"      ,NO_ARG   ,nullptr ,003 ,nullptr ,"fraud"},
+        {"help"         ,NO_ARG   ,nullptr ,'h' ,nullptr ,"display this help and exit"},
+        {"mellon"       ,NO_ARG   ,nullptr ,002 ,nullptr ,"pedo mellon a minno"},
+        {"mello"        ,NO_ARG   ,nullptr ,003 ,nullptr ,"fraud"},
+        {"pyx"          ,REQD_ARG ,nullptr ,'x' ,nullptr ,"for docimasy"},
+        {"file"         ,REQD_ARG ,nullptr ,'f' ,nullptr ,"input file to run"},
+        {"data_path"    ,REQD_ARG ,nullptr ,'d' ,nullptr ,"path to data files"},
+        {"print_db"     ,NO_ARG   ,nullptr ,'p' ,nullptr ,"print product databases"},
+        {"prospicience" ,REQD_ARG ,nullptr ,004 ,nullptr ,"validation date"},
+        {nullptr              ,NO_ARG   ,nullptr ,0   ,nullptr ,""}
       };
 
     bool show_help        = false;
@@ -1272,7 +1272,7 @@ bool Skeleton::ProcessCommandLine(int argc, char* argv[])
 
             case 'f':
                 {
-                LMI_ASSERT(NULL != getopt_long.optarg);
+                LMI_ASSERT(nullptr != getopt_long.optarg);
                 input_files.push_back(getopt_long.optarg);
                 }
                 break;

--- a/snprintf_test.cpp
+++ b/snprintf_test.cpp
@@ -38,7 +38,7 @@ int test_main(int, char*[])
     char buf[1000] = "zzzzzzzzz";
     int len;
 
-    len = snprintf(0, 0, "%4d", 1234);
+    len = snprintf(nullptr, 0, "%4d", 1234);
     BOOST_TEST_EQUAL(4, len);
 
     // All tests in this group fail with the defective msvc rtl.

--- a/solve.cpp
+++ b/solve.cpp
@@ -258,7 +258,7 @@ double AccountValue::Solve()
         ThatSolveEndYear = BasicValues::GetLength();
         }
 
-    double(*SolveFn)(double)     = 0;
+    double(*SolveFn)(double)     = nullptr;
     double           LowerBound  = 0.0;
     double           UpperBound  = 0.0;
     root_bias        Bias        = bias_higher;

--- a/stream_cast.hpp
+++ b/stream_cast.hpp
@@ -166,7 +166,7 @@ To stream_cast(From from, To = To())
 template<>
 inline std::string stream_cast<std::string>(char* from, std::string)
 {
-    if(0 == from)
+    if(nullptr == from)
         {
         throw std::runtime_error
             ("Cannot convert (char*)(0) to std::string."
@@ -178,7 +178,7 @@ inline std::string stream_cast<std::string>(char* from, std::string)
 template<>
 inline std::string stream_cast<std::string>(char const* from, std::string)
 {
-    if(0 == from)
+    if(nullptr == from)
         {
         throw std::runtime_error
             ("Cannot convert (char const*)(0) to std::string."

--- a/stream_cast_test.cpp
+++ b/stream_cast_test.cpp
@@ -90,13 +90,13 @@ int test_main(int, char*[])
     // explains, a conversion to bool is used instead.
 
     BOOST_TEST_THROW
-        (stream_cast<std::string>((char*)(0))
+        (stream_cast<std::string>((char*)nullptr)
         ,std::runtime_error
         ,"Cannot convert (char*)(0) to std::string."
         );
 
     BOOST_TEST_THROW
-        (stream_cast<std::string>((char const*)(0))
+        (stream_cast<std::string>((char const*)nullptr)
         ,std::runtime_error
         ,"Cannot convert (char const*)(0) to std::string."
         );

--- a/system_command.cpp
+++ b/system_command.cpp
@@ -34,7 +34,7 @@ namespace
 }
 
 typedef system_command_fp_type FunctionPointer;
-template<> FunctionPointer callback<FunctionPointer>::function_pointer_ = 0;
+template<> FunctionPointer callback<FunctionPointer>::function_pointer_ = nullptr;
 
 bool system_command_initialize(system_command_fp_type f)
 {

--- a/test_coding_rules.cpp
+++ b/test_coding_rules.cpp
@@ -480,9 +480,9 @@ void check_copyright(file const& f)
         return;
         }
 
-    std::time_t const t0 = std::time(0);
+    std::time_t const t0 = std::time(nullptr);
     std::tm const*const t1 = std::localtime(&t0);
-    LMI_ASSERT(NULL != t1);
+    LMI_ASSERT(nullptr != t1);
     int const year = 1900 + t1->tm_year;
 
     std::ostringstream oss;

--- a/text_view.cpp
+++ b/text_view.cpp
@@ -44,7 +44,7 @@ IMPLEMENT_DYNAMIC_CLASS(TextEditView, ViewEx)
 
 TextEditView::TextEditView()
     :ViewEx      ()
-    ,text_window_(0)
+    ,text_window_(nullptr)
 {
 }
 

--- a/tier_view_editor.hpp
+++ b/tier_view_editor.hpp
@@ -102,12 +102,12 @@ class tier_entity_adapter
 
 inline bool tier_entity_adapter::is_void() const
 {
-    return limits_ == NULL;
+    return limits_ == nullptr;
 }
 
 inline tier_entity_adapter::tier_entity_adapter()
-    :limits_(NULL)
-    ,values_(NULL)
+    :limits_(nullptr)
+    ,values_(nullptr)
 {
 }
 

--- a/timer.cpp
+++ b/timer.cpp
@@ -192,7 +192,7 @@ elapsed_t Timer::inspect() const
 {
 #if defined LMI_POSIX
     timeval x;
-    gettimeofday(&x, 0);
+    gettimeofday(&x, nullptr);
     return elapsed_t(1000000) * x.tv_sec + x.tv_usec;
 #elif defined LMI_MSW
 #   ifdef LMI_MS_HEADER_INCLUDED

--- a/transferor.cpp
+++ b/transferor.cpp
@@ -161,40 +161,40 @@ bool Transferor::PerformTransfer(transfer_direction td)
     // Custom controls.
     InputSequenceEntry * sequence   ;
 
-    if     (0 != (button       = dynamic_cast<wxButton         *>(control)))
+    if     (nullptr != (button       = dynamic_cast<wxButton         *>(control)))
         return Transfer(td, data_,             *button      );
-    else if(0 != (checkbox     = dynamic_cast<wxCheckBox       *>(control)))
+    else if(nullptr != (checkbox     = dynamic_cast<wxCheckBox       *>(control)))
         return Transfer(td, data_,             *checkbox    );
-    else if(0 != (checklistbox = dynamic_cast<wxCheckListBox   *>(control)))
+    else if(nullptr != (checklistbox = dynamic_cast<wxCheckListBox   *>(control)))
         return Transfer(td, data_,             *checklistbox);
-    else if(0 != (combobox     = dynamic_cast<wxComboBox       *>(control)))
+    else if(nullptr != (combobox     = dynamic_cast<wxComboBox       *>(control)))
         return Transfer(td, data_,             *combobox    );
-    else if(0 != (choice       = dynamic_cast<wxChoice         *>(control)))
+    else if(nullptr != (choice       = dynamic_cast<wxChoice         *>(control)))
         return Transfer(td, data_,             *choice      );
-    else if(0 != (datepicker   = dynamic_cast<wxDatePickerCtrl *>(control)))
+    else if(nullptr != (datepicker   = dynamic_cast<wxDatePickerCtrl *>(control)))
         return Transfer(td, data_,             *datepicker  );
-    else if(0 != (gauge        = dynamic_cast<wxGauge          *>(control)))
+    else if(nullptr != (gauge        = dynamic_cast<wxGauge          *>(control)))
         return Transfer(td, data_,             *gauge       );
-    else if(0 != (listbox      = dynamic_cast<wxListBox        *>(control)))
+    else if(nullptr != (listbox      = dynamic_cast<wxListBox        *>(control)))
         return Transfer(td, data_,             *listbox     );
-    else if(0 != (radiobox     = dynamic_cast<wxRadioBox       *>(control)))
+    else if(nullptr != (radiobox     = dynamic_cast<wxRadioBox       *>(control)))
         return Transfer(td, data_,             *radiobox    );
-    else if(0 != (radiobutton  = dynamic_cast<wxRadioButton    *>(control)))
+    else if(nullptr != (radiobutton  = dynamic_cast<wxRadioButton    *>(control)))
         return Transfer(td, data_,             *radiobutton );
-    else if(0 != (scrollbar    = dynamic_cast<wxScrollBar      *>(control)))
+    else if(nullptr != (scrollbar    = dynamic_cast<wxScrollBar      *>(control)))
         return Transfer(td, data_,             *scrollbar   );
-    else if(0 != (slider       = dynamic_cast<wxSlider         *>(control)))
+    else if(nullptr != (slider       = dynamic_cast<wxSlider         *>(control)))
         return Transfer(td, data_,             *slider      );
-    else if(0 != (spinbutton   = dynamic_cast<wxSpinButton     *>(control)))
+    else if(nullptr != (spinbutton   = dynamic_cast<wxSpinButton     *>(control)))
         return Transfer(td, data_,             *spinbutton  );
-    else if(0 != (spinctrl     = dynamic_cast<wxSpinCtrl       *>(control)))
+    else if(nullptr != (spinctrl     = dynamic_cast<wxSpinCtrl       *>(control)))
         return Transfer(td, data_,             *spinctrl    );
-    else if(0 != (statictext   = dynamic_cast<wxStaticText     *>(control)))
+    else if(nullptr != (statictext   = dynamic_cast<wxStaticText     *>(control)))
         return Transfer(td, data_,             *statictext  );
-    else if(0 != (textctrl     = dynamic_cast<wxTextCtrl       *>(control)))
+    else if(nullptr != (textctrl     = dynamic_cast<wxTextCtrl       *>(control)))
         return Transfer(td, data_,             *textctrl    );
     // Custom controls.
-    else if(0 != (sequence     = dynamic_cast<InputSequenceEntry *>(control)))
+    else if(nullptr != (sequence     = dynamic_cast<InputSequenceEntry *>(control)))
         return Transfer(td, data_,             *sequence    );
     else
         {

--- a/value_cast.hpp
+++ b/value_cast.hpp
@@ -140,7 +140,7 @@ void throw_if_null_pointer(T)
 template<typename T>
 void throw_if_null_pointer(T* t)
 {
-    if(0 == t)
+    if(nullptr == t)
         {
         throw std::runtime_error("Null pointer holds no value to convert.");
         }

--- a/value_cast_test.cpp
+++ b/value_cast_test.cpp
@@ -128,9 +128,9 @@ int test_main(int, char*[])
     BOOST_TEST_EQUAL(e_direct       ,method(cp  ,ccp));
 
     // Not convertible: value_cast() forbids conversion to pointer.
-    BOOST_TEST_EQUAL(e_stream       ,method(s, (char volatile*)(0)   ));
+    BOOST_TEST_EQUAL(e_stream       ,method(s, (char volatile*)nullptr   ));
 
-    BOOST_TEST_EQUAL(e_stream       ,method(   (char volatile*)(0), s));
+    BOOST_TEST_EQUAL(e_stream       ,method(   (char volatile*)nullptr, s));
 
     n_d_c = value_cast<NotDefaultConstructible>(n_d_c);
     n_d_c = value_cast(n_d_c, n_d_c);
@@ -285,19 +285,19 @@ int extra_tests0()
     BOOST_TEST_THROW(value_cast<double>(""), std::invalid_argument, "");
 
     BOOST_TEST_THROW
-        (value_cast<std::string>((char*)(0))
+        (value_cast<std::string>((char*)nullptr)
         ,std::runtime_error
         ,"Null pointer holds no value to convert."
         );
 
     BOOST_TEST_THROW
-        (value_cast<std::string>((char const*)(0))
+        (value_cast<std::string>((char const*)nullptr)
         ,std::runtime_error
         ,"Null pointer holds no value to convert."
         );
 
-    BOOST_TEST_EQUAL("0", value_cast<std::string>((char volatile*)(0)));
-    BOOST_TEST_EQUAL("0", value_cast<std::string>((char const volatile*)(0)));
+    BOOST_TEST_EQUAL("0", value_cast<std::string>((char volatile*)nullptr));
+    BOOST_TEST_EQUAL("0", value_cast<std::string>((char const volatile*)nullptr));
 
     // Numeric casts from
     //   (char               *)(0)
@@ -305,7 +305,7 @@ int extra_tests0()
     //   (char const volatile*)(0)
     // are forbidden by a compile-time assertion.
     BOOST_TEST_THROW
-        (value_cast<unsigned int>((char const*)(0))
+        (value_cast<unsigned int>((char const*)nullptr)
         ,std::runtime_error
         ,"Cannot convert (char const*)(0) to number."
         );

--- a/view_ex.tpp
+++ b/view_ex.tpp
@@ -65,12 +65,12 @@ std::string ViewName()
 template<typename ViewType>
 ViewType& PredominantView(wxDocument const& document)
 {
-    ViewType* view = 0;
+    ViewType* view = nullptr;
     wxList const& views = document.GetViews();
     for(wxList::const_iterator i = views.begin(); i != views.end(); ++i)
         {
         wxObject* p = *i;
-        LMI_ASSERT(0 != p);
+        LMI_ASSERT(nullptr != p);
         if(p->IsKindOf(CLASSINFO(ViewType)))
             {
             view = dynamic_cast<ViewType*>(p);

--- a/wx_test_about_version.cpp
+++ b/wx_test_about_version.cpp
@@ -139,7 +139,7 @@ int extract_last_copyright_year(wxString const& html)
 // the dialog. The dialog name is only used for diagnostic purposes.
 wxHtmlWindow* find_html_window(wxWindow* parent, std::string const& dialog_name)
 {
-    wxHtmlWindow* html_win = 0;
+    wxHtmlWindow* html_win = nullptr;
     wxWindowList const& wl = parent->GetChildren();
     for(wxWindowList::const_iterator i = wl.begin(); i != wl.end(); ++i)
         {
@@ -173,7 +173,7 @@ LMI_WX_TEST_CASE(about_dialog_version)
     {
         virtual int OnInvoked(wxDialog* d) const
             {
-            LMI_ASSERT(0 != d);
+            LMI_ASSERT(nullptr != d);
 
             // Extract the last word of the dialog title.
             wxString const last_word = d->GetTitle().AfterLast(' ');

--- a/wx_test_calculation_summary.cpp
+++ b/wx_test_calculation_summary.cpp
@@ -90,8 +90,8 @@ class expect_preferences_dialog_base
 {
   public:
     expect_preferences_dialog_base()
-        :dialog_(NULL)
-        ,use_checkbox_(NULL)
+        :dialog_(nullptr)
+        ,use_checkbox_(nullptr)
         {
         }
 

--- a/wx_test_input_validation.cpp
+++ b/wx_test_input_validation.cpp
@@ -80,9 +80,9 @@ coi_multiplier_test_data const test_cases[] =
     { "-1"  ,"Lowest COI multiplier entered is -1, but 0.9 is the lowest multiplier allowed." },
     { "0"   ,"COI multiplier entered is '0', but it must contain at least one number other than zero." },
     { "0.8" ,"Lowest COI multiplier entered is 0.8, but 0.9 is the lowest multiplier allowed." },
-    { "0.9" ,NULL },
-    { "1"   ,NULL },
-    { "1.1" ,NULL },
+    { "0.9" ,nullptr },
+    { "1"   ,nullptr },
+    { "1.1" ,nullptr },
 };
 
 } // anonymous namespace

--- a/wx_utility.cpp
+++ b/wx_utility.cpp
@@ -238,7 +238,7 @@ void EnumerateLineage
     for(wxWindowList::const_iterator i = wl.begin(); i != wl.end(); ++i)
         {
         wxWindow* c = *i;
-        LMI_ASSERT(0 != c);
+        LMI_ASSERT(nullptr != c);
         v.push_back(c);
         EnumerateLineage(c, v);
         }

--- a/wx_utility.hpp
+++ b/wx_utility.hpp
@@ -80,7 +80,7 @@ void Connect
     ,wxEventType     event
     ,Return (Class::*handler)(Argument)
     ,int             id = wxID_ANY
-    ,wxEvtHandler*   event_sink = NULL
+    ,wxEvtHandler*   event_sink = nullptr
     )
 {
     // Double parentheses: don't parse comma as a macro parameter separator.
@@ -104,7 +104,7 @@ void Connect
         (id
         ,event
         ,c_cast<t1>(static_cast<t0>(handler))
-        ,NULL
+        ,nullptr
         ,event_sink
         );
 }

--- a/xml_serializable.tpp
+++ b/xml_serializable.tpp
@@ -225,7 +225,7 @@ std::string const& xml_serializable<T>::xml_root_name() const
 template<typename X, typename Y>
 inline Y sfinae_cast
     (X const& x
-    ,typename boost::enable_if<boost::is_same<X,Y> >::type* = 0
+    ,typename boost::enable_if<boost::is_same<X,Y> >::type* = nullptr
     )
 {
     return x;
@@ -234,7 +234,7 @@ inline Y sfinae_cast
 template<typename X, typename Y>
 inline Y sfinae_cast
     (X const&
-    ,typename boost::disable_if<boost::is_same<X,Y> >::type* = 0
+    ,typename boost::disable_if<boost::is_same<X,Y> >::type* = nullptr
     )
 {
     fatal_error() << "Impermissible type conversion." << LMI_FLUSH;


### PR DESCRIPTION
This is a new version of #32, copying the description from there:

The commits here should be squashed, I separated them only to show how much work was done by clang-tidy automatically and how little I had to do manually and also to ease the review as you can be certain that the first commit doesn't introduce any errors while the second one has only whitespace changes (as can be seen by appending `?w=1` to the diff URL in Github).