### PR TITLE
Allow lmi to compile with wxNO_UNSAFE_WXSTRING_CONV

### DIFF
--- a/group_quote_pdf_gen_wx.cpp
+++ b/group_quote_pdf_gen_wx.cpp
@@ -545,7 +545,7 @@ class group_quote_pdf_generator_wx
         std::string premium_mode_;
         std::string contract_state_;
         std::string effective_date_;
-        std::string footer_;
+        wxString    footer_html_;
 
         // Dynamically-determined fields.
         std::string elected_riders_;
@@ -700,7 +700,7 @@ void group_quote_pdf_generator_wx::global_report_data::fill_global_report_data
     effective_date_   = ConvertDateToWx(eff_date).FormatDate().ToStdString();
     // Deliberately begin the footer with <br> tags, to separate it
     // from the logo right above it.
-    footer_ =
+    footer_html_ =
           brbr (invar.GroupQuoteIsNotAnOffer)
         + brbr (invar.GroupQuoteRidersFooter)
         + brbr (elected_riders_footnote_)
@@ -801,7 +801,7 @@ void group_quote_pdf_generator_wx::add_ledger(Ledger const& ledger)
                 {
                 rd.values[col] = ConvertDateToWx
                     (jdn_t(static_cast<int>(invar.DateOfBirthJdn))
-                    ).FormatDate();
+                    ).FormatDate().ToStdString(wxConvUTF8);
                 }
                 break;
             case e_col_basic_face_amount:
@@ -1424,7 +1424,7 @@ void group_quote_pdf_generator_wx::output_footer
         *pos_y += vert_skip;
         }
 
-    wxString const footer_html = "<p>" + report_data_.footer_ + "</p>";
+    wxString const footer_html = "<p>" + report_data_.footer_html_ + "</p>";
 
     *pos_y += output_html
         (html_parser

--- a/input_sequence_entry.cpp
+++ b/input_sequence_entry.cpp
@@ -1541,7 +1541,7 @@ void InputSequenceEntry::DoOpenEditor()
     // close to user's point of attention and the mouse cursor.
     InputSequenceEditor editor(button_, title_, in);
 
-    std::string sequence_string = std::string(text_->GetValue());
+    std::string sequence_string = text_->GetValue().ToStdString(wxConvUTF8);
     datum_sequence const& ds = *member_cast<datum_sequence>(in[field_name()]);
 
     std::map<std::string,std::string> const kwmap = ds.allowed_keywords();

--- a/multidimgrid_any.cpp
+++ b/multidimgrid_any.cpp
@@ -1170,7 +1170,7 @@ void MultiDimGrid::SetValue(int row, int col, wxString const& value)
         DoSetValue
             (EnsureIndexIsPositive(row)
             ,EnsureIndexIsPositive(col)
-            ,std::string(value)
+            ,value.ToStdString(wxConvUTF8)
             );
         }
     catch(std::exception const& e)
@@ -1376,7 +1376,7 @@ void MultiDimAxisAnyChoice::PopulateChoiceList()
     int const selection = GetSelection();
     std::string const selected_label =
         selection != wxNOT_FOUND
-        ? std::string(GetString(selection))
+        ? GetString(selection).ToStdString(wxConvUTF8)
         : std::string()
         ;
 

--- a/policy_document.cpp
+++ b/policy_document.cpp
@@ -110,7 +110,7 @@ void PolicyDocument::WriteDocument(std::string const& filename)
         PolicyView& view = PredominantView();
         for(auto const& i : values_)
             {
-            *i.second = view.controls()[i.first]->GetValue();
+            *i.second = view.controls()[i.first]->GetValue().ToStdString(wxConvUTF8);
             }
         }
     save(product_data_, filename);

