### PR TITLE
Use C++11 raw strings to reduce the number of backslashes

### DIFF
--- a/regex_test.cpp
+++ b/regex_test.cpp
@@ -288,7 +288,7 @@ void test_input_sequence_regex()
 {
     // A crude regex for a floating-point number, which defectively
     // accepts '.'.
-    std::string const N("\\-?[0-9.]+");
+    std::string const N(R"(\-?[0-9.]+)");
     // A set of keywords. These happen to be the ones permitted for
     // 'specamt_sequence'.
     std::string       K("maximum|target|sevenpay|glp|gsp|corridor|salary");
@@ -309,7 +309,7 @@ void test_input_sequence_regex()
     //    with ']' or ')', with anything but a semicolon in between
     //    (the actual grammar is of course more restrictive, but need
     //    not be described here).
-    std::string const Y("(( +| *, *)([@#]? *[0-9]+|[a-z]+|[\\[\\(][^;]+[\\]\\)]))");
+    std::string const Y(R"((( +| *, *)([@#]? *[0-9]+|[a-z]+|[\[\(][^;]+[\]\)])))");
     // The regex to be tested. It can consist solely of zero or more
     // spaces. Otherwise, it consists of one or more data-duration
     // pairs ('X' and an optional 'Y' as above), with an obligatory

--- a/test_coding_rules.cpp
+++ b/test_coding_rules.cpp
@@ -215,7 +215,7 @@ file::file(std::string const& file_path)
     data_ = '\n' + data();
     if('\n' != data().at(data().size() - 1))
         {
-        throw std::runtime_error("File does not end in '\\n'.");
+        throw std::runtime_error(R"(File does not end in '\n'.)");
         }
 }
 
@@ -296,7 +296,7 @@ void taboo
 
 void assay_non_latin(file const& f)
 {
-    static boost::regex const forbidden("[\\x00-\\x08\\x0e-\\x1f\\x7f-\\x9f]");
+    static boost::regex const forbidden(R"([\x00-\x08\x0e-\x1f\x7f-\x9f])");
     if(boost::regex_search(f.data(), forbidden))
         {
         throw std::runtime_error("File contains a forbidden character.");
@@ -319,7 +319,7 @@ void assay_whitespace(file const& f)
         ||  contains(f.data(), '\v')
         )
         {
-        throw std::runtime_error("File contains '\\r' or '\\v'.");
+        throw std::runtime_error(R"(File contains '\r' or '\v'.)");
         }
 
     if
@@ -328,7 +328,7 @@ void assay_whitespace(file const& f)
         &&  contains(f.data(), '\f')
         )
         {
-        throw std::runtime_error("File contains '\\f'.");
+        throw std::runtime_error(R"(File contains '\f'.)");
         }
 
     if
@@ -339,13 +339,13 @@ void assay_whitespace(file const& f)
         &&  contains(f.data(), '\t')
         )
         {
-        throw std::runtime_error("File contains '\\t'.");
+        throw std::runtime_error(R"(File contains '\t'.)");
         }
 
-    static boost::regex const postinitial_tab("[^\\n]\\t");
+    static boost::regex const postinitial_tab(R"([^\n]\t)");
     if(f.is_of_phylum(e_make) && boost::regex_search(f.data(), postinitial_tab))
         {
-        throw std::runtime_error("File contains postinitial '\\t'.");
+        throw std::runtime_error(R"(File contains postinitial '\t'.)");
         }
 
     if
@@ -354,7 +354,7 @@ void assay_whitespace(file const& f)
         &&  contains(f.data(), "\n\n\n")
         )
         {
-        complain(f, "contains '\\n\\n\\n'.");
+        complain(f, R"(contains '\n\n\n'.)");
         }
 
     if
@@ -362,7 +362,7 @@ void assay_whitespace(file const& f)
         &&  contains(f.data(), " \n")
         )
         {
-        complain(f, "contains ' \\n'.");
+        complain(f, R"(contains ' \n'.)");
         }
 }
 
