### PR TITLE
Use C++11 range-based for loops when possible

### DIFF
--- a/actuarial_table.cpp
+++ b/actuarial_table.cpp
@@ -467,10 +467,10 @@ void actuarial_table::read_values(std::istream& is, int nominal_length)
         );
     data_.resize(number_of_values);
     char z[sizeof(double)];
-    for(int j = 0; j < number_of_values; ++j)
+    for(auto& d: data_)
         {
         is.read(z, sizeof(double));
-        data_[j] = deserialize_cast<double>(z);
+        d = deserialize_cast<double>(z);
         }
 }
 

--- a/any_member.hpp
+++ b/any_member.hpp
@@ -634,9 +634,8 @@ void MemberSymbolTable<ClassType>::ascribe
 
     ClassType* class_object = static_cast<ClassType*>(this);
     map_.insert(member_pair_type(s, any_member<ClassType>(class_object, p2m)));
-    typedef std::vector<std::string>::iterator svi;
     // TODO ?? This would appear to be O(N^2).
-    svi i = std::lower_bound(member_names_.begin(), member_names_.end(), s);
+    auto i = std::lower_bound(member_names_.begin(), member_names_.end(), s);
     member_names_.insert(i, s);
 }
 
@@ -645,10 +644,9 @@ MemberSymbolTable<ClassType>& MemberSymbolTable<ClassType>::assign
     (MemberSymbolTable<ClassType> const& z
     )
 {
-    typedef std::vector<std::string>::const_iterator mnci;
-    for(mnci i = member_names().begin(); i != member_names().end(); ++i)
+    for(auto const& name: member_names())
         {
-        operator[](*i) = z[*i];
+        operator[](name) = z[name];
         }
     return *this;
 }
@@ -658,10 +656,9 @@ bool MemberSymbolTable<ClassType>::equals
     (MemberSymbolTable<ClassType> const& z
     ) const
 {
-    typedef std::vector<std::string>::const_iterator mnci;
-    for(mnci i = member_names().begin(); i != member_names().end(); ++i)
+    for(auto const& name: member_names())
         {
-        if(z[*i] != operator[](*i))
+        if(z[name] != operator[](name))
             {
             return false;
             }
@@ -687,11 +684,9 @@ std::map<std::string,std::string> member_state
     )
 {
     std::map<std::string,std::string> z;
-    std::vector<std::string> const& names = object.member_names();
-    typedef std::vector<std::string>::const_iterator mnci;
-    for(mnci i = names.begin(); i != names.end(); ++i)
+    for(auto const& name: object.member_names())
         {
-        z[*i] = object[*i].str();
+        z[name] = object[name].str();
         }
     return z;
 }

--- a/authenticity.cpp
+++ b/authenticity.cpp
@@ -292,12 +292,12 @@ std::string md5_hex_string(std::vector<unsigned char> const& vuc)
     LMI_ASSERT(md5len == vuc.size());
     std::stringstream oss;
     oss << std::hex;
-    for(int j = 0; j < md5len; ++j)
+    for(auto uc: vuc)
         {
         oss
             << std::setw(chars_per_formatted_hex_byte)
             << std::setfill('0')
-            << static_cast<unsigned int>(vuc[j])
+            << static_cast<unsigned int>(uc)
             ;
         }
     return oss.str();

--- a/authenticity_test.cpp
+++ b/authenticity_test.cpp
@@ -127,10 +127,10 @@ void PasskeyTest::RemoveTestFiles(char const* file, int line) const
     filenames.push_back("passkey");
     filenames.push_back("coleridge");
     filenames.push_back(md5sum_file());
-    for(auto const& fn: filenames)
+    for(auto const& filename: filenames)
         {
-        std::remove(fn.c_str());
-        INVOKE_BOOST_TEST(!fs::exists(fn), file, line);
+        std::remove(filename.c_str());
+        INVOKE_BOOST_TEST(!fs::exists(filename), file, line);
         }
 }
 

--- a/authenticity_test.cpp
+++ b/authenticity_test.cpp
@@ -127,11 +127,10 @@ void PasskeyTest::RemoveTestFiles(char const* file, int line) const
     filenames.push_back("passkey");
     filenames.push_back("coleridge");
     filenames.push_back(md5sum_file());
-    typedef std::vector<std::string>::const_iterator aut0;
-    for(aut0 i = filenames.begin(); i != filenames.end(); ++i)
+    for(auto const& fn: filenames)
         {
-        std::remove(i->c_str());
-        INVOKE_BOOST_TEST(!fs::exists(*i), file, line);
+        std::remove(fn.c_str());
+        INVOKE_BOOST_TEST(!fs::exists(fn), file, line);
         }
 }
 

--- a/bcc_ld.cpp
+++ b/bcc_ld.cpp
@@ -61,11 +61,16 @@ namespace
     std::string switch_slashes(std::string const& s, bool skip_first)
         {
         std::string t(s);
-        for(std::string::size_type j = skip_first; j < t.size(); ++j)
+        for(char& c: t)
             {
-            if('/' == t[j])
+            if(skip_first)
                 {
-                t[j] = '\\';
+                skip_first = false;
+                continue;
+                }
+            if('/' == c)
+                {
+                c = '\\';
                 }
             }
         return t;

--- a/ce_product_name.cpp
+++ b/ce_product_name.cpp
@@ -41,15 +41,13 @@ std::vector<std::string> fetch_product_names()
 {
     fs::path path(global_settings::instance().data_directory());
     std::vector<std::string> names;
-    fs::directory_iterator i(path);
-    fs::directory_iterator end_i;
-    for(; i != end_i; ++i)
+    for(fs::path const& p: path)
         {
-        if(is_directory(*i) || ".policy" != fs::extension(*i))
+        if(is_directory(p) || ".policy" != fs::extension(p))
             {
             continue;
             }
-        names.push_back(basename(*i));
+        names.push_back(basename(p));
         }
 
     if(names.empty())

--- a/ce_product_name.cpp
+++ b/ce_product_name.cpp
@@ -41,7 +41,7 @@ std::vector<std::string> fetch_product_names()
 {
     fs::path path(global_settings::instance().data_directory());
     std::vector<std::string> names;
-    for(fs::path const& p: path)
+    for(fs::path const& p: fs::directory_iterator(path))
         {
         if(is_directory(p) || ".policy" != fs::extension(p))
             {

--- a/ce_skin_name.cpp
+++ b/ce_skin_name.cpp
@@ -42,7 +42,7 @@ std::vector<std::string> fetch_skin_names()
 {
     fs::path path(global_settings::instance().data_directory());
     std::vector<std::string> names;
-    for(fs::path const& p: path)
+    for(fs::path const& p: fs::directory_iterator(path))
         {
         if(is_directory(p) || ".xrc" != fs::extension(p))
             {

--- a/ce_skin_name.cpp
+++ b/ce_skin_name.cpp
@@ -42,15 +42,13 @@ std::vector<std::string> fetch_skin_names()
 {
     fs::path path(global_settings::instance().data_directory());
     std::vector<std::string> names;
-    fs::directory_iterator i(path);
-    fs::directory_iterator end_i;
-    for(; i != end_i; ++i)
+    for(fs::path const& p: path)
         {
-        if(is_directory(*i) || ".xrc" != fs::extension(*i))
+        if(is_directory(p) || ".xrc" != fs::extension(p))
             {
             continue;
             }
-        std::string const name(i->leaf());
+        std::string const name(p.leaf());
         if(!begins_with(name, "skin"))
             {
             continue;

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -69,14 +69,13 @@ std::string insert_spaces_between_words(std::string const& s)
 {
     std::string r;
     std::insert_iterator<std::string> j(r, r.begin());
-    std::string::const_iterator i;
-    for(i = s.begin(); i != s.end(); ++i)
+    for(auto c: s)
         {
-        if(is_ok_for_cctype(*i) && std::isupper(*i) && !r.empty())
+        if(is_ok_for_cctype(c) && std::isupper(c) && !r.empty())
             {
             *j++ = ' ';
             }
-        *j++ = *i;
+        *j++ = c;
         }
     return r;
 }
@@ -966,10 +965,9 @@ bool CensusView::column_value_varies_across_cells
     ,std::vector<Input> const& cells
     ) const
 {
-    typedef std::vector<Input>::const_iterator ici;
-    for(ici j = cells.begin(); j != cells.end(); ++j)
+    for(auto const& cell: cells)
         {
-        if(!((*j)[header] == case_parms()[0][header]))
+        if(!(cell[header] == case_parms()[0][header]))
             {
             return true;
             }
@@ -1036,10 +1034,9 @@ void CensusView::update_class_names()
     // Extract names and add them even if they might be duplicates.
     std::vector<std::string> all_class_names;
 
-    typedef std::vector<Input>::const_iterator ici;
-    for(ici i = cell_parms().begin(); i != cell_parms().end(); ++i)
+    for(auto const& cell_parm: cell_parms())
         {
-        all_class_names.push_back((*i)["EmployeeClass"].str());
+        all_class_names.push_back(cell_parm["EmployeeClass"].str());
         }
 
     std::vector<std::string> unique_class_names;
@@ -1123,36 +1120,33 @@ void CensusView::apply_changes
 
     std::vector<std::string> headers_of_changed_parameters;
     std::vector<std::string> const& all_headers(case_parms()[0].member_names());
-    typedef std::vector<std::string>::const_iterator sci;
-    for(sci i = all_headers.begin(); i != all_headers.end(); ++i)
+    for(auto const& header: all_headers)
         {
-        if(!(old_parms[*i] == new_parms[*i]))
+        if(!(old_parms[header] == new_parms[header]))
             {
-            headers_of_changed_parameters.push_back(*i);
+            headers_of_changed_parameters.push_back(header);
             }
         }
-    for(sci i = headers_of_changed_parameters.begin(); i != headers_of_changed_parameters.end(); ++i)
+    for(auto const& header: headers_of_changed_parameters)
         {
         if(!for_this_class_only)
             {
-            typedef std::vector<Input>::iterator ii;
-            for(ii j = class_parms().begin(); j != class_parms().end(); ++j)
+            for(auto& class_parm: class_parms())
                 {
-                (*j)[*i] = new_parms[*i].str();
+                class_parm[header] = new_parms[header].str();
                 }
-            for(ii j = cell_parms ().begin(); j != cell_parms ().end(); ++j)
+            for(auto& cell_parm: cell_parms())
                 {
-                (*j)[*i] = new_parms[*i].str();
+                cell_parm[header] = new_parms[header].str();
                 }
             }
         else
             {
-            typedef std::vector<Input>::iterator ii;
-            for(ii j = cell_parms().begin(); j != cell_parms().end(); ++j)
+            for(auto& cell_parm: cell_parms())
                 {
-                if((*j)["EmployeeClass"] == old_parms["EmployeeClass"])
+                if(cell_parm["EmployeeClass"] == old_parms["EmployeeClass"])
                     {
-                    (*j)[*i] = new_parms[*i].str();
+                    cell_parm[header] = new_parms[header].str();
                     }
                 }
             }
@@ -1161,14 +1155,13 @@ void CensusView::apply_changes
     // Probably this should be factored out into a member function
     // that's called elsewhere too--e.g., when a cell is read from
     // file, or when a census is pasted.
-    typedef std::vector<Input>::iterator ii;
-    for(ii j = class_parms().begin(); j != class_parms().end(); ++j)
+    for(auto& class_parm: class_parms())
         {
-        j->Reconcile();
+        class_parm.Reconcile();
         }
-    for(ii j = cell_parms() .begin(); j != cell_parms() .end(); ++j)
+    for(auto& cell_parm: cell_parms())
         {
-        j->Reconcile();
+        cell_parm.Reconcile();
         }
 }
 
@@ -1509,10 +1502,9 @@ void CensusView::UponDeleteCells(wxCommandEvent&)
     Timer timer;
 
     wxArrayInt erasures;
-    typedef wxDataViewItemArray::const_iterator dvci;
-    for(dvci i = selection.begin(); i != selection.end(); ++i)
+    for(auto i: selection)
         {
-        erasures.push_back(list_model_->GetRow(*i));
+        erasures.push_back(list_model_->GetRow(i));
         }
     std::sort(erasures.begin(), erasures.end());
 

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -69,7 +69,7 @@ std::string insert_spaces_between_words(std::string const& s)
 {
     std::string r;
     std::insert_iterator<std::string> j(r, r.begin());
-    for(auto c: s)
+    for(char c: s)
         {
         if(is_ok_for_cctype(c) && std::isupper(c) && !r.empty())
             {
@@ -1190,25 +1190,25 @@ void CensusView::update_visible_columns()
     // still information--so if the user made them different from any cell
     // wrt some column, we respect that conscious decision.
     std::vector<std::string> const& all_headers(case_parms()[0].member_names());
-    std::vector<std::string>::const_iterator i;
-    unsigned int column;
-    for(i = all_headers.begin(), column = 0; i != all_headers.end(); ++i, ++column)
+    unsigned int column = 0;
+    for(auto const& header: all_headers)
         {
+        ++column;
         if
-            (  column_value_varies_across_cells(*i, class_parms())
-            || column_value_varies_across_cells(*i, cell_parms ())
+            (  column_value_varies_across_cells(header, class_parms())
+            || column_value_varies_across_cells(header, cell_parms ())
             )
             {
-            any_member<Input> const& representative_value = list_model_->cell_at(0, 1 + column);
+            any_member<Input> const& representative_value = list_model_->cell_at(0, column);
 
             wxDataViewRenderer* renderer = renderer_type_converter::get(representative_value).create_renderer(representative_value);
             LMI_ASSERT(renderer);
 
             list_window_->AppendColumn
                 (new(wx) wxDataViewColumn
-                    (insert_spaces_between_words(*i)
+                    (insert_spaces_between_words(header)
                     ,renderer
-                    ,1 + column
+                    ,column
                     ,width
                     ,wxALIGN_LEFT
                     ,wxDATAVIEW_COL_RESIZABLE

--- a/crc32.cpp
+++ b/crc32.cpp
@@ -151,9 +151,9 @@ unsigned int CRC::value() const
 //============================================================================
 CRC& CRC::operator+=(std::string const& z)
 {
-    for(unsigned int j = 0; j < z.length(); j++)
+    for(char c: z)
         {
-        operator+=(z[j]);
+        operator+=(c);
         }
     return *this;
 }

--- a/crc32.cpp
+++ b/crc32.cpp
@@ -84,9 +84,9 @@ namespace
 
         // Make exclusive-or pattern from polynomial (0xedb88320).
         e = 0;
-        for(i = 0; i < sizeof p / sizeof(int); ++i)
+        for(int pc: p)
             {
-            e |= 1L << (31 - p[i]);
+            e |= 1L << (31 - pc);
             }
 
         for(i = 1; i < 256; ++i)

--- a/database_view.cpp
+++ b/database_view.cpp
@@ -177,11 +177,12 @@ void DatabaseView::SetupControls()
 
     wxTreeCtrl& tree_ctrl = tree();
 
-    for(std::size_t i = 0; i < names.size(); ++i)
+    bool is_first = true;
+    for(auto const& name: names)
         {
-        db_names const& name = names[i];
-        if(0 == i)
+        if(is_first)
             {
+            is_first = false;
             LMI_ASSERT(name.Idx == name.ParentIdx);
             wxTreeItemId id = tree_ctrl.AddRoot
                 (""

--- a/dbdict.cpp
+++ b/dbdict.cpp
@@ -511,10 +511,9 @@ void DBDictionary::InitDB()
     static double const dbl_inf = infinity<double>();
     static double const bignum = std::numeric_limits<double>::max();
 
-    typedef std::vector<std::string>::const_iterator svci;
-    for(svci i = member_names().begin(); i != member_names().end(); ++i)
+    for(auto const& name: member_names())
         {
-        Add(database_entity(db_key_from_name(*i), 0.0));
+        Add(database_entity(db_key_from_name(name), 0.0));
         }
 
     // It would be dangerous to set these to zero.
@@ -966,10 +965,9 @@ void DBDictionary::InitAntediluvian()
     // Zero is inappropriate for some entities ("DB_CurrCoiMultiplier",
     // e.g.), but the antediluvian branch doesn't actually use most
     // database entities.
-    typedef std::vector<std::string>::const_iterator svci;
-    for(svci i = member_names().begin(); i != member_names().end(); ++i)
+    for(auto const& name: member_names())
         {
-        Add(database_entity(db_key_from_name(*i), 0.0));
+        Add(database_entity(db_key_from_name(name), 0.0));
         }
 
     // These are the same as class date_trammel's nominal limits.
@@ -1085,10 +1083,9 @@ void print_databases()
 
             fs::path out_file = fs::change_extension(*i, ".dbt");
             fs::ofstream os(out_file, ios_out_trunc_binary());
-            typedef std::vector<std::string>::const_iterator svci;
-            for(svci i = z.member_names().begin(); i != z.member_names().end(); ++i)
+            for(auto const& mn: z.member_names())
                 {
-                z.datum(*i).write(os);
+                z.datum(mn).write(os);
                 }
             }
         catch(...)

--- a/dbdict.cpp
+++ b/dbdict.cpp
@@ -1069,19 +1069,17 @@ void DBDictionary::InitAntediluvian()
 void print_databases()
 {
     fs::path path(global_settings::instance().data_directory());
-    fs::directory_iterator i(path);
-    fs::directory_iterator end_i;
-    for(; i != end_i; ++i)
+    for(fs::path const& p: path)
         {
-        if(is_directory(*i) || ".database" != fs::extension(*i))
+        if(is_directory(p) || ".database" != fs::extension(p))
             {
             continue;
             }
         try
             {
-            DBDictionary const z(i->string());
+            DBDictionary const z(p.string());
 
-            fs::path out_file = fs::change_extension(*i, ".dbt");
+            fs::path out_file = fs::change_extension(p, ".dbt");
             fs::ofstream os(out_file, ios_out_trunc_binary());
             for(auto const& mn: z.member_names())
                 {

--- a/dbdict.cpp
+++ b/dbdict.cpp
@@ -36,14 +36,13 @@
 #include "miscellany.hpp"
 #include "my_proem.hpp"                 // ::write_proem()
 #include "oecumenic_enumerations.hpp"
+#include "path_utility.hpp"
 #include "premium_tax.hpp"              // premium_tax_rates_for_life_insurance()
 #include "xml_lmi.hpp"
 #include "xml_serialize.hpp"
 
 #include <boost/filesystem/convenience.hpp>
 #include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 
 #include <limits>
 #include <vector>
@@ -1069,7 +1068,7 @@ void DBDictionary::InitAntediluvian()
 void print_databases()
 {
     fs::path path(global_settings::instance().data_directory());
-    for(fs::path const& p: path)
+    for(fs::path const& p: fs::directory_iterator(path))
         {
         if(is_directory(p) || ".database" != fs::extension(p))
             {

--- a/dbnames.cpp
+++ b/dbnames.cpp
@@ -89,10 +89,9 @@ std::map<std::string,int> static_get_short_names()
 {
     std::map<std::string,int> m;
     static std::vector<db_names> const names = static_get_db_names();
-    typedef std::vector<db_names>::const_iterator vdbnci;
-    for(vdbnci i = names.begin(); i != names.end(); ++i)
+    for(auto const& name: names)
         {
-        m[i->ShortName] = i->Idx;
+        m[name.ShortName] = name.Idx;
         }
     return m;
 }

--- a/gpt_input.cpp
+++ b/gpt_input.cpp
@@ -577,17 +577,14 @@ std::vector<std::string> gpt_input::RealizeAllSequenceInput(bool report_errors)
     if(report_errors)
         {
         for
-            (std::vector<std::string>::iterator i = s.begin()
-            ;i != s.end()
-            ;++i
-            )
+            (auto const& str: s)
             {
             std::ostringstream oss;
             bool diagnostics_present = false;
-            if(!i->empty())
+            if(!str.empty())
                 {
                 diagnostics_present = true;
-                oss << (*i) << "\n";
+                oss << str << "\n";
                 }
             if(diagnostics_present)
                 {

--- a/gpt_state.cpp
+++ b/gpt_state.cpp
@@ -43,10 +43,9 @@ template class xml_serializable<gpt_state>;
 gpt_state::gpt_state()
 {
     AscribeMembers();
-    std::vector<std::string>::const_iterator i;
-    for(i = member_names().begin(); i != member_names().end(); ++i)
+    for(auto const& name: member_names())
         {
-        operator[](*i) = "0";
+        operator[](name) = "0";
         }
 }
 

--- a/group_quote_pdf_gen_wx.cpp
+++ b/group_quote_pdf_gen_wx.cpp
@@ -77,14 +77,14 @@ wxString escape_for_html_elem(std::string const& s)
 
     wxString z;
     z.reserve(u.length());
-    for(wxString::const_iterator i = u.begin(); i != u.end(); ++i)
+    for(auto uc: u)
         {
-        switch((*i).GetValue())
+        switch(uc.GetValue())
             {
             case '<': z += "&lt;" ; break;
             case '>': z += "&gt;" ; break;
             case '&': z += "&amp;"; break;
-            default : z += *i     ;
+            default : z += uc     ;
             }
         }
     return z;
@@ -247,36 +247,35 @@ std::vector<extra_summary_field> parse_extra_report_fields(std::string const& s)
     std::vector<extra_summary_field> fields;
     fields.reserve(lines.size());
 
-    typedef std::vector<std::string>::const_iterator vsci;
-    for(vsci i = lines.begin(); i != lines.end(); ++i)
+    for(auto const& line: lines)
         {
         // Ignore the empty or blank lines, they could be added for readability
         // reasons and this also deals with the problem of split_into_lines()
         // returning a vector of a single empty line even if the source string
         // is entirely empty.
-        if(i->find_first_not_of(' ') == std::string::npos)
+        if(line.find_first_not_of(' ') == std::string::npos)
             {
             continue;
             }
 
         extra_summary_field field;
 
-        std::string::size_type const pos_colon = i->find(':');
+        std::string::size_type const pos_colon = line.find(':');
 
         // Notice that substr() call is correct even if there is no colon in
         // this line, i.e. pos_colon == npos.
-        field.name = i->substr(0, pos_colon);
+        field.name = line.substr(0, pos_colon);
 
         if(pos_colon != std::string::npos)
             {
             // Skip any spaces after the colon as this is what would be
             // normally expected by the user.
             std::string::size_type const
-                pos_value = i->find_first_not_of(' ', pos_colon + 1);
+                pos_value = line.find_first_not_of(' ', pos_colon + 1);
 
             if(pos_value != std::string::npos)
                 {
-                field.value = i->substr(pos_value);
+                field.value = line.substr(pos_value);
                 }
             }
         // else: If there is no colon or nothing but space after it, just leave
@@ -1045,10 +1044,9 @@ void group_quote_pdf_generator_wx::do_generate_pdf(wxPdfDC& pdf_dc)
 
     int current_page = 1;
 
-    typedef std::vector<row_data>::const_iterator rdci;
-    for(rdci i = rows_.begin(); i != rows_.end(); ++i)
+    for(auto const& row: rows_)
         {
-        table_gen.output_row(&pos_y, i->values);
+        table_gen.output_row(&pos_y, row.values);
 
         if(last_row_y <= pos_y)
             {
@@ -1235,8 +1233,7 @@ void group_quote_pdf_generator_wx::output_document_header
     std::vector<extra_summary_field> const& f = report_data_.extra_fields_;
     fields.insert(fields.end(), f.begin(), f.end());
 
-    typedef std::vector<extra_summary_field>::const_iterator esfci;
-    for(esfci i = fields.begin(); i != fields.end();)
+    for(auto i = fields.begin(); i != fields.end();)
         {
         // Start a new table row and ensure it will be closed.
         open_and_ensure_closing_tag tag_tr(summary_html, "tr");

--- a/group_values.cpp
+++ b/group_values.cpp
@@ -320,11 +320,7 @@ census_run_result run_census_in_parallel::operator()
             ;
         }
 
-    for
-        (std::vector<mcenum_run_basis>::const_iterator run_basis = RunBases.begin()
-        ;run_basis != RunBases.end()
-        ;++run_basis
-        )
+    for(auto run_basis: RunBases)
         {
         // It seems somewhat anomalous to create and update a GUI
         // progress meter inside this critical calculation section,
@@ -339,22 +335,22 @@ census_run_result run_census_in_parallel::operator()
         mcenum_gen_basis expense_and_general_account_basis;
         mcenum_sep_basis separate_account_basis;
         set_cloven_bases_from_run_basis
-            (*run_basis
+            (run_basis
             ,expense_and_general_account_basis
             ,separate_account_basis
             );
 
         // Calculate duration when the youngest life matures.
         int MaxYr = 0;
-        for(i = cell_values.begin(); i != cell_values.end(); ++i)
+        for(auto& cell_value: cell_values)
             {
-            (*i)->InitializeLife(*run_basis);
+            cell_value->InitializeLife(run_basis);
             MaxYr = std::max(MaxYr, (*i)->GetLength());
             }
 
         meter = create_progress_meter
             (MaxYr - first_cell_inforce_year
-            ,mc_str(*run_basis)
+            ,mc_str(run_basis)
             ,progress_meter_mode(emission)
             );
 
@@ -601,9 +597,9 @@ census_run_result run_census_in_parallel::operator()
             } // End for year.
         meter->culminate();
 
-        for(i = cell_values.begin(); i != cell_values.end(); ++i)
+        for(auto& cell_value: cell_values)
             {
-            (*i)->FinalizeLife(*run_basis);
+            cell_value->FinalizeLife(run_basis);
             }
 
         } // End fenv_guard scope.
@@ -676,12 +672,11 @@ census_run_result run_census::operator()
     census_run_result result;
 
     int composite_length = 0;
-    typedef std::vector<Input>::const_iterator svii;
-    for(svii i = cells.begin(); i != cells.end(); ++i)
+    for(auto const& cell: cells)
         {
-        if(!cell_should_be_ignored(*i))
+        if(!cell_should_be_ignored(cell))
             {
-            composite_length = std::max(composite_length, i->years_to_maturity());
+            composite_length = std::max(composite_length, cell.years_to_maturity());
             }
         }
     // If cell_should_be_ignored() is true for all cells, composite

--- a/icon_monger.cpp
+++ b/icon_monger.cpp
@@ -153,8 +153,7 @@ wxBitmap icon_monger::CreateBitmap
     bool is_builtin = 0 == icon_name.find("wxART_");
     if(is_builtin)
         {
-        typedef std::map<wxArtID,std::string>::const_iterator mci;
-        mci const i = icon_names_by_wx_id_.find(icon_name);
+        auto const i = icon_names_by_wx_id_.find(icon_name);
         if(i == icon_names_by_wx_id_.end())
             {
             // This is not an error as not all wxART id's have lmi overrides,

--- a/ihs_acctval.cpp
+++ b/ihs_acctval.cpp
@@ -317,14 +317,9 @@ double AccountValue::RunAllApplicableBases()
         // on the solve basis.
         }
     // Run all bases, current first.
-    std::vector<mcenum_run_basis> const& run_bases = ledger_->GetRunBases();
-    for
-        (std::vector<mcenum_run_basis>::const_iterator b = run_bases.begin()
-        ;b != run_bases.end()
-        ;++b
-        )
+    for(auto run_base: ledger_->GetRunBases())
         {
-        RunOneBasis(*b);
+        RunOneBasis(run_base);
         }
     return z;
 }

--- a/illustrator.cpp
+++ b/illustrator.cpp
@@ -228,22 +228,23 @@ void assert_consistent_run_order
     ,std::vector<Input> const& cells
     )
 {
-    typedef std::vector<Input>::size_type svst;
-    for(svst i = 0; i != cells.size(); ++i)
+    std::size_t i = 0;
+    for(auto const& cell: cells)
         {
-        if(case_default["RunOrder"] != cells[i]["RunOrder"])
+        if(case_default["RunOrder"] != cell["RunOrder"])
             {
             fatal_error()
                 << "Case-default run order '"
                 << case_default["RunOrder"]
                 << "' differs from run order '"
-                << cells[i]["RunOrder"]
+                << cell["RunOrder"]
                 << "' of cell number "
                 << 1 + i
                 << ". Make this consistent before running illustrations."
                 << LMI_FLUSH
                 ;
             }
+        ++i;
         }
 }
 
@@ -291,13 +292,11 @@ void assert_okay_to_run_group_quote
         fatal_error() << "Group quotes allowed for new business only." << LMI_FLUSH;
         }
 
-    typedef std::vector<Input>::size_type svst;
-    for(svst i = 0; i != cells.size(); ++i)
+    std::size_t i = 0;
+    for(auto const& cell: cells)
         {
-        Input const& cell = cells[i];
-        for(std::size_t j = 0; j != n; ++j)
+        for(auto field: fields)
             {
-            char const*const field = fields[j];
             if(case_default[field] != cell[field])
                 {
                 fatal_error()
@@ -314,6 +313,7 @@ void assert_okay_to_run_group_quote
                     ;
                 }
             }
+        ++i;
         }
 }
 } // Unnamed namespace.

--- a/input_harmonization.cpp
+++ b/input_harmonization.cpp
@@ -844,21 +844,20 @@ false // Silly workaround for now.
         && 0.0 < InforceSeparateAccountValue.value()
         ;
 
-    typedef std::vector<mcenum_report_column>::const_iterator vrci;
-    for(vrci i = weird_report_columns.begin(); i != weird_report_columns.end(); ++i)
+    for(auto c: weird_report_columns)
         {
-        SupplementalReportColumn00.allow(*i, enable_weirdness);
-        SupplementalReportColumn01.allow(*i, enable_weirdness);
-        SupplementalReportColumn02.allow(*i, enable_weirdness);
-        SupplementalReportColumn03.allow(*i, enable_weirdness);
-        SupplementalReportColumn04.allow(*i, enable_weirdness);
-        SupplementalReportColumn05.allow(*i, enable_weirdness);
-        SupplementalReportColumn06.allow(*i, enable_weirdness);
-        SupplementalReportColumn07.allow(*i, enable_weirdness);
-        SupplementalReportColumn08.allow(*i, enable_weirdness);
-        SupplementalReportColumn09.allow(*i, enable_weirdness);
-        SupplementalReportColumn10.allow(*i, enable_weirdness);
-        SupplementalReportColumn11.allow(*i, enable_weirdness);
+        SupplementalReportColumn00.allow(c, enable_weirdness);
+        SupplementalReportColumn01.allow(c, enable_weirdness);
+        SupplementalReportColumn02.allow(c, enable_weirdness);
+        SupplementalReportColumn03.allow(c, enable_weirdness);
+        SupplementalReportColumn04.allow(c, enable_weirdness);
+        SupplementalReportColumn05.allow(c, enable_weirdness);
+        SupplementalReportColumn06.allow(c, enable_weirdness);
+        SupplementalReportColumn07.allow(c, enable_weirdness);
+        SupplementalReportColumn08.allow(c, enable_weirdness);
+        SupplementalReportColumn09.allow(c, enable_weirdness);
+        SupplementalReportColumn10.allow(c, enable_weirdness);
+        SupplementalReportColumn11.allow(c, enable_weirdness);
         }
 }
 

--- a/input_realization.cpp
+++ b/input_realization.cpp
@@ -157,10 +157,9 @@ Input::permissible_specified_amount_strategy_keywords()
 //    std::map<std::string,std::string> permissible_keywords = all_keywords;
     std::map<std::string,std::string> permissible_keywords;
     // Don't use initialization--we want this to happen every time [6.7].
-    typedef std::map<std::string,std::string>::const_iterator smci;
-    for(smci i = all_keywords.begin(); i != all_keywords.end(); ++i)
+    for(auto const& keyword: all_keywords)
         {
-        permissible_keywords.insert(*i);
+        permissible_keywords.insert(keyword);
         }
 
     bool specified_amount_indeterminate = mce_solve_specamt == SolveType;
@@ -232,18 +231,14 @@ std::vector<std::string> Input::RealizeAllSequenceInput(bool report_errors)
 
     if(report_errors)
         {
-        for
-            (std::vector<std::string>::iterator i = s.begin()
-            ;i != s.end()
-            ;++i
-            )
+        for(auto const& str: s)
             {
             std::ostringstream oss;
             bool diagnostics_present = false;
-            if(!i->empty())
+            if(!str.empty())
                 {
                 diagnostics_present = true;
-                oss << (*i) << "\n";
+                oss << str << "\n";
                 }
             if(diagnostics_present)
                 {

--- a/input_seq_helpers.hpp
+++ b/input_seq_helpers.hpp
@@ -113,10 +113,9 @@ std::vector<T> convert_vector_type
     )
 {
     std::vector<T> z;
-    typename std::vector<mc_enum<T> >::const_iterator ve_i;
-    for(ve_i = ve.begin(); ve_i != ve.end(); ++ve_i)
+    for(auto const& e: ve)
         {
-        z.push_back(ve_i->value());
+        z.push_back(e.value());
         }
     return z;
 }
@@ -127,10 +126,9 @@ std::vector<Number> convert_vector_type
     )
 {
     std::vector<Number> z;
-    typename std::vector<tn_range<Number,Trammel> >::const_iterator vr_i;
-    for(vr_i = vr.begin(); vr_i != vr.end(); ++vr_i)
+    for(auto const& r: vr)
         {
-        z.push_back(vr_i->value());
+        z.push_back(r.value());
         }
     return z;
 }

--- a/input_sequence.cpp
+++ b/input_sequence.cpp
@@ -133,13 +133,9 @@ InputSequence::InputSequence(std::vector<double> const& v)
     intervals.push_back(dummy);
     intervals.back().value_number = current_value;
 
-    for
-        (std::vector<double>::const_iterator vi = v.begin()
-        ;vi != v.end()
-        ;++vi
-        )
+    for(double vi : v)
         {
-        current_value = *vi;
+        current_value = vi;
         if(prior_value == current_value)
             {
             ++intervals.back().end_duration;
@@ -173,13 +169,9 @@ InputSequence::InputSequence(std::vector<std::string> const& v)
     intervals.push_back(dummy);
     intervals.back().value_keyword = current_value;
 
-    for
-        (std::vector<std::string>::const_iterator vi = v.begin()
-        ;vi != v.end()
-        ;++vi
-        )
+    for(auto const& vi: v)
         {
-        current_value = *vi;
+        current_value = vi;
         if(prior_value == current_value)
             {
             ++intervals.back().end_duration;

--- a/input_sequence.cpp
+++ b/input_sequence.cpp
@@ -133,7 +133,7 @@ InputSequence::InputSequence(std::vector<double> const& v)
     intervals.push_back(dummy);
     intervals.back().value_number = current_value;
 
-    for(double vi : v)
+    for(double vi: v)
         {
         current_value = vi;
         if(prior_value == current_value)

--- a/input_sequence_entry.cpp
+++ b/input_sequence_entry.cpp
@@ -92,9 +92,9 @@ DurationModeChoice::DurationModeChoice(wxWindow* parent)
 
     {
     wxWindowUpdateLocker lock(this);
-    for(unsigned int i = 0; i < duration_mode_choices; ++i)
+    for(auto const& duration_mode_choice_value: duration_mode_choice_values)
         {
-        Append(duration_mode_choice_values[i].label);
+        Append(duration_mode_choice_value.label);
         }
     }
 
@@ -694,11 +694,11 @@ void InputSequenceEditor::insert_row(int new_row)
     sizer_->wxSizer::Insert(insert_pos++, add, wxSizerFlags(flags).Border(wxLEFT, 0).Right());
 
     // update id_to_row_ mapping:
-    for(id_to_row_map::iterator i = id_to_row_.begin(); i != id_to_row_.end(); ++i)
+    for(auto& i: id_to_row_)
         {
-        if(new_row <= i->second)
+        if(new_row <= i.second)
             {
-            i->second = i->second + 1;
+            i.second = i.second + 1;
             }
         }
 
@@ -808,15 +808,15 @@ void InputSequenceEditor::remove_row(int row)
 
     // update id_to_row_ mapping:
     std::vector<wxWindowID> to_remove;
-    for(id_to_row_map::iterator i = id_to_row_.begin(); i != id_to_row_.end(); ++i)
+    for(auto& i: id_to_row_)
         {
-        if(i->second == row)
+        if(i.second == row)
             {
-            to_remove.push_back(i->first);
+            to_remove.push_back(i.first);
             }
-        else if(row < i->second)
+        else if(row < i.second)
             {
-            i->second = i->second - 1;
+            i.second = i.second - 1;
             }
         }
     LMI_ASSERT(!to_remove.empty());

--- a/input_sequence_entry.cpp
+++ b/input_sequence_entry.cpp
@@ -820,11 +820,9 @@ void InputSequenceEditor::remove_row(int row)
             }
         }
     LMI_ASSERT(!to_remove.empty());
-    for(std::vector<wxWindowID>::const_iterator rm = to_remove.begin()
-        ;rm != to_remove.end()
-        ;++rm)
+    for(auto rm: to_remove)
         {
-        id_to_row_.erase(*rm);
+        id_to_row_.erase(rm);
         }
 
     // update the row following the one we just removed and the one before it,

--- a/ledger.cpp
+++ b/ledger.cpp
@@ -323,18 +323,16 @@ void Ledger::AutoScale()
     double mult = ledger_invariant_->DetermineScaleFactor();
 
     ledger_map_t& l_map_rep = ledger_map_->held_;
-    ledger_map_t::const_iterator lmci = l_map_rep.begin();
-    for(;lmci != l_map_rep.end(); ++lmci)
+    for(auto const& ci: l_map_rep)
         {
-        mult = std::min(mult, (*lmci).second.DetermineScaleFactor());
+        mult = std::min(mult, ci.second.DetermineScaleFactor());
         }
 
     ledger_invariant_->ApplyScaleFactor(mult);
 
-    ledger_map_t::iterator lmi = l_map_rep.begin();
-    for(;lmi != l_map_rep.end(); ++lmi)
+    for(auto& i: l_map_rep)
         {
-        (*lmi).second.ApplyScaleFactor(mult);
+        i.second.ApplyScaleFactor(mult);
         }
 }
 
@@ -344,10 +342,9 @@ unsigned int Ledger::CalculateCRC() const
     CRC crc;
     ledger_invariant_->UpdateCRC(crc);
     ledger_map_t const& l_map_rep = ledger_map_->held();
-    ledger_map_t::const_iterator lmci = l_map_rep.begin();
-    for(;lmci != l_map_rep.end(); ++lmci)
+    for(auto const& ci: l_map_rep)
         {
-        (*lmci).second.UpdateCRC(crc);
+        ci.second.UpdateCRC(crc);
         }
 
     return crc.value();
@@ -358,10 +355,9 @@ void Ledger::Spew(std::ostream& os) const
 {
     ledger_invariant_->Spew(os);
     ledger_map_t const& l_map_rep = ledger_map_->held();
-    ledger_map_t::const_iterator lmci = l_map_rep.begin();
-    for(;lmci != l_map_rep.end(); ++lmci)
+    for(auto const& ci: l_map_rep)
         {
-        (*lmci).second.Spew(os);
+        ci.second.Spew(os);
         }
 }
 

--- a/ledger.cpp
+++ b/ledger.cpp
@@ -134,14 +134,10 @@ void Ledger::SetRunBases(int length)
             }
         }
 
-    for
-        (ledger_map_t::iterator p = l_map_rep.begin()
-        ;p != l_map_rep.end()
-        ;++p
-        )
+    for(auto& p: l_map_rep)
         {
-        ledger_map_t::key_type const& key = (*p).first;
-        ledger_map_t::mapped_type& data = (*p).second;
+        ledger_map_t::key_type const& key = p.first;
+        ledger_map_t::mapped_type& data = p.second;
 
         run_bases_.push_back(key);
         data.set_run_basis(key);
@@ -312,13 +308,9 @@ int Ledger::GetMaxLength() const
     ledger_map_t const& l_map_rep = ledger_map_->held();
     double max_length = 0.0;
 
-    for
-        (ledger_map_t::const_iterator lmci = l_map_rep.begin()
-        ;lmci != l_map_rep.end()
-        ;++lmci
-        )
+    for(auto const& lmci: l_map_rep)
         {
-        max_length = std::max(max_length, (*lmci).second.LapseYear);
+        max_length = std::max(max_length, lmci.second.LapseYear);
         }
     return static_cast<int>(max_length);
 }

--- a/ledger_base.cpp
+++ b/ledger_base.cpp
@@ -85,22 +85,14 @@ void LedgerBase::Alloc()
 //============================================================================
 void LedgerBase::Initialize(int a_Length)
 {
-    for
-        (double_vector_map::iterator i = AllVectors.begin()
-        ;i != AllVectors.end()
-        ;i++
-        )
+    for(auto& i: AllVectors)
         {
-        (*i).second->assign(a_Length, 0.0);
+        i.second->assign(a_Length, 0.0);
         }
 
-    for
-        (scalar_map::iterator i = AllScalars.begin()
-        ;i != AllScalars.end()
-        ;i++
-        )
+    for(auto& i: AllScalars)
         {
-        *(*i).second = 0.0;
+        *i.second = 0.0;
         }
 }
 
@@ -333,13 +325,9 @@ double LedgerBase::DetermineScaleFactor() const
     double min_val = 0.0;
     double max_val = 0.0;
 
-    for
-        (double_vector_map::const_iterator svmi = ScalableVectors.begin()
-        ;svmi != ScalableVectors.end()
-        ;svmi++
-        )
+    for(auto const& svmi: ScalableVectors)
         {
-        minmax<double> extrema(*(*svmi).second);
+        minmax<double> extrema(*svmi.second);
         min_val = std::min(min_val, extrema.minimum());
         max_val = std::max(max_val, extrema.maximum());
         }
@@ -461,14 +449,10 @@ void LedgerBase::ApplyScaleFactor(double a_Mult)
 
     // TODO ?? Would be clearer with bind1st.
     std::vector<double>M(GetLength(), m_scaling_factor);
-    for
-        (double_vector_map::iterator svmi = ScalableVectors.begin()
-        ;svmi != ScalableVectors.end()
-        ;svmi++
-        )
+    for(auto& svmi: ScalableVectors)
         {
         // ET !! *(*svmi).second *= M;
-        std::vector<double>& v = *(*svmi).second;
+        std::vector<double>& v = *svmi.second;
         std::transform
             (v.begin()
             ,v.end()
@@ -495,31 +479,19 @@ double LedgerBase::ScaleFactor() const
 void LedgerBase::UpdateCRC(CRC& crc) const
 {
 // TODO ?? std::transform() might be cleaner.
-    for
-        (double_vector_map::const_iterator vmi = AllVectors.begin()
-        ;vmi != AllVectors.end()
-        ;vmi++
-        )
+    for(auto const& vmi: AllVectors)
         {
-        crc += *(*vmi).second;
+        crc += *vmi.second;
         }
 
-    for
-        (scalar_map::const_iterator sci = AllScalars.begin()
-        ;sci != AllScalars.end()
-        ;sci++
-        )
+    for(auto const& sci: AllScalars)
         {
-        crc += *(*sci).second;
+        crc += *sci.second;
         }
 
-    for
-        (string_map::const_iterator sti = Strings.begin()
-        ;sti != Strings.end()
-        ;sti++
-        )
+    for(auto const& sti: Strings)
         {
-        crc += *(*sti).second;
+        crc += *sti.second;
         }
 }
 
@@ -528,39 +500,27 @@ void LedgerBase::Spew(std::ostream& os) const
 {
     static int const prec = max_stream_precision();
 
-    for
-        (double_vector_map::const_iterator vmi = AllVectors.begin()
-        ;vmi != AllVectors.end()
-        ;vmi++
-        )
+    for(auto const& vmi: AllVectors)
         {
-        SpewVector(os, (*vmi).first, *(*vmi).second);
+        SpewVector(os, vmi.first, *vmi.second);
         }
 
-    for
-        (scalar_map::const_iterator sci = AllScalars.begin()
-        ;sci != AllScalars.end()
-        ;sci++
-        )
+    for(auto const& sci: AllScalars)
         {
         os
-            << (*sci).first
+            << sci.first
             << "=="
-            << std::setprecision(prec) << *(*sci).second
+            << std::setprecision(prec) << *sci.second
             << '\n'
             ;
         }
 
-    for
-        (string_map::const_iterator sti = Strings.begin()
-        ;sti != Strings.end()
-        ;sti++
-        )
+    for(auto const& sti: Strings)
         {
         os
-            << (*sti).first
+            << sti.first
             << "=="
-            << *(*sti).second
+            << *sti.second
             << '\n'
             ;
         }

--- a/ledger_text_formats.cpp
+++ b/ledger_text_formats.cpp
@@ -321,15 +321,14 @@ std::string calculation_summary_formatter::format_as_html() const
         }
 
     std::string const width = value_cast<std::string>(100 / columns_.size());
-    typedef std::vector<std::string>::const_iterator vsci;
     oss
         << "<hr>\n"
         << "<table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" width=\"100%\">\n"
         << "<tr align=\"right\">\n"
         ;
-    for(vsci i = columns_.begin(); i != columns_.end(); ++i)
+    for(auto const& column: columns_)
         {
-        ledger_metadata const& z = map_lookup(ledger_metadata_map(), *i);
+        ledger_metadata const& z = map_lookup(ledger_metadata_map(), column);
         oss << "<td valign=\"bottom\" width=\"" << width << "%\">" << z.legend_ << " </td>\n";
         }
     oss << "</tr>\n";
@@ -341,11 +340,11 @@ std::string calculation_summary_formatter::format_as_html() const
             oss << "<tr><td><br></td></tr>\n";
             }
         oss << "<tr align=\"right\">\n";
-        for(vsci i = columns_.begin(); i != columns_.end(); ++i)
+        for(auto const& column: columns_)
             {
-            ledger_metadata const& z = map_lookup(ledger_metadata_map(), *i);
+            ledger_metadata const& z = map_lookup(ledger_metadata_map(), column);
             std::string s = ledger_format
-                (numeric_vector(ledger_, *i)[j]
+                (numeric_vector(ledger_, column)[j]
                 ,std::make_pair(z.decimals_, z.style_)
                 );
             oss << "<td nowrap>&nbsp;&nbsp;&nbsp;" << s << "</td>\n";
@@ -410,22 +409,21 @@ std::string calculation_summary_formatter::format_as_tsv() const
         }
 
     std::string const width = value_cast<std::string>(100 / columns_.size());
-    typedef std::vector<std::string>::const_iterator vsci;
     oss << '\n';
-    for(vsci i = columns_.begin(); i != columns_.end(); ++i)
+    for(auto const& column: columns_)
         {
-        ledger_metadata const& z = map_lookup(ledger_metadata_map(), *i);
+        ledger_metadata const& z = map_lookup(ledger_metadata_map(), column);
         oss << z.legend_ << '\t';
         }
     oss << '\n';
 
     for(int j = 0; j < max_length_; ++j)
         {
-        for(vsci i = columns_.begin(); i != columns_.end(); ++i)
+        for(auto const& column: columns_)
             {
-            ledger_metadata const& z = map_lookup(ledger_metadata_map(), *i);
+            ledger_metadata const& z = map_lookup(ledger_metadata_map(), column);
             std::string s = ledger_format
-                (numeric_vector(ledger_, *i)[j]
+                (numeric_vector(ledger_, column)[j]
                 ,std::make_pair(z.decimals_, z.style_)
                 );
             oss << s << '\t';
@@ -583,10 +581,9 @@ void PrintCellTabDelimited
         (cheaders
         ,cheaders + lmi_array_size(cheaders)
         );
-    typedef std::vector<std::string>::const_iterator vsi;
-    for(vsi i = sheaders.begin(); i != sheaders.end(); ++i)
+    for(auto const& sheader: sheaders)
         {
-        os << *i << '\t';
+        os << sheader << '\t';
         }
     os << "\n\n";
 
@@ -754,10 +751,9 @@ void PrintRosterHeaders(std::string const& file_name)
         (cheaders
         ,cheaders + lmi_array_size(cheaders)
         );
-    typedef std::vector<std::string>::const_iterator vsi;
-    for(vsi i = sheaders.begin(); i != sheaders.end(); ++i)
+    for(auto const& sheader: sheaders)
         {
-        os << *i << '\t';
+        os << sheader << '\t';
         }
     os << "\n\n";
 
@@ -1035,9 +1031,8 @@ void FlatTextLedgerPrinter::PrintNumericalSummary() const
 
     int summary_rows[] = {4, 9, 19, std::min(99, 69 - value_cast<int>(invar().Age))};
 
-    for(int j = 0; j < static_cast<int>(sizeof summary_rows / sizeof(int)); ++j)
+    for(int row: summary_rows)
         {
-        int row = summary_rows[j];
         // Skip row if it doesn't exist. For instance, if issue age is
         // 85 and maturity age is 100, then there is no twentieth duration.
         if(ledger_.GetMaxLength() < 1 + row)
@@ -1226,9 +1221,9 @@ std::vector<std::string> ledger_format
     )
 {
     std::vector<std::string> sv;
-    for(unsigned int j = 0; j < dv.size(); ++j)
+    for(double d: dv)
         {
-        sv.push_back(ledger_format(dv[j], f));
+        sv.push_back(ledger_format(d, f));
         }
     return sv;
 }

--- a/ledger_xml_io.cpp
+++ b/ledger_xml_io.cpp
@@ -752,14 +752,12 @@ void Ledger::write(xml::element& x) const
 
     // That was the tricky part. Now it's all downhill.
 
-    ledger_map_t const& l_map_rep = ledger_map_->held();
-    typedef ledger_map_t::const_iterator lmci;
-    for(lmci i = l_map_rep.begin(); i != l_map_rep.end(); i++)
+    for(auto const& i: ledger_map_->held())
         {
-        std::string suffix = suffixes[i->first];
+        std::string suffix = suffixes[i.first];
         for
-            (scalar_map::const_iterator j = i->second.AllScalars.begin()
-            ;j != i->second.AllScalars.end()
+            (scalar_map::const_iterator j = i.second.AllScalars.begin()
+            ;j != i.second.AllScalars.end()
             ;++j
             )
             {
@@ -768,16 +766,16 @@ void Ledger::write(xml::element& x) const
                 stringscalars[j->first + suffix] = ledger_format(*j->second, format_map[j->first]);
             }
         for
-            (string_map::const_iterator j = i->second.Strings.begin()
-            ;j != i->second.Strings.end()
+            (string_map::const_iterator j = i.second.Strings.begin()
+            ;j != i.second.Strings.end()
             ;++j
             )
             {
             strings[j->first + suffix] = j->second;
             }
         for
-            (double_vector_map::const_iterator j = i->second.AllVectors.begin()
-            ;j != i->second.AllVectors.end()
+            (double_vector_map::const_iterator j = i.second.AllVectors.begin()
+            ;j != i.second.AllVectors.end()
             ;++j
             )
             {

--- a/main_cli.cpp
+++ b/main_cli.cpp
@@ -406,11 +406,9 @@ void process_command_line(int argc, char* argv[])
         {
         getopt_long.usage();
         std::cout << "Suboptions for '--emit':\n";
-        std::vector<std::string> const& v = allowed_strings_emission();
-        typedef std::vector<std::string>::const_iterator vsi;
-        for(vsi i = v.begin(); i != v.end(); ++i)
+        for(auto const& s: allowed_strings_emission())
             {
-            std::cout << "  " << *i << '\n';
+            std::cout << "  " << s << '\n';
             }
         return;
         }

--- a/main_wx_test.cpp
+++ b/main_wx_test.cpp
@@ -269,12 +269,11 @@ void application_test::process_test_name(char const* name)
 
     bool any_tests_matched = false;
 
-    typedef std::vector<test_descriptor>::iterator tdi;
-    for(tdi i = tests_.begin(); i != tests_.end(); ++i)
+    for(auto& test: tests_)
         {
-        if (wxString(i->get_name()).Matches(name))
+        if (wxString(test.get_name()).Matches(name))
             {
-            i->run = run;
+            test.run = run;
             any_tests_matched = true;
             }
         }
@@ -452,21 +451,20 @@ TestsResults application_test::run()
 
     TestsResults results;
 
-    typedef std::vector<test_descriptor>::const_iterator ctdi;
-    for(ctdi i = tests_.begin(); i != tests_.end(); ++i)
+    for(auto const& test: tests_)
         {
-        if ((run_all_ && i->run != run_no) || i->run == run_yes)
+        if ((run_all_ && test.run != run_no) || test.run == run_yes)
             {
             std::string error;
             results.total++;
 
-            char const* const name = i->get_name();
+            char const* const name = test.get_name();
 
             try
                 {
                 wxPrintf("%s: started\n", name);
                 wxStopWatch sw;
-                i->run_test();
+                test.run_test();
                 // Check that no messages were unexpectedly logged during this
                 // test execution.
                 wxLog::FlushActive();
@@ -522,10 +520,9 @@ void application_test::list_tests()
 
     std::cout << "Available tests:\n";
 
-    typedef std::vector<test_descriptor>::const_iterator ctdi;
-    for(ctdi i = tests_.begin(); i != tests_.end(); ++i)
+    for(auto const& test: tests_)
         {
-        std::cout << '\t' << i->get_name() << '\n';
+        std::cout << '\t' << test.get_name() << '\n';
         }
 
     std::cout << tests_.size() << " test cases.\n";

--- a/mec_input.cpp
+++ b/mec_input.cpp
@@ -522,18 +522,14 @@ std::vector<std::string> mec_input::RealizeAllSequenceInput(bool report_errors)
 
     if(report_errors)
         {
-        for
-            (std::vector<std::string>::iterator i = s.begin()
-            ;i != s.end()
-            ;++i
-            )
+        for(auto const& str: s)
             {
             std::ostringstream oss;
             bool diagnostics_present = false;
-            if(!i->empty())
+            if(!str.empty())
                 {
                 diagnostics_present = true;
-                oss << (*i) << "\n";
+                oss << str << "\n";
                 }
             if(diagnostics_present)
                 {

--- a/miscellany.cpp
+++ b/miscellany.cpp
@@ -108,10 +108,8 @@ std::string htmlize(std::string const& raw_text)
     std::string html;
     html.reserve(raw_text.size());
 
-    typedef std::string::const_iterator sci;
-    for(sci i = raw_text.begin(); i != raw_text.end(); ++i)
+    for(char c: raw_text)
         {
-        std::string::const_reference c = *i;
         switch(c)
             {
             case '&': {html += "&amp;";} break;

--- a/multiple_cell_document.cpp
+++ b/multiple_cell_document.cpp
@@ -142,24 +142,22 @@ void multiple_cell_document::parse(xml_lmi::dom_parser const& parser)
     class_parms_.clear();
     cell_parms_ .clear();
 
-    xml::const_nodes_view const elements(root.elements());
-    typedef xml::const_nodes_view::const_iterator cnvi;
     Input cell;
     int counter = 0;
-    for(cnvi i = elements.begin(); i != elements.end(); ++i)
+    for(auto const& element: root.elements())
         {
-        std::string const tag(i->get_name());
+        std::string const tag(element.get_name());
         std::vector<Input>& v
             ( ("case_default"     == tag) ? case_parms_
             : ("class_defaults"   == tag) ? class_parms_
             : ("particular_cells" == tag) ? cell_parms_
             : hurl<std::vector<Input> >("Unexpected element '" + tag + "'.")
             );
-        xml::const_nodes_view const subelements(i->elements());
+        xml::const_nodes_view const subelements(element.elements());
         v.reserve(std::distance(subelements.begin(), subelements.end()));
-        for(cnvi j = subelements.begin(); j != subelements.end(); ++j)
+        for(auto const& subelement: subelements)
             {
-            *j >> cell;
+            subelement >> cell;
             v.push_back(cell);
             status() << "Read " << ++counter << " cells." << std::flush;
             }
@@ -177,8 +175,7 @@ void multiple_cell_document::parse_v0(xml_lmi::dom_parser const& parser)
     Input temp;
 
     xml::const_nodes_view const elements(root.elements());
-    typedef xml::const_nodes_view::const_iterator cnvi;
-    cnvi i = elements.begin();
+    auto i = elements.begin();
 
     // Case default parameters.
 
@@ -383,20 +380,16 @@ bool multiple_cell_document::data_source_is_external(xml::document const& d) con
     // INPUT !! Remove "InforceDataSource" and the following code when
     // external systems are updated to use the "data_source" attribute.
 
-    typedef xml::const_nodes_view::const_iterator cnvi;
-
     // Tag names vary: {"case_default", "class_defaults", "particular_cells"}.
     xml::const_nodes_view const i_nodes(root.elements());
     LMI_ASSERT(3 == i_nodes.size());
-    for(cnvi i = i_nodes.begin(); i != i_nodes.end(); ++i)
+    for(auto const& i_node: i_nodes)
         {
-        xml::const_nodes_view const j_nodes(i->elements("cell"));
-        for(cnvi j = j_nodes.begin(); j != j_nodes.end(); ++j)
+        for(auto const& j_node: i_node.elements("cell"))
             {
-            xml::const_nodes_view const k_nodes(j->elements("InforceDataSource"));
-            for(cnvi k = k_nodes.begin(); k != k_nodes.end(); ++k)
+            for(auto const& k_node: j_node.elements("InforceDataSource"))
                 {
-                std::string s(xml_lmi::get_content(*k));
+                std::string s(xml_lmi::get_content(k_node));
                 if("0" != s && "1" != s)
                     {
                     return true;
@@ -479,20 +472,18 @@ void multiple_cell_document::write(std::ostream& os) const
     xml::node::iterator case_i = root.insert(case_default);
     case_parms_[0].write(*case_i);
 
-    typedef std::vector<Input>::const_iterator svii;
-
     xml::element class_defaults("class_defaults");
     xml::node::iterator classes_i = root.insert(class_defaults);
-    for(svii i = class_parms_.begin(); i != class_parms_.end(); ++i)
+    for(auto const& class_parm: class_parms_)
         {
-        i->write(*classes_i);
+        class_parm.write(*classes_i);
         }
 
     xml::element particular_cells("particular_cells");
     xml::node::iterator cells_i = root.insert(particular_cells);
-    for(svii i = cell_parms_.begin(); i != cell_parms_.end(); ++i)
+    for(auto const& cell_parm: cell_parms_)
         {
-        i->write(*cells_i);
+        cell_parm.write(*cells_i);
         }
 
     os << document;

--- a/mvc_controller.cpp
+++ b/mvc_controller.cpp
@@ -133,14 +133,12 @@ MvcController::MvcController
     // Call ModelReference() to ensure that each Model entity is of a
     // type derived from class datum_base.
 
-    std::vector<std::string> const& mn = model_.Names();
-    typedef std::vector<std::string>::const_iterator svci;
-    for(svci i = mn.begin(); i != mn.end(); ++i)
+    for(auto const& mn: model_.Names())
         {
-        ModelReference<datum_base>(*i);
-        if(FindWindow(wxXmlResource::GetXRCID(i->c_str())))
+        ModelReference<datum_base>(mn);
+        if(FindWindow(wxXmlResource::GetXRCID(mn.c_str())))
             {
-            Bind(*i, transfer_data_[*i] = model_.Entity(*i).str());
+            Bind(mn, transfer_data_[mn] = model_.Entity(mn).str());
             }
         }
 
@@ -178,10 +176,9 @@ void MvcController::Assimilate(std::string const& name_to_ignore)
 
     ConditionallyEnable();
 
-    typedef std::map<std::string,std::string>::const_iterator smci;
-    for(smci i = transfer_data_.begin(); i != transfer_data_.end(); ++i)
+    for(auto const& i: transfer_data_)
         {
-        std::string const& name        = i->first;
+        std::string const& name        = i.first;
         std::string const& model_value = model_.Entity(name).str();
         if(name == name_to_ignore || ModelAndViewValuesEquivalent(name))
             {
@@ -212,11 +209,8 @@ wxBookCtrlBase const& MvcController::BookControl() const
 
 void MvcController::ConditionallyEnable()
 {
-    typedef std::vector<wxWindow*>::const_iterator wvci;
-    std::vector<wxWindow*> page_lineage = Lineage(&CurrentPage());
-    for(wvci i = page_lineage.begin(); i != page_lineage.end(); ++i)
+    for(auto pw: Lineage(&CurrentPage()))
         {
-        wxWindow* pw = *i;
         LMI_ASSERT(nullptr != pw);
         Transferor* t = dynamic_cast<Transferor*>(pw->GetValidator());
         if(t)
@@ -244,9 +238,8 @@ void MvcController::ConditionallyEnable()
     // date ranges fail to work, and the observable symptom is quite
     // spectacular.
 
-    for(wvci i = lineage_.begin(); i != lineage_.end(); ++i)
+    for(auto pw: lineage_)
         {
-        wxWindow* pw = *i;
         LMI_ASSERT(nullptr != pw);
         Transferor* t = dynamic_cast<Transferor*>(pw->GetValidator());
         if(t)
@@ -424,11 +417,8 @@ void MvcController::EnsureOptimalFocus()
         }
 
     SetFocus();
-    typedef std::vector<wxWindow*>::const_iterator wvci;
-    std::vector<wxWindow*> page_lineage = Lineage(&CurrentPage());
-    for(wvci i = page_lineage.begin(); i != page_lineage.end(); ++i)
+    for(auto w: Lineage(&CurrentPage()))
         {
-        wxWindow* w = *i;
         if(w && w->IsEnabled() && w->AcceptsFocus())
             {
             w->SetFocus();
@@ -458,10 +448,8 @@ void MvcController::EnsureOptimalFocus()
 
 void MvcController::Initialize()
 {
-    typedef std::vector<wxWindow*>::const_iterator wvci;
-    for(wvci i = lineage_.begin(); i != lineage_.end(); ++i)
+    for(auto pw: lineage_)
         {
-        wxWindow* pw = *i;
         LMI_ASSERT(nullptr != pw);
         Transferor* t = dynamic_cast<Transferor*>(pw->GetValidator());
         if(t)
@@ -521,20 +509,16 @@ void MvcController::RefocusLastFocusedWindow()
 
 void MvcController::TestModelViewConsistency() const
 {
-    std::vector<std::string> const& mn = model_.Names();
-    typedef std::vector<std::string>::const_iterator svci;
-    for(svci i = mn.begin(); i != mn.end(); ++i)
+    for(auto const& mn: model_.Names())
         {
-        if(!FindWindow(wxXmlResource::GetXRCID(i->c_str())))
+        if(!FindWindow(wxXmlResource::GetXRCID(mn.c_str())))
             {
-            warning() << "No View entity matches '" << *i << "'.\n";
+            warning() << "No View entity matches '" << mn << "'.\n";
             }
         }
 
-    typedef std::vector<wxWindow*>::const_iterator wvci;
-    for(wvci i = lineage_.begin(); i != lineage_.end(); ++i)
+    for(auto pw: lineage_)
         {
-        wxWindow* pw = *i;
         if
             (   pw->AcceptsFocus()
             &&  !dynamic_cast<Transferor*>(pw->GetValidator())
@@ -823,11 +807,10 @@ void MvcController::UponUpdateUI(wxUpdateUIEvent& event)
     DiagnosticsWindow().SetLabel("");
     std::vector<std::string> control_changes;
     std::string const name_to_ignore = NameOfControlToDeferEvaluating();
-    typedef std::map<std::string,std::string>::const_iterator smci;
-    for(smci i = transfer_data_.begin(); i != transfer_data_.end(); ++i)
+    for(auto const& i: transfer_data_)
         {
-        std::string const& name        = i->first;
-        std::string const& view_value  = i->second;
+        std::string const& name        = i.first;
+        std::string const& view_value  = i.second;
         std::string const& model_value = model_.Entity(name).str();
         if(name == name_to_ignore || ModelAndViewValuesEquivalent(name))
             {
@@ -854,10 +837,9 @@ void MvcController::UponUpdateUI(wxUpdateUIEvent& event)
     if(1 < control_changes.size())
         {
         warning() << "Contents of more than one control changed.\n";
-        typedef std::vector<std::string>::const_iterator svci;
-        for(svci i = control_changes.begin(); i != control_changes.end(); ++i)
+        for(auto const& change: control_changes)
             {
-            warning() << *i;
+            warning() << change;
             }
         warning() << LMI_FLUSH;
         }

--- a/mvc_model.cpp
+++ b/mvc_model.cpp
@@ -171,11 +171,10 @@ void MvcModel::Harmonize()
 
 void MvcModel::Transmogrify()
 {
-    typedef NamesType::const_iterator ntci;
-    for(ntci i = Names().begin(); i != Names().end(); ++i)
+    for(auto const& name: Names())
         {
-        DoEnforceCircumscription(*i);
-        DoEnforceProscription   (*i);
+        DoEnforceCircumscription(name);
+        DoEnforceProscription   (name);
         }
     DoTransmogrify();
 }

--- a/path_utility.hpp
+++ b/path_utility.hpp
@@ -26,6 +26,7 @@
 
 #include "so_attributes.hpp"
 
+#include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
 
 #include <ostream>
@@ -67,6 +68,16 @@ namespace filesystem
 inline std::ostream& operator<<(std::ostream& os, fs::path const& z)
 {
     return os << z.string();
+}
+
+inline directory_iterator begin(directory_iterator iter)
+{
+    return iter;
+}
+
+inline directory_iterator end(directory_iterator const&)
+{
+    return directory_iterator();
 }
 
 } // namespace filesystem

--- a/policy_document.cpp
+++ b/policy_document.cpp
@@ -96,14 +96,9 @@ void PolicyDocument::ReadDocument(std::string const& filename)
     if(!GetViews().empty())
         {
         PolicyView& view = PredominantView();
-        for
-            (values_type::iterator it = values_.begin()
-            ,end = values_.end()
-            ;it != end
-            ;++it
-            )
+        for(auto const& value: values_)
             {
-            view.controls()[it->first]->SetValue(*it->second);
+            view.controls()[value.first]->SetValue(*value.second);
             }
         }
 }
@@ -113,14 +108,9 @@ void PolicyDocument::WriteDocument(std::string const& filename)
     if(!GetViews().empty())
         {
         PolicyView& view = PredominantView();
-        for
-            (values_type::iterator it = values_.begin()
-            ,end = values_.end()
-            ;it != end
-            ;++it
-            )
+        for(auto& value: values_)
             {
-            *it->second = view.controls()[it->first]->GetValue();
+            *value.second = view.controls()[value.first]->GetValue();
             }
         }
     save(product_data_, filename);

--- a/policy_view.cpp
+++ b/policy_view.cpp
@@ -54,17 +54,11 @@ wxWindow* PolicyView::CreateChildWindow()
         fatal_error() << "Unable to load xml resource." << LMI_FLUSH;
         }
 
-    typedef PolicyDocument::values_type::const_iterator value_const_iterator;
-    for
-        (value_const_iterator cit = document().values().begin()
-        ,end = document().values().end()
-        ;cit != end
-        ;++cit
-        )
+    for(auto const& value: document().values())
         {
         wxTextCtrl* text_ctrl = dynamic_cast<wxTextCtrl*>
             (wxWindow::FindWindowById
-                (wxXmlResource::GetXRCID(cit->first.c_str())
+                (wxXmlResource::GetXRCID(value.first.c_str())
                 ,frame
                 )
             );
@@ -72,12 +66,12 @@ wxWindow* PolicyView::CreateChildWindow()
             {
             fatal_error()
                 << "Required text control '"
-                << cit->first
+                << value.first
                 << "' not found."
                 << LMI_FLUSH
                 ;
             }
-        controls_[cit->first] = text_ctrl;
+        controls_[value.first] = text_ctrl;
         }
 
     return main_panel;
@@ -100,14 +94,9 @@ PolicyDocument& PolicyView::document() const
 
 bool PolicyView::IsModified() const
 {
-    for
-        (controls_type::const_iterator it = controls().begin()
-        ,end = controls().end()
-        ;it != end
-        ;++it
-        )
+    for(auto const& it: controls())
         {
-        if(it->second->IsModified())
+        if(it.second->IsModified())
             {
             return true;
             }
@@ -117,13 +106,8 @@ bool PolicyView::IsModified() const
 
 void PolicyView::DiscardEdits()
 {
-    for
-        (controls_type::iterator it = controls().begin()
-        ,end = controls().end()
-        ;it != end
-        ;++it
-        )
+    for(auto& it: controls())
         {
-        it->second->DiscardEdits();
+        it.second->DiscardEdits();
         }
 }

--- a/preferences_model.cpp
+++ b/preferences_model.cpp
@@ -190,21 +190,20 @@ void PreferencesModel::DoHarmonize()
     weird_report_columns.push_back(mce_current_0_cash_surrender_value             );
     weird_report_columns.push_back(mce_guaranteed_0_cash_surrender_value          );
 
-    typedef std::vector<mcenum_report_column>::const_iterator vrci;
-    for(vrci i = weird_report_columns.begin(); i != weird_report_columns.end(); ++i)
+    for(auto c: weird_report_columns)
         {
-        CalculationSummaryColumn00.allow(*i, false);
-        CalculationSummaryColumn01.allow(*i, false);
-        CalculationSummaryColumn02.allow(*i, false);
-        CalculationSummaryColumn03.allow(*i, false);
-        CalculationSummaryColumn04.allow(*i, false);
-        CalculationSummaryColumn05.allow(*i, false);
-        CalculationSummaryColumn06.allow(*i, false);
-        CalculationSummaryColumn07.allow(*i, false);
-        CalculationSummaryColumn08.allow(*i, false);
-        CalculationSummaryColumn09.allow(*i, false);
-        CalculationSummaryColumn10.allow(*i, false);
-        CalculationSummaryColumn11.allow(*i, false);
+        CalculationSummaryColumn00.allow(c, false);
+        CalculationSummaryColumn01.allow(c, false);
+        CalculationSummaryColumn02.allow(c, false);
+        CalculationSummaryColumn03.allow(c, false);
+        CalculationSummaryColumn04.allow(c, false);
+        CalculationSummaryColumn05.allow(c, false);
+        CalculationSummaryColumn06.allow(c, false);
+        CalculationSummaryColumn07.allow(c, false);
+        CalculationSummaryColumn08.allow(c, false);
+        CalculationSummaryColumn09.allow(c, false);
+        CalculationSummaryColumn10.allow(c, false);
+        CalculationSummaryColumn11.allow(c, false);
         }
 }
 

--- a/print_matrix.hpp
+++ b/print_matrix.hpp
@@ -94,9 +94,9 @@ void print_matrix
     for(std::size_t j = 0; j < data.size(); ++j)
         {
         os << '\t' << value_cast<std::string>(data[j]);
-        for(std::size_t k = 0; k < moduli.size(); ++k)
+        for(auto m: moduli)
             {
-            if(0 == (1 + j) % moduli[k])
+            if(0 == (1 + j) % m)
                 {
                 os << '\n';
                 }

--- a/product_data.cpp
+++ b/product_data.cpp
@@ -531,10 +531,9 @@ void product_data::write_policy_files()
 
     // 'sample2' product
 
-    typedef std::vector<std::string>::const_iterator svci;
-    for(svci i = z.member_names().begin(); i != z.member_names().end(); ++i)
+    for(auto const& mn: z.member_names())
         {
-        z[*i] = '{' + *i + '}';
+        z[mn] = '{' + mn + '}';
         }
 
     // Names of lmi product files.

--- a/regex_test.cpp
+++ b/regex_test.cpp
@@ -163,10 +163,9 @@ bool contains_regex0(std::string const& regex)
 bool contains_regex1(std::string const& regex)
 {
     boost::regex const r(regex, boost::regex::sed);
-    typedef std::vector<std::string>::const_iterator vsi;
-    for(vsi i = lines.begin(); i != lines.end(); ++i)
+    for(auto const& line: lines)
         {
-        if(boost::regex_search(*i, r))
+        if(boost::regex_search(line, r))
             {
             return true;
             }
@@ -223,12 +222,11 @@ char never[] = "lord";
 void test_psalm_37()
 {
     lines = vectorize(original);
-    typedef std::vector<std::string>::iterator vsi;
-    for(vsi i = lines.begin(); i != lines.end(); ++i)
+    for(auto const& line: lines)
         {
         for(int j = 0; j < 10; ++j)
             {
-            text += *i + '\n';
+            text += line + '\n';
             }
         }
     lines = vectorize(text);

--- a/rounding_document.cpp
+++ b/rounding_document.cpp
@@ -76,10 +76,9 @@ void RoundingDocument::ReadDocument(std::string const& filename)
     if(!GetViews().empty())
         {
         RoundingView& view = PredominantView();
-        typedef values_type::const_iterator vtci;
-        for(vtci i = values_.begin(); i != values_.end(); ++i)
+        for(auto const& value: values_)
             {
-            view.controls()[i->first]->SetValue(*i->second);
+            view.controls()[value.first]->SetValue(*value.second);
             }
         }
 }
@@ -89,10 +88,9 @@ void RoundingDocument::WriteDocument(std::string const& filename)
     if(!GetViews().empty())
         {
         RoundingView& view = PredominantView();
-        typedef values_type::const_iterator vtci;
-        for(vtci i = values_.begin(); i != values_.end(); ++i)
+        for(auto& value: values_)
             {
-            *i->second = view.controls()[i->first]->GetValue();
+            *value.second = view.controls()[value.first]->GetValue();
             }
         }
     save(rounding_rules_, filename);

--- a/rounding_view.cpp
+++ b/rounding_view.cpp
@@ -54,17 +54,11 @@ wxWindow* RoundingView::CreateChildWindow()
         fatal_error() << "Unable to load xml resource." << LMI_FLUSH;
         }
 
-    typedef RoundingDocument::values_type::const_iterator value_const_iterator;
-    for
-        (value_const_iterator cit = document().values().begin()
-        ,end = document().values().end()
-        ;cit != end
-        ;++cit
-        )
+    for(auto const& value: document().values())
         {
         RoundingButtons* control = dynamic_cast<RoundingButtons*>
             (wxWindow::FindWindowById
-                (wxXmlResource::GetXRCID(cit->first.c_str())
+                (wxXmlResource::GetXRCID(value.first.c_str())
                 ,frame
                 )
             );
@@ -72,12 +66,12 @@ wxWindow* RoundingView::CreateChildWindow()
             {
             fatal_error()
                 << "Required text control '"
-                << cit->first
+                << value.first
                 << "' not found."
                 << LMI_FLUSH
                 ;
             }
-        controls_[cit->first] = control;
+        controls_[value.first] = control;
         }
     return main_panel;
 }
@@ -99,14 +93,9 @@ RoundingDocument& RoundingView::document() const
 
 bool RoundingView::IsModified() const
 {
-    for
-        (controls_type::const_iterator it = controls().begin()
-        ,end = controls().end()
-        ;it != end
-        ;++it
-        )
+    for(auto const& it: controls())
         {
-        if(it->second->IsModified())
+        if(it.second->IsModified())
             {
             return true;
             }

--- a/single_cell_document.cpp
+++ b/single_cell_document.cpp
@@ -152,16 +152,13 @@ bool single_cell_document::data_source_is_external(xml::document const& d) const
     // INPUT !! Remove "InforceDataSource" and the following code when
     // external systems are updated to use the "data_source" attribute.
 
-    typedef xml::const_nodes_view::const_iterator cnvi;
-
     xml::const_nodes_view const i_nodes(root.elements("cell"));
     LMI_ASSERT(1 == i_nodes.size());
-    for(cnvi i = i_nodes.begin(); i != i_nodes.end(); ++i)
+    for(auto const& i_node: i_nodes)
         {
-        xml::const_nodes_view const j_nodes(i->elements("InforceDataSource"));
-        for(cnvi j = j_nodes.begin(); j != j_nodes.end(); ++j)
+        for(auto const& j_node: i_node.elements("InforceDataSource"))
             {
-            std::string s(xml_lmi::get_content(*j));
+            std::string s(xml_lmi::get_content(j_node));
             if("0" != s && "1" != s)
                 {
                 return true;

--- a/skeleton.cpp
+++ b/skeleton.cpp
@@ -821,10 +821,9 @@ void Skeleton::UponMenuOpen(wxMenuEvent& event)
     if(child_frame)
         {
         bool has_multiple_mdi_children = false;
-        wxWindowList const& wl = frame_->GetChildren();
-        for(wxWindowList::const_iterator i = wl.begin(); i != wl.end(); ++i)
+        for(auto w: frame_->GetChildren())
             {
-            wxMDIChildFrame const*const child = dynamic_cast<wxMDIChildFrame*>(*i);
+            wxMDIChildFrame const*const child = dynamic_cast<wxMDIChildFrame*>(w);
             if(child && child != child_frame)
                 {
                 has_multiple_mdi_children = true;
@@ -860,15 +859,14 @@ namespace
         new_text.reserve(original_text.size());
 
         std::insert_iterator<std::string> j(new_text, new_text.begin());
-        typedef std::string::const_iterator sci;
-        for(sci i = original_text.begin(); i != original_text.end(); ++i)
+        for(char c: original_text)
             {
-            switch(*i)
+            switch(c)
                 {
                 case '\n': {*j++ = ';';} break;
                 case '\r': {           } break;
                 case '\t': {*j++ = ';';} break;
-                default  : {*j++ =  *i;}
+                default  : {*j++ =   c;}
                 }
             }
 
@@ -1368,14 +1366,13 @@ void Skeleton::OpenCommandLineFiles(std::vector<std::string> const& files)
 {
     LMI_ASSERT(doc_manager_);
 
-    typedef std::vector<std::string>::const_iterator vsci;
-    for(vsci i = files.begin(); i != files.end(); ++i)
+    for(auto const& file: files)
         {
-        if(!doc_manager_->CreateDocument(*i, wxDOC_SILENT))
+        if(!doc_manager_->CreateDocument(file, wxDOC_SILENT))
             {
             warning()
                 << "Document '"
-                << *i
+                << file
                 << "' specified on command line couldn't be opened."
                 << LMI_FLUSH
                 ;
@@ -1386,10 +1383,9 @@ void Skeleton::OpenCommandLineFiles(std::vector<std::string> const& files)
 void Skeleton::UpdateViews()
 {
     wxBusyCursor wait;
-    wxWindowList const& wl = frame_->GetChildren();
-    for(wxWindowList::const_iterator i = wl.begin(); i != wl.end(); ++i)
+    for(auto w: frame_->GetChildren())
         {
-        wxDocMDIChildFrame const* c = dynamic_cast<wxDocMDIChildFrame*>(*i);
+        wxDocMDIChildFrame const* c = dynamic_cast<wxDocMDIChildFrame*>(w);
         if(c)
             {
             IllustrationView* v = dynamic_cast<IllustrationView*>(c->GetView());

--- a/test_coding_rules.cpp
+++ b/test_coding_rules.cpp
@@ -965,16 +965,14 @@ void enforce_taboos(file const& f)
         )
         {
         // Unspeakable private taboos.
-        std::map<std::string, bool> const z = my_taboos();
-        typedef std::map<std::string, bool>::const_iterator mci;
-        for(mci i = z.begin(); i != z.end(); ++i)
+        for(auto const& i: my_taboos())
             {
             boost::regex::flag_type syntax =
-                i->second
+                i.second
                 ? boost::regex::ECMAScript | boost::regex::icase
                 : boost::regex::ECMAScript
                 ;
-            taboo(f, i->first, syntax);
+            taboo(f, i.first, syntax);
             }
         }
 }

--- a/tier_document.cpp
+++ b/tier_document.cpp
@@ -51,11 +51,9 @@ void TierDocument::initialize_charges()
         (std::vector<double>(1, infinity<double>()) // limits
         ,std::vector<double>(1,                0.0) // values
         );
-    std::vector<std::string> const& v = charges_.member_names();
-    typedef std::vector<std::string>::const_iterator svci;
-    for(svci i = v.begin(); i != v.end(); ++i)
+    for(auto const& mn: charges_.member_names())
         {
-        charges_.datum(*i) = dummy_entity;
+        charges_.datum(mn) = dummy_entity;
         }
 }
 

--- a/tier_view.cpp
+++ b/tier_view.cpp
@@ -122,14 +122,12 @@ MultiDimGrid* TierView::CreateGridCtrl(wxWindow* parent)
 
 void TierView::SetupControls()
 {
-    std::vector<tier_entity_info> const& entities = get_tier_entity_infos();
     std::map<e_stratified, wxTreeItemId> index_to_id;
 
     wxTreeCtrl& tree_ctrl = tree();
 
-    for(std::size_t i = 0; i < entities.size(); ++i)
+    for(auto const& entity: get_tier_entity_infos())
         {
-        tier_entity_info const& entity = entities[i];
         if(entity.index == entity.parent_index)
             {
             wxTreeItemId id = tree_ctrl.AddRoot("");

--- a/view_ex.tpp
+++ b/view_ex.tpp
@@ -63,10 +63,8 @@ template<typename ViewType>
 ViewType& PredominantView(wxDocument const& document)
 {
     ViewType* view = nullptr;
-    wxList const& views = document.GetViews();
-    for(wxList::const_iterator i = views.begin(); i != views.end(); ++i)
+    for(auto p: document.GetViews())
         {
-        wxObject* p = *i;
         LMI_ASSERT(nullptr != p);
         if(p->IsKindOf(CLASSINFO(ViewType)))
             {

--- a/wx_table_generator.cpp
+++ b/wx_table_generator.cpp
@@ -160,21 +160,20 @@ void wx_table_generator::do_compute_column_widths_if_necessary()
     int num_expand = 0;
     int total_fixed = 0;
 
-    typedef std::vector<column_info>::const_iterator cici;
-    for(cici i = columns_.begin(); i != columns_.end(); ++i)
+    for(auto const& ci: columns_)
         {
-        if(i->is_hidden())
+        if(ci.is_hidden())
             {
             continue;
             }
 
-        if(0 == i->width_)
+        if(0 == ci.width_)
             {
             num_expand++;
             }
         else
             {
-            total_fixed += i->width_;
+            total_fixed += ci.width_;
             }
         }
 
@@ -189,17 +188,16 @@ void wx_table_generator::do_compute_column_widths_if_necessary()
         int const per_expand
             = (total_width_ - total_fixed + num_expand - 1)/num_expand;
 
-        typedef std::vector<column_info>::iterator cii;
-        for(cii i = columns_.begin(); i != columns_.end(); ++i)
+        for(auto& column: columns_)
             {
-            if(i->is_hidden())
+            if(column.is_hidden())
                 {
                 continue;
                 }
 
-            if(0 == i->width_)
+            if(0 == column.width_)
                 {
-                i->width_ = per_expand;
+                column.width_ = per_expand;
                 }
             }
         }

--- a/wx_table_generator.cpp
+++ b/wx_table_generator.cpp
@@ -188,16 +188,16 @@ void wx_table_generator::do_compute_column_widths_if_necessary()
         int const per_expand
             = (total_width_ - total_fixed + num_expand - 1)/num_expand;
 
-        for(auto& column: columns_)
+        for(auto& ci: columns_)
             {
-            if(column.is_hidden())
+            if(ci.is_hidden())
                 {
                 continue;
                 }
 
-            if(0 == column.width_)
+            if(0 == ci.width_)
                 {
-                column.width_ = per_expand;
+                ci.width_ = per_expand;
                 }
             }
         }

--- a/wx_test_about_version.cpp
+++ b/wx_test_about_version.cpp
@@ -83,25 +83,23 @@ int year_from_string(wxString const& s)
 int extract_last_copyright_year(wxString const& html)
 {
     // Find the line starting with "Copyright".
-    wxArrayString const lines = wxSplit(html ,'\n' ,'\0');
-
-    wxString line;
-    for(wxArrayString::const_iterator i = lines.begin(); i != lines.end(); ++i)
+    wxString copyright_line;
+    for(auto const& line: wxSplit(html ,'\n' ,'\0'))
         {
-        if(i->StartsWith("Copyright"))
+        if(line.StartsWith("Copyright"))
             {
             LMI_ASSERT_WITH_MSG
-                (line.empty()
+                (copyright_line.empty()
                 ,"Unexpectedly found more than one copyright line in the "
                  "license notices text"
                 );
 
-            line = *i;
+            copyright_line = line;
             }
         }
 
     LMI_ASSERT_WITH_MSG
-        (!line.empty()
+        (!copyright_line.empty()
         ,"Copyright line not found in the license notices text"
         );
 
@@ -116,15 +114,15 @@ int extract_last_copyright_year(wxString const& html)
     // and notably not with MinGW 3.4. As we are only interested in matching
     // ASCII characters such as digits, using UTF-8 is safe even though
     // boost::regex has no real support for it.
-    std::string const line_utf8(line.utf8_str());
+    std::string const copyright_line_utf8(copyright_line.utf8_str());
     boost::smatch m;
     LMI_ASSERT_WITH_MSG
         (boost::regex_search
-            (line_utf8
+            (copyright_line_utf8
             ,m
             ,boost::regex("(?:\\d{4}, )+(\\d{4})")
             )
-        ,"Copyright line \"" + line + "\" doesn't contain copyright years"
+        ,"Copyright line \"" + copyright_line + "\" doesn't contain copyright years"
         );
 
     return year_from_string(wxString(m[1]));
@@ -137,10 +135,9 @@ int extract_last_copyright_year(wxString const& html)
 wxHtmlWindow* find_html_window(wxWindow* parent, std::string const& dialog_name)
 {
     wxHtmlWindow* html_win = nullptr;
-    wxWindowList const& wl = parent->GetChildren();
-    for(wxWindowList::const_iterator i = wl.begin(); i != wl.end(); ++i)
+    for(auto w: parent->GetChildren())
         {
-        wxHtmlWindow* const maybe_html_win = dynamic_cast<wxHtmlWindow*>(*i);
+        wxHtmlWindow* const maybe_html_win = dynamic_cast<wxHtmlWindow*>(w);
         if(maybe_html_win)
             {
             LMI_ASSERT_WITH_MSG

--- a/wx_test_benchmark_census.cpp
+++ b/wx_test_benchmark_census.cpp
@@ -22,6 +22,7 @@
 #include "pchfile_wx.hpp"
 
 #include "assert_lmi.hpp"
+#include "path_utility.hpp"
 #include "wx_test_case.hpp"
 #include "wx_test_statusbar.hpp"
 #include "uncopyable_lmi.hpp"
@@ -32,8 +33,6 @@
 #include <wx/scopeguard.h>
 #include <wx/testing.h>
 #include <wx/uiaction.h>
-
-#include <boost/filesystem/operations.hpp>
 
 #include <cmath>                        // std::fabs()
 
@@ -133,7 +132,7 @@ class census_benchmark
 LMI_WX_TEST_CASE(benchmark_census)
 {
     fs::directory_iterator const end_i;
-    for(fs::path const& p: get_test_files_path())
+    for(fs::path const& p: fs::directory_iterator(get_test_files_path()))
         {
         if(!wxString(p.leaf()).Matches("MSEC*.cns"))
             {

--- a/wx_test_benchmark_census.cpp
+++ b/wx_test_benchmark_census.cpp
@@ -133,14 +133,14 @@ class census_benchmark
 LMI_WX_TEST_CASE(benchmark_census)
 {
     fs::directory_iterator const end_i;
-    for(fs::directory_iterator i(get_test_files_path()); i != end_i; ++i)
+    for(fs::path const& p: get_test_files_path())
         {
-        if(!wxString(i->leaf()).Matches("MSEC*.cns"))
+        if(!wxString(p.leaf()).Matches("MSEC*.cns"))
             {
             continue;
             }
 
-        census_benchmark b(*i);
+        census_benchmark b(p);
 
         {
         // Ensure that the window doesn't stay opened (and possibly affects

--- a/wx_test_input_sequences.cpp
+++ b/wx_test_input_sequences.cpp
@@ -161,10 +161,10 @@ LMI_WX_TEST_CASE(input_sequences)
     };
 
     wxUIActionSimulator ui;
-    for(std::size_t n = 0; n < sizeof test_cases / sizeof(test_cases[0]); n++)
+    for(auto const& test_case: test_cases)
         {
         ui.Char('e', wxMOD_CONTROL); // "Illustration|Edit Cell"
-        wxTEST_DIALOG(wxYield(), test_sequence_dialog(test_cases[n]));
+        wxTEST_DIALOG(wxYield(), test_sequence_dialog(test_case));
         }
 
     ill.close_discard_changes();

--- a/wx_test_input_validation.cpp
+++ b/wx_test_input_validation.cpp
@@ -133,10 +133,8 @@ LMI_WX_TEST_CASE(input_validation)
         char const* const value_;
     };
 
-    for(std::size_t n = 0; n < sizeof test_cases / sizeof(test_cases[0]); n++)
+    for(auto const& td: test_cases)
         {
-        coi_multiplier_test_data const& td = test_cases[n];
-
         // This flag is used to assert that all expected exceptions were
         // generated at the end of the loop. The reason for using it instead of
         // just asserting directly inside the "try" statement is that failing

--- a/wx_test_paste_census.cpp
+++ b/wx_test_paste_census.cpp
@@ -93,15 +93,16 @@ std::string build_not_found_message(std::set<std::string> const& remaining)
     bool const only_one = remaining.size() == 1;
     message << (only_one ? "column" : "columns");
 
-    typedef std::set<std::string>::const_iterator ssci;
-    for(ssci i = remaining.begin(); i != remaining.end(); ++i)
+    bool first = true;
+    for(auto const& s: remaining)
         {
-        if(i != remaining.begin())
+        if(!first)
             {
             message << ",";
+            first = false;
             }
 
-        message << " '" << *i << "'";
+        message << " '" << s << "'";
         }
 
     message << " " << (only_one ? "was" : "were") << " not found" << " ";

--- a/wx_utility.cpp
+++ b/wx_utility.cpp
@@ -231,10 +231,8 @@ void EnumerateLineage
     ,std::vector<wxWindow*>& v
     )
 {
-    wxWindowList const& wl = w->GetChildren();
-    for(wxWindowList::const_iterator i = wl.begin(); i != wl.end(); ++i)
+    for(auto c: w->GetChildren())
         {
-        wxWindow* c = *i;
         LMI_ASSERT(nullptr != c);
         v.push_back(c);
         EnumerateLineage(c, v);

--- a/xml_lmi.cpp
+++ b/xml_lmi.cpp
@@ -278,15 +278,14 @@ std::string get_content(xml::element const& element)
     try
         {
         std::string s;
-        typedef xml::node::const_iterator NodeConstIterator;
-        for(NodeConstIterator i = element.begin(); i != element.end(); ++i)
+        for(auto const& node: element)
             {
-            if(i->is_text())
+            if(node.is_text())
                 {
-                char const* content = i->get_content();
+                char const* content = node.get_content();
                 if(content)
                     {
-                    s += i->get_content();
+                    s += node.get_content();
                     }
                 }
             }

--- a/xml_serializable.tpp
+++ b/xml_serializable.tpp
@@ -108,11 +108,9 @@ void xml_serializable<T>::read(xml::element const& x)
         );
     std::list<std::string>::iterator current_member;
 
-    xml::const_nodes_view const elements(x.elements());
-    typedef xml::const_nodes_view::const_iterator cnvi;
-    for(cnvi child = elements.begin(); child != elements.end(); ++child)
+    for(auto const& child: x.elements())
         {
-        std::string node_tag(child->get_name());
+        std::string node_tag(child.get_name());
         current_member = std::find
             (residuary_names.begin()
             ,residuary_names.end()
@@ -120,13 +118,13 @@ void xml_serializable<T>::read(xml::element const& x)
             );
         if(residuary_names.end() != current_member)
             {
-            read_element(*child, node_tag, file_version);
+            read_element(child, node_tag, file_version);
             residuary_names.erase(current_member);
             }
         else if(is_detritus(node_tag))
             {
             // Hold certain obsolete entities that must be translated.
-            value_type v = fetch_element(*child);
+            value_type v = fetch_element(child);
             redintegrate_ex_ante(file_version, node_tag, v);
             detritus_map[node_tag] = v;
             }

--- a/xml_serialize.hpp
+++ b/xml_serialize.hpp
@@ -92,13 +92,12 @@ struct xml_sequence_io
     {
         // XMLWRAPP !! Add a clear() function.
         e.erase(e.begin(), e.end());
-        typedef typename T::const_iterator tci;
-        for(tci i = t.begin(); i != t.end(); ++i)
+        for(auto const& x: t)
             {
             // This is not equivalent to calling set_element():
             // multiple <item> elements are expressly permitted.
             xml::element z("item");
-            xml_io<item_t>::to_xml(z, *i);
+            xml_io<item_t>::to_xml(z, x);
             e.push_back(z);
             }
     }
@@ -106,12 +105,10 @@ struct xml_sequence_io
     static void from_xml(xml::element const& e, T& t)
     {
         t.clear();
-        xml::const_nodes_view const items(e.elements("item"));
-        typedef xml::const_nodes_view::const_iterator cnvi;
-        for(cnvi i = items.begin(); i != items.end(); ++i)
+        for(auto const& element: e.elements("item"))
             {
             item_t z;
-            xml_io<item_t>::from_xml(*i, z);
+            xml_io<item_t>::from_xml(element, z);
             t.push_back(z);
             }
     }


### PR DESCRIPTION
The first commit contains changes mostly done automatically by clang-tidy and which should be completely safe to apply. The second one contains the changes done manually and so is more complicated and potentially error-prone.