### PR TITLE
Fix value_cast<bool>("string") and switch to using standard C++11 functions

### DIFF
--- a/value_cast.hpp
+++ b/value_cast.hpp
@@ -28,12 +28,10 @@
 #include "stream_cast.hpp"
 
 #include <boost/cast.hpp>
-#include <boost/type_traits/is_arithmetic.hpp>
-#include <boost/type_traits/is_convertible.hpp>
-#include <boost/type_traits/is_pointer.hpp>
 
 #include <sstream>
 #include <stdexcept>
+#include <type_traits>
 
 // INELEGANT !! Test the runtime performance of value_cast() compared
 // to the other casts it uses, to ensure that its overhead is minimal.
@@ -103,10 +101,10 @@
 /// although their rationale is not to increase the expressive power,
 /// but merely to work around a compiler defect.
 ///
-/// All uses of class boost::is_convertible here are commented to avoid
+/// All uses of class std::is_convertible here are commented to avoid
 /// confusion due to the surprising order of its template parameters:
 /// compare
-///   boost::is_convertible<From,To>(From z)
+///   std::is_convertible<From,To>(From z)
 /// to the declarations above. Also see this comment:
 ///   http://lists.boost.org/Archives/boost/2006/01/99722.php
 ///   "BTW Its a real pain that the parameter order for is_convertible
@@ -127,7 +125,7 @@ template<typename T>
 struct is_string
 {
     // Here, is_convertible means 'T' is convertible to std::string.
-    enum {value = boost::is_convertible<T,std::string>::value};
+    enum {value = std::is_convertible<T,std::string>::value};
 };
 
 template<typename T>
@@ -185,21 +183,21 @@ struct value_cast_choice
     enum
         {
         // Here, is_convertible means 'From' is convertible to 'To'.
-        convertible = boost::is_convertible<From,To>::value
+        convertible = std::is_convertible<From,To>::value
         };
 
     enum
         {
         both_numeric =
-                boost::is_arithmetic<From>::value
-            &&  boost::is_arithmetic<To  >::value
+                std::is_arithmetic<From>::value
+            &&  std::is_arithmetic<To  >::value
         };
 
     enum
         {
         one_numeric_one_string =
-                boost::is_arithmetic<From>::value && is_string<To  >::value
-            ||  boost::is_arithmetic<To  >::value && is_string<From>::value
+                std::is_arithmetic<From>::value && is_string<To  >::value
+            ||  std::is_arithmetic<To  >::value && is_string<From>::value
         };
 
     enum
@@ -250,7 +248,7 @@ struct value_cast_chooser<To,From,e_stream>
 template<typename To, typename From>
 To value_cast(From const& from)
 {
-    BOOST_STATIC_ASSERT(!boost::is_pointer<To>::value);
+    BOOST_STATIC_ASSERT(!std::is_pointer<To>::value);
     return value_cast_chooser<To,From>()(from);
 }
 

--- a/value_cast.hpp
+++ b/value_cast.hpp
@@ -183,7 +183,16 @@ struct value_cast_choice
     enum
         {
         // Here, is_convertible means 'From' is convertible to 'To'.
-        convertible = std::is_convertible<From,To>::value
+        // We explicitly exclude the case of 'char[]' string literals which are
+        // deemed to be convertible to 'bool' in virtue of C++ implicit
+        // conversion rules, but it doesn't make sense to apply these
+        // conversions here, so just exclude them (notice that 'To' is known
+        // not to be an array due to a check in value_cast(), so there is no
+        // need to check if 'From' is convertible to it if it's a pointer: it
+        // isn't).
+        convertible =
+               !std::is_array<From>::value
+            &&  std::is_convertible<From,To>::value
         };
 
     enum

--- a/value_cast_test.cpp
+++ b/value_cast_test.cpp
@@ -736,15 +736,10 @@ int boost_tests()
     BOOST_TEST_EQUAL(true, value_cast<bool>(true));
     BOOST_TEST_EQUAL(false, value_cast<bool>(false));
 
-    // COMPILER !! Suppress this test for gcc-4.1.2, which refuses,
-    // defectively it would seem, to compile it. See:
-    //   http://lists.nongnu.org/archive/html/lmi/2008-06/msg00010.html
-#if !(defined __GNUC__ && 40102 == LMI_GCC_VERSION)
     BOOST_TEST_EQUAL(true, value_cast<bool>("1"));
-#endif // !(defined __GNUC__ && 40102 == LMI_GCC_VERSION)
+    BOOST_TEST_EQUAL(false, value_cast<bool>("0"));
 
     // This fails; should it?
-//    BOOST_TEST_EQUAL(false, value_cast<bool>("0"));
 //    BOOST_TEST_THROW(value_cast<bool>(""), boost::bad_value_cast);
 //    BOOST_TEST_THROW(value_cast<bool>("Test"), boost::bad_value_cast);
 


### PR DESCRIPTION
This makes the `value_cast` unit test pass with gcc 6.3, where it previously failed, and also makes the previously disabled check which was broken before pass.