### PR TITLE
Don't set minimal size specially for InputSequenceButton

### DIFF
--- a/input_sequence_entry.cpp
+++ b/input_sequence_entry.cpp
@@ -1366,11 +1366,6 @@ InputSequenceButton::InputSequenceButton(wxWindow* parent, wxWindowID id)
     :wxButton(parent, id, "...", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT)
 {
     SetToolTip("Open sequence editor");
-
-    // Set vertical size to 1px - it's ridiculously small, but the sizers will make it as
-    // tall as the text control. Use text extent of "..." for width, because standard
-    // buttons use more padding.
-    SetMinSize(wxSize(8 + GetTextExtent(GetLabel()).x, 1));
 }
 
 } // Unnamed namespace.


### PR DESCRIPTION
The default size of small buttons with wxBU_EXACTFIT is good enough in wxMSW
since the commit c4d06e8117f8930b57bffaf6a3323007c9df8d4b there, so there is
no need to set the minimal size of InputSequenceButton manually as it just
makes it inconsistent with the buttons used in wx{File,Dir}PickerCtrls.