### PR TITLE
Fix harmless "unused parameter" warnings in Boost with clang

### DIFF
--- a/rate_table.cpp
+++ b/rate_table.cpp
@@ -30,7 +30,17 @@
 #include <boost/filesystem/convenience.hpp>
 #include <boost/filesystem/exception.hpp>
 #include <boost/filesystem/fstream.hpp>
+
+// Work around unused parameters in Boost 1.33.1 comparison operators for
+// optional.
+#ifdef __clang__
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wunused-parameter"
+#endif // __clang__
 #include <boost/optional.hpp>
+#ifdef __clang__
+#   pragma clang diagnostic pop
+#endif // __clang__
 
 #include <algorithm>
 #include <climits>                      // ULLONG_MAX


### PR DESCRIPTION
Disable -Wunused-parameter warning (implicitly enabled by -Wextra) in
Boost.Optional code when building with clang 3.8. This warning is absolutely
harmless but still results in a build error because of -Werror.

Notice that for some unfathomable reason g++ does not give this warning,
although it looks like it should, too. But as it doesn't, there is no need to
disable it for it and we do it only for clang.