### PR TITLE
Fix non-MSW build after DLL preloading changes

### DIFF
--- a/skeleton.cpp
+++ b/skeleton.cpp
@@ -691,11 +691,13 @@ bool Skeleton::OnInit()
             return false;
             }
 
+#ifdef LMI_MSW
         // Preload DLLs after calling ProcessCommandLine(). Reason:
         // command-line option '--data_path' may specify the directory
         // from which 'configurable_settings.xml' is read, and that
         // XML file gives the list of DLLs to preload.
         MswDllPreloader::instance().PreloadDesignatedDlls();
+#endif // LMI_MSW defined.
 
         authenticate_system();
 


### PR DESCRIPTION
This fixes build under Linux after 521f8bce06ee613e27df4ecde9a6197a466033f9
which moved the call to MswDllPreloader::PreloadDesignatedDlls() to
non-MSW-only code.

Make this call only when using MSW, it doesn't make sense for, and doesn't
compile under, the other platforms.