@@ -383,39 +383,39 @@ void assay_whitespace(file const& f)
 
 void check_config_hpp(file const& f)
 {
-    static std::string const loose  ("# *include *[<\"]config.hpp[>\"]");
-    static std::string const strict ("\\n(#include \"config.hpp\")\\n");
-    static std::string const indent ("\\n(#   include \"config.hpp\")\\n");
+    static std::string const loose  (R"(# *include *[<"]config.hpp[>"])");
+    static std::string const strict (R"(\n(#include "config.hpp")\n)");
+    static std::string const indent (R"(\n(#   include "config.hpp")\n)");
 
     if
         (   f.is_of_phylum(e_log)
         ||  f.phyloanalyze("^test_coding_rules_test.sh$")
         ||  f.phyloanalyze("^GNUmakefile$")
-        ||  f.phyloanalyze("^pchfile(_.*)?\\.hpp$")
+        ||  f.phyloanalyze(R"(^pchfile(_.*)?\.hpp$)")
         )
         {
         return;
         }
-    else if(f.is_of_phylum(e_header) && f.phyloanalyze("^pchlist(_.*)?\\.hpp$"))
+    else if(f.is_of_phylum(e_header) && f.phyloanalyze(R"(^pchlist(_.*)?\.hpp$)"))
         {
         require(f, loose , "must include 'config.hpp'.");
-        require(f, indent, "lacks line '#   include \"config.hpp\"'.");
+        require(f, indent, R"(lacks line '#   include "config.hpp"'.)");
         boost::smatch match;
-        static boost::regex const first_include("(# *include[^\\n]*)");
+        static boost::regex const first_include(R"((# *include[^\n]*))");
         boost::regex_search(f.data(), match, first_include);
-        if("#   include \"config.hpp\"" != match[1])
+        if(R"(#   include "config.hpp")" != match[1])
             {
             complain(f, "must include 'config.hpp' first.");
             }
         }
-    else if(f.is_of_phylum(e_header) && !f.phyloanalyze("^config(_.*)?\\.hpp$"))
+    else if(f.is_of_phylum(e_header) && !f.phyloanalyze(R"(^config(_.*)?\.hpp$)"))
         {
         require(f, loose , "must include 'config.hpp'.");
-        require(f, strict, "lacks line '#include \"config.hpp\"'.");
+        require(f, strict, R"(lacks line '#include "config.hpp"'.)");
         boost::smatch match;
-        static boost::regex const first_include("(# *include[^\\n]*)");
+        static boost::regex const first_include(R"((# *include[^\n]*))");
         boost::regex_search(f.data(), match, first_include);
-        if("#include \"config.hpp\"" != match[1])
+        if(R"(#include "config.hpp")" != match[1])
             {
             complain(f, "must include 'config.hpp' first.");
             }
@@ -473,13 +473,13 @@ void check_copyright(file const& f)
     int const year = 1900 + t1->tm_year;
 
     std::ostringstream oss;
-    oss << "Copyright \\(C\\)[^\\n]*" << year;
+    oss << R"(Copyright \(C\)[^\n]*)" << year;
     require(f, oss.str(), "lacks current copyright.");
 
     if(f.is_of_phylum(e_html) && !f.phyloanalyze("^COPYING"))
         {
         std::ostringstream oss;
-        oss << "Copyright &copy;[^\\n]*" << year;
+        oss << R"(Copyright &copy;[^\n]*)" << year;
         require(f, oss.str(), "lacks current secondary copyright.");
         }
 }
@@ -498,7 +498,7 @@ void check_cxx(file const& f)
         }
 
     {
-    static boost::regex const r("(\\w+)( +)([*&])(\\w+\\b)([*;]?)([^\\n]*)");
+    static boost::regex const r(R"((\w+)( +)([*&])(\w+\b)([*;]?)([^\n]*))");
     boost::sregex_iterator i(f.data().begin(), f.data().end(), r);
     boost::sregex_iterator const omega;
     for(; i != omega; ++i)
@@ -519,7 +519,7 @@ void check_cxx(file const& f)
     }
 
     {
-    static boost::regex const r("\\bconst +([A-Za-z][A-Za-z0-9_:]*) *[*&]");
+    static boost::regex const r(R"(\bconst +([A-Za-z][A-Za-z0-9_:]*) *[*&])");
     boost::sregex_iterator i(f.data().begin(), f.data().end(), r);
     boost::sregex_iterator const omega;
     for(; i != omega; ++i)
@@ -556,7 +556,7 @@ void check_defect_markers(file const& f)
         }
 
     {
-    static boost::regex const r("(\\b\\w+\\b\\W*)\\?\\?(.)");
+    static boost::regex const r(R"((\b\w+\b\W*)\?\?(.))");
     boost::sregex_iterator i(f.data().begin(), f.data().end(), r);
     boost::sregex_iterator const omega;
     for(; i != omega; ++i)
@@ -574,7 +574,7 @@ void check_defect_markers(file const& f)
     }
 
     {
-    static boost::regex const r("(\\b\\w+\\b\\W?)!!(.)");
+    static boost::regex const r(R"((\b\w+\b\W?)!!(.))");
     boost::sregex_iterator i(f.data().begin(), f.data().end(), r);
     boost::sregex_iterator const omega;
     for(; i != omega; ++i)
@@ -622,14 +622,14 @@ void check_include_guards(file const& f)
 
     std::string const guard = boost::regex_replace
         (f.leaf_name()
-        ,boost::regex("\\.hpp$")
+        ,boost::regex(R"(\.hpp$)")
         ,"_hpp"
         );
     std::string const guards =
-            "\\n#ifndef "   + guard
-        +   "\\n#define "   + guard + "\\n"
+            R"(\n#ifndef )"   + guard
+        +   R"(\n#define )"   + guard + R"(\n)"
         +   ".*"
-        +   "\\n#endif // " + guard + "\\n+$"
+        +   R"(\n#endif // )" + guard + R"(\n+$)"
         ;
     require(f, guards, "lacks canonical header guards.");
 }
@@ -641,7 +641,7 @@ void check_label_indentation(file const& f)
         return;
         }
 
-    static boost::regex const r("\\n( *)([A-Za-z][A-Za-z0-9_]*)( *:)(?!:)");
+    static boost::regex const r(R"(\n( *)([A-Za-z][A-Za-z0-9_]*)( *:)(?!:))");
     boost::sregex_iterator i(f.data().begin(), f.data().end(), r);
     boost::sregex_iterator const omega;
     for(; i != omega; ++i)
@@ -685,7 +685,7 @@ void check_logs(file const& f)
         entries = f.data();
         }
 
-    static boost::regex const r("\\n(?!\\|)(?! *https?:)([^\\n]{71,})(?=\\n)");
+    static boost::regex const r(R"(\n(?!\|)(?! *https?:)([^\n]{71,})(?=\n))");
     boost::sregex_iterator i(entries.begin(), entries.end(), r);
     boost::sregex_iterator const omega;
     if(omega == i)
@@ -865,7 +865,7 @@ void check_reserved_names(file const& f)
         return;
         }
 
-    static boost::regex const r("(\\b\\w*__\\w*\\b)");
+    static boost::regex const r(R"((\b\w*__\w*\b))");
     boost::sregex_iterator i(f.data().begin(), f.data().end(), r);
     boost::sregex_iterator const omega;
     for(; i != omega; ++i)
@@ -896,24 +896,24 @@ void enforce_taboos(file const& f)
         }
 
     // ASCII copyright symbol requires upper-case 'C'.
-    taboo(f, "\\(c\\) *[0-9]");
+    taboo(f, R"(\(c\) *[0-9])");
     // Former addresses of the Free Software Foundation.
     taboo(f, "Cambridge");
     taboo(f, "Temple");
     // Patented.
-    taboo(f, "\\.gif", boost::regex::icase);
+    taboo(f, R"(\.gif)", boost::regex::icase);
     // Obsolete email address.
     taboo(f, "chicares@mindspring.com");
     // Obscured email address.
     taboo(f, "address@hidden");
     // Certain proprietary libraries.
-    taboo(f, "\\bowl\\b", boost::regex::icase);
+    taboo(f, R"(\bowl\b)", boost::regex::icase);
     taboo(f, "vtss", boost::regex::icase);
     // Suspiciously specific to msw.
     taboo(f, "Microsoft");
     taboo(f, "Visual [A-Z]");
-    taboo(f, "\\bWIN\\b");
-    taboo(f, "\\bExcel\\b");
+    taboo(f, R"(\bWIN\b)");
+    taboo(f, R"(\bExcel\b)");
     // Insinuated by certain msw tools.
     taboo(f, "Microsoft Word");
     taboo(f, "Stylus Studio");
@@ -931,7 +931,7 @@ void enforce_taboos(file const& f)
         &&  !f.is_of_phylum(e_synopsis)
         )
         {
-        taboo(f, "\\bexe\\b", boost::regex::icase);
+        taboo(f, R"(\bexe\b)", boost::regex::icase);
         }
 
     if


### PR DESCRIPTION
C++11 raw string literals are more readable than classic C string with
backslash escapes for string containing multiple backslashes, so update the
code to use them in this case (and also, sometimes, even for the string with
just a single backslash for consistency).