### PR TITLE
Define floating-point environment functions for non-x87 platforms

### DIFF
--- a/config.hpp
+++ b/config.hpp
@@ -68,6 +68,17 @@ namespace fs = boost::filesystem;
 #   error Unknown hardware. Consider contributing support.
 #endif // Unknown hardware.
 
+#if defined LMI_X86
+    #if defined _M_IX86_FP && _M_IX86_FP == 0
+        #define LMI_X87
+    // Test for __SSE_MATH__ instead of __SSE__ as the latter is still defined
+    // in x86-64 builds even if the use of SSE is explicitly disabled using gcc
+    // -mfpmath=387 option.
+    #elif !defined __SSE_MATH__
+        #define LMI_X87
+    #endif
+#endif // defined LMI_X86
+
 #if defined __GNUC__
 // This selects a correct snprintf() for MinGW-w64.
 #   if !defined _ISOC99_SOURCE

--- a/fenv_lmi.hpp
+++ b/fenv_lmi.hpp
@@ -26,29 +26,9 @@
 
 #include "so_attributes.hpp"
 
-#if defined LMI_X86
+#if defined LMI_X87
 #   include "fenv_lmi_x86.hpp"
-#else  // Unknown compiler or platform.
-#   error Unknown compiler or platform.
-#endif // Unknown compiler or platform.
-
-// SOMEDAY !! Revisit suppressed __STDC_IEC_559__ support. See:
-//   http://lists.nongnu.org/archive/html/lmi/2008-06/msg00033.html
-#if defined LMI_IEC_559
-// In case the C++ compiler supports C99 7.6 facilities, assume that
-// it defines __STDC_IEC_559__ (except that MinGW supports some such
-// facilities but defines no such macro), and puts prototypes in
-// <fenv.h> but not in namespace std.
-#   include <fenv.h>
-#   if defined __GNUC__ && LMI_GCC_VERSION <= 40300
-// As of 2007-07-05, the gcc manual here:
-//   http://gcc.gnu.org/onlinedocs/gcc/Floating-point-implementation.html
-// which "corresponds to GCC version 4.3.0" says "This pragma is not
-// implemented".
-#   else  // Pragma STDC FENV_ACCESS implemented.
-#       pragma STDC FENV_ACCESS ON
-#   endif // Pragma STDC FENV_ACCESS implemented.
-#endif // defined LMI_IEC_559
+#endif // !defined LMI_X87
 
 #include <cfenv>
 
@@ -66,10 +46,10 @@
 /// with a valid argument, and invalid arguments can be disallowed by
 /// C++'s type system).
 ///
+/// When using x87, i.e. the symbol LMI_X87 is defined, the following
+/// syntactically-similar functions are also available:
 ///   e_ieee754_precision fenv_precision();
 ///   void fenv_precision(e_ieee754_precision);
-/// The precision functions similarly resemble GNU/Linux functions
-/// fe[gs]etprecision().
 ///
 ///   bool LMI_SO fenv_is_valid()
 /// If current floating-point environment matches lmi default, then
@@ -121,8 +101,10 @@ enum enum_fenv_indulgence
 
 void LMI_SO fenv_initialize();
 
+#if defined LMI_X87
 e_ieee754_precision LMI_SO fenv_precision();
 void                LMI_SO fenv_precision(e_ieee754_precision);
+#endif // defined LMI_X87
 
 e_ieee754_rounding LMI_SO fenv_rounding();
 void               LMI_SO fenv_rounding(e_ieee754_rounding);

--- a/fenv_lmi_test.cpp
+++ b/fenv_lmi_test.cpp
@@ -41,10 +41,6 @@
 
 #include <bitset>
 #include <climits>                      // CHAR_BIT
-#if defined LMI_IEC_559 || defined __MINGW32__
-// Specify '|| defined __MINGW32__' to test MinGW extensions like FE_PC64_ENV.
-#   include <fenv.h>
-#endif // defined LMI_IEC_559
 #include <math.h>                       // C99 rint()
 #include <stdexcept>
 
