### PR TITLE
Avoid warnings about shadowing wxApp::argc and argv

### DIFF
--- a/skeleton.cpp
+++ b/skeleton.cpp
@@ -686,7 +686,7 @@ bool Skeleton::OnInit()
         wxLog::SetActiveTarget(new DebugStderrLog);
 #endif // defined __WXMSW__
 
-        if(false == ProcessCommandLine(argc, argv))
+        if(false == ProcessCommandLine())
             {
             return false;
             }
@@ -1191,7 +1191,7 @@ void Skeleton::UponWindowTileVertically(wxCommandEvent&)
 #endif // !wxCHECK_VERSION(2,6,0)
 }
 
-bool Skeleton::ProcessCommandLine(int argc, char* argv[])
+bool Skeleton::ProcessCommandLine()
 {
     // TRICKY !! Some long options are aliased to unlikely octal values.
     static Option long_options[] =

--- a/skeleton.hpp
+++ b/skeleton.hpp
@@ -129,7 +129,7 @@ class Skeleton
     virtual int  OnExit               ();
     virtual void OnUnhandledException ();
 
-    bool ProcessCommandLine(int argc, char* argv[]);
+    bool ProcessCommandLine();
     void OpenCommandLineFiles(std::vector<std::string> const& files);
     void UpdateViews();
 


### PR DESCRIPTION
These warnings, given by MSVC 2015 by default, are harmless, but still
annoying, so get rid of function parameters with the same names as wxApp class
members and just use the latter ones directly from ProcessCommandLine().