### PR TITLE
Use pchfile_wx.hpp in the files which are part of libskeleton

### DIFF
--- a/default_view.cpp
+++ b/default_view.cpp
@@ -19,7 +19,7 @@
 // email: <gchicares@sbcglobal.net>
 // snail: Chicares, 186 Belle Woods Drive, Glastonbury CT 06033, USA
 
-#include "pchfile.hpp"
+#include "pchfile_wx.hpp"
 
 #include "default_view.hpp"
 

--- a/msw_workarounds.cpp
+++ b/msw_workarounds.cpp
@@ -19,7 +19,7 @@
 // email: <gchicares@sbcglobal.net>
 // snail: Chicares, 186 Belle Woods Drive, Glastonbury CT 06033, USA
 
-#include "pchfile.hpp"
+#include "pchfile_wx.hpp"
 
 #include "msw_workarounds.hpp"
 

--- a/mvc_view.cpp
+++ b/mvc_view.cpp
@@ -19,7 +19,7 @@
 // email: <gchicares@sbcglobal.net>
 // snail: Chicares, 186 Belle Woods Drive, Glastonbury CT 06033, USA
 
-#include "pchfile.hpp"
+#include "pchfile_wx.hpp"
 
 #include "mvc_view.hpp"
 

--- a/preferences_view.cpp
+++ b/preferences_view.cpp
@@ -19,7 +19,7 @@
 // email: <gchicares@sbcglobal.net>
 // snail: Chicares, 186 Belle Woods Drive, Glastonbury CT 06033, USA
 
-#include "pchfile.hpp"
+#include "pchfile_wx.hpp"
 
 #include "preferences_view.hpp"
 

--- a/tier_view.cpp
+++ b/tier_view.cpp
@@ -25,6 +25,7 @@
 
 #include "multidimgrid_any.hpp"
 #include "multidimgrid_tools.hpp"
+#include "multidimgrid_safe.tpp"
 #include "safely_dereference_as.hpp"
 #include "stratified_charges.hpp"
 #include "stratified_charges.xpp"

--- a/wx_new.cpp
+++ b/wx_new.cpp
@@ -19,7 +19,7 @@
 // email: <gchicares@sbcglobal.net>
 // snail: Chicares, 186 Belle Woods Drive, Glastonbury CT 06033, USA
 
-#include "pchfile.hpp"
+#include "pchfile_wx.hpp"
 
 #include "wx_new.hpp"
 


### PR DESCRIPTION
All files compiled together as part of the same target must use the same
precompiled header and as these files are part of libskeleton, together with
other files that include pchfile_wx.hpp because they use wxWidgets, they need
to also include this header and not just pchfile.hpp as well, even if they
don't use any GUI features.