@@ -67,7 +63,7 @@ std::bitset<CHAR_BIT * sizeof(unsigned long int)> bits(unsigned long int i)
 
 int test_main(int, char*[])
 {
-#if defined LMI_X86
+#if defined LMI_X87
     unsigned short int cw = 0x0000;
 
     BOOST_TEST_EQUAL_BITS(0x037f, msvc_to_intel(0x0008001f));
@@ -168,11 +164,10 @@ int test_main(int, char*[])
     fenv_rounding(fe_towardzero);
     BOOST_TEST_EQUAL_BITS(0x0f7f, x87_control_word());
 
-#else  // Unknown platform.
-    throw std::runtime_error("Unknown platform.");
-#endif // Unknown platform.
+#endif // defined LMI_X87
 
-    // Test precision control.
+    // Test precision control (currently only available on x87).
+#if defined LMI_X87
 
     fenv_precision  (fe_fltprec);
     BOOST_TEST_EQUAL(fe_fltprec , fenv_precision());
@@ -182,6 +177,7 @@ int test_main(int, char*[])
 
     fenv_precision  (fe_ldblprec);
     BOOST_TEST_EQUAL(fe_ldblprec, fenv_precision());
+#endif // defined LMI_X87
 
     // Test rounding control.
 
@@ -224,14 +220,15 @@ int test_main(int, char*[])
     BOOST_TEST_EQUAL( 2, rint( 2.5));
 #endif // defined LMI_COMPILER_PROVIDES_RINT
 
+    fenv_initialize();
+    BOOST_TEST(fenv_validate());
+
+#if defined LMI_X87
     std::cout
         << "Expect induced warnings exactly as predicted below,"
         << " but no test failure."
         << std::endl
         ;
-
-    fenv_initialize();
-    BOOST_TEST(fenv_validate());
 
     fenv_initialize();
     fenv_precision(fe_dblprec);
@@ -269,6 +266,7 @@ int test_main(int, char*[])
     BOOST_TEST(0 == fenv_guard::instance_count());
     std::cout << "...end of induced warning]." << std::endl;
     BOOST_TEST(fenv_validate());
+#endif // defined LMI_X87
 
     return 0;
 }

--- a/fenv_lmi_x86.hpp
+++ b/fenv_lmi_x86.hpp
@@ -24,6 +24,10 @@
 
 #include "config.hpp"
 
+#if !defined LMI_X87
+#   error This header should only be included from fenv_lmi.hpp if necessary.
+#endif // LMI_X87
+
 #include <bitset>
 #include <stdexcept>
 
@@ -31,7 +35,6 @@
 #   include <float.h>                   // nonstandard _control87()
 #endif // defined __BORLANDC__ || defined _MSC_VER
 
-#if defined LMI_X86
 /// These functions manipulate the x86 fpu (x87) control word. This
 /// shouldn't be as difficult as it actually is. Part of the problem
 /// is that C was strangely slow to adopt sophisticated numerics:
@@ -348,7 +351,6 @@ inline void x87_control_word(unsigned short int cw)
 #   endif // Unknown compiler or platform.
 }
 
-#endif // LMI_X86
 
 #endif // fenv_lmi_x86_hpp
 

--- a/round_test.cpp
+++ b/round_test.cpp
@@ -44,24 +44,6 @@
 #include <math.h>                       // C99 round() and kin
 #include <ostream>
 
-#if defined LMI_IEC_559
-    // In case the C++ compiler offers C99 fesetround(), assume that
-    // it defines __STDC_IEC_559__, but doesn't support
-    //   #pragma STDC FENV_ACCESS ON
-    // in C++ mode. (I have no such compiler, so that assumption and
-    // code that ought to use that pragma are untested.)
-    enum e_ieee754_rounding
-        {fe_tonearest  = FE_TONEAREST
-        ,fe_downward   = FE_DOWNWARD
-        ,fe_upward     = FE_UPWARD
-        ,fe_towardzero = FE_TOWARDZERO
-        };
-#elif defined LMI_X86
-    // "fenv_lmi_x86.hpp" provides the necessary values.
-#else  // No known way to set rounding style.
-#   error No known way to set rounding style.
-#endif // No known way to set rounding style.
-
 // Print name of software rounding style for diagnostics.
 char const* get_name_of_style(rounding_style style)
 {
@@ -112,21 +94,7 @@ template<> char const* get_name_of_float_type<long double>()
 
 void set_hardware_rounding_mode(e_ieee754_rounding mode, bool synchronize)
 {
-#if defined LMI_IEC_559
-    fesetround(mode);
-#elif defined LMI_X86_64
-    // See the parallel section of 'round_to_test.cpp'.
-    // For the nonce, set both i87 and SSE rounding modes here.
-    fesetround(mode);
     fenv_rounding(mode);
-#elif defined LMI_X86
-    fenv_rounding(mode);
-#else // No known way to set hardware rounding mode.
-    std::cerr
-        << "\nCannot set floating-point hardware rounding mode.\n"
-        << "Results may be invalid.\n"
-        ;
-#endif // No known way to set hardware rounding mode.
 
     if(synchronize)
         {
@@ -177,13 +145,13 @@ void print_hex_val(T t, char const* name)
   std::cout << "hex value of " << name << " is: ";
 
 // GWC modifications begin
-  // My principal compiler, mingw gcc, has sizeof(long double) == 12,
+  // When using x87 with gcc, sizeof(long double) == 12,
   // but only ten bytes are significant; the other two are padding.
   std::size_t size_of_T = sizeof(T);
-#if defined __GNUC__ && defined LMI_X86
+#if defined __GNUC__ && defined LMI_X87
   if(12 == size_of_T)
     size_of_T = 10;
-#endif // defined __GNUC__ && defined LMI_X86
+#endif // defined __GNUC__ && defined LMI_X87
 // GWC modifications end
 
   for (unsigned int i = 0; i < size_of_T; ++i) { // modified by GWC

--- a/skeleton.cpp
+++ b/skeleton.cpp
@@ -153,7 +153,9 @@ BEGIN_EVENT_TABLE(Skeleton, wxApp)
     EVT_MENU(XRCID("test_lib_arbitrary_exception"    ),Skeleton::UponTestLibArbitraryException    )
     EVT_MENU(XRCID("test_lib_catastrophe_report"     ),Skeleton::UponTestLibCatastropheReport     )
     EVT_MENU(XRCID("test_date_conversions"           ),Skeleton::UponTestDateConversions          )
+#if defined LMI_X87
     EVT_MENU(XRCID("test_floating_point_environment" ),Skeleton::UponTestFloatingPointEnvironment )
+#endif // defined LMI_X87
     EVT_MENU(XRCID("test_pasting"                    ),Skeleton::UponTestPasting                  )
     EVT_MENU(XRCID("test_system_command"             ),Skeleton::UponTestSystemCommand            )
     EVT_MENU(XRCID("window_cascade"                  ),Skeleton::UponWindowCascade                )
@@ -1024,6 +1026,7 @@ void Skeleton::UponTestDateConversions(wxCommandEvent&)
     TestDateConversions();
 }
 
+#if defined LMI_X87
 void Skeleton::UponTestFloatingPointEnvironment(wxCommandEvent&)
 {
     status() << "Begin test of floating-point environment." << std::flush;
@@ -1080,6 +1083,7 @@ void Skeleton::UponTestFloatingPointEnvironment(wxCommandEvent&)
 
     status() << "End test of floating-point environment." << std::flush;
 }
+#endif // defined LMI_X87
 
 /// Test custom handler UponPaste().
 ///

--- a/skeleton.hpp
+++ b/skeleton.hpp
@@ -113,7 +113,9 @@ class Skeleton
 
     // Miscellaneous tests.
     void UponTestDateConversions          (wxCommandEvent&);
+#if defined LMI_X87
     void UponTestFloatingPointEnvironment (wxCommandEvent&);
+#endif // defined LMI_X87
     void UponTestPasting                  (wxCommandEvent&);
     void UponTestSystemCommand            (wxCommandEvent&);
 


### PR DESCRIPTION
This change allows the tests relying on the correct rounding mode being set to
pass on such platforms and generally simplifies the code as it replaces the
previous experiment (guarded by the never defined LMI_IEC_559) with using C99
functions.

Note that such platforms include x86, or x86-64, using SSE instead of x87.