--- a/product_editor.cpp
+++ b/product_editor.cpp
@@ -73,7 +73,7 @@ bool ProductEditorDocument::DoOpenDocument(wxString const& filename)
 {
     try
         {
-        ReadDocument(std::string(filename));
+        ReadDocument(filename.ToStdString(wxConvUTF8));
         return true;
         }
     catch(std::exception const& e)
@@ -95,7 +95,7 @@ bool ProductEditorDocument::DoSaveDocument(wxString const& filename)
 {
     try
         {
-        WriteDocument(std::string(filename));
+        WriteDocument(filename.ToStdString(wxConvUTF8));
         return true;
         }
     catch(std::exception const& e)

--- a/rounding_view_editor.cpp
+++ b/rounding_view_editor.cpp
@@ -179,7 +179,7 @@ void RoundingButtons::Create
     ,wxPoint const&     pos
     ,wxSize const&      size
     ,long               style
-    ,std::string const& name
+    ,wxString const&    name
     )
 {
     wxPanel::Create(parent, id, pos, size, style, name);
@@ -379,7 +379,7 @@ wxObject* RoundingButtonsXmlHandler::DoCreateResource()
         ,GetPosition()
         ,GetSize()
         ,GetStyle()
-        ,std::string(GetName())
+        ,GetName()
         );
 
     SetupWindow(control);

--- a/rounding_view_editor.hpp
+++ b/rounding_view_editor.hpp
@@ -56,7 +56,7 @@ class RoundingButtons
         ,wxPoint const&     pos   = wxDefaultPosition
         ,wxSize const&      size  = wxDefaultSize
         ,long               style = 0
-        ,std::string const& name  = wxPanelNameStr
+        ,wxString const&    name  = wxPanelNameStr
         );
 
     bool IsModified() const;

--- a/transferor.cpp
+++ b/transferor.cpp
@@ -222,7 +222,7 @@ namespace
             }
         else
             {
-            data = control.GetLabel();
+            data = control.GetLabel().ToStdString(wxConvUTF8);
             }
         return true;
     }
@@ -303,7 +303,7 @@ namespace
             // suppressed if living with that problem is acceptable.
 #   error Outdated library: wx-2.6.2 or greater is required.
 #endif // !wxCHECK_VERSION(2,6,2)
-            data = control.GetStringSelection();
+            data = control.GetStringSelection().ToStdString(wxConvUTF8);
             }
         return true;
     }
@@ -462,7 +462,7 @@ namespace
             }
         else
             {
-            data = control.GetValue();
+            data = control.GetValue().ToStdString(wxConvUTF8);
             }
         return true;
     }

--- a/view_ex.cpp
+++ b/view_ex.cpp
@@ -214,7 +214,7 @@ void ViewEx::OnDraw(wxDC*)
 
 std::string ViewEx::base_filename() const
 {
-    std::string t(GetDocument()->GetUserReadableName());
+    std::string t(GetDocument()->GetUserReadableName().ToStdString(wxConvUTF8));
     fs::path path(t);
     return path.has_leaf() ? path.leaf() : std::string("Hastur");
 }

--- a/wx_utility.cpp
+++ b/wx_utility.cpp
@@ -58,7 +58,7 @@ std::string ClipboardEx::GetText()
 
     wxTextDataObject z;
     wxTheClipboard->GetData(z);
-    std::string s(z.GetText());
+    std::string s(z.GetText().ToStdString(wxConvUTF8));
 
     static std::string const crlf("\r\n");
     static std::string const   lf(  "\n");
@@ -187,7 +187,11 @@ void TestDateConversions()
             }
 
         std::string const lmi_str(lmi_date0.str());
-        std::string const wx_str(ConvertDateToWx(lmi_date0).FormatISODate());
+        std::string const wx_str
+            (ConvertDateToWx(lmi_date0)
+            .FormatISODate()
+            .ToStdString(wxConvUTF8)
+            );
         if(lmi_str != wx_str)
             {
             fatal_error()
@@ -213,7 +217,7 @@ std::vector<std::string> EnumerateBookPageNames(wxBookCtrlBase const& book)
     std::vector<std::string> z;
     for(std::size_t j = 0; j < book.GetPageCount(); ++j)
         {
-        std::string name(book.GetPageText(j));
+        std::string name(book.GetPageText(j).ToStdString(wxConvUTF8));
         LMI_ASSERT(!contains(z, name));
         z.push_back(name);
         }


### PR DESCRIPTION
This series of commits fixes lmi compilation with `wxNO_UNSAFE_WXSTRING_CONV` when using the latest (i.e. including https://github.com/wxWidgets/wxWidgets/commit/e16d899f6b9206a692f6dd8fa8cc1e580d26920b) version of wxWidgets.

Notice that it does _not_ enable the use of `wxNO_UNSAFE_WXSTRING_CONV` yet however.