### PR TITLE
Menu refresh fix

### DIFF
--- a/single_choice_popup_menu.cpp
+++ b/single_choice_popup_menu.cpp
@@ -23,6 +23,7 @@
 
 #include "single_choice_popup_menu.hpp"
 
+#include <wx/evtloop.h>
 #include <wx/window.h>
 
 SingleChoicePopupMenu::SingleChoicePopupMenu
@@ -51,5 +52,15 @@ SingleChoicePopupMenu::SingleChoicePopupMenu
 int SingleChoicePopupMenu::Choose()
 {
     int const selection_index = parent_.GetPopupMenuSelectionFromUser(menu_);
+
+    if (wxEventLoopBase* const loop = wxEventLoopBase::GetActive())
+        {
+        // This function can often be used to get users choice before starting
+        // some time-consuming operation. Ensure that the area previously
+        // covered by the menu shown by GetPopupMenuSelectionFromUser() is
+        // repainted to avoid leaving it invalidated for a possibly long time.
+        loop->YieldFor(wxEVT_CATEGORY_UI);
+        }
+
     return selection_index != wxID_NONE ? selection_index : -1;
 }

--- a/single_choice_popup_menu.cpp
+++ b/single_choice_popup_menu.cpp
@@ -31,7 +31,6 @@ SingleChoicePopupMenu::SingleChoicePopupMenu
     ,wxWindow*            parent
     )
     :wxWindow        (parent, wxID_ANY, wxDefaultPosition, wxSize(0, 0))
-    ,selection_index_(-1)
 {
     if(!title.IsEmpty())
         {
@@ -46,23 +45,11 @@ SingleChoicePopupMenu::SingleChoicePopupMenu
             }
         menu_.Append(j, s);
         }
-    Connect
-        (0
-        ,choices.GetCount()
-        ,wxEVT_COMMAND_MENU_SELECTED
-        ,wxCommandEventHandler(SingleChoicePopupMenu::UponMenuChoice)
-        );
 }
 
 // WX !! Can't be const because PopupMenu() isn't.
 int SingleChoicePopupMenu::Choose()
 {
-    PopupMenu(&menu_);
-    return selection_index_;
+    int const selection_index = GetPopupMenuSelectionFromUser(menu_);
+    return selection_index != wxID_NONE ? selection_index : -1;
 }
-
-void SingleChoicePopupMenu::UponMenuChoice(wxCommandEvent& e)
-{
-    selection_index_ = e.GetId();
-}
-

--- a/single_choice_popup_menu.cpp
+++ b/single_choice_popup_menu.cpp
@@ -23,14 +23,14 @@
 
 #include "single_choice_popup_menu.hpp"
 
-#include <wx/gdicmn.h>                  // wxDefaultPosition, wxSize
+#include <wx/window.h>
 
 SingleChoicePopupMenu::SingleChoicePopupMenu
     (wxArrayString const& choices
     ,wxString const&      title
-    ,wxWindow*            parent
+    ,wxWindow&            parent
     )
-    :wxWindow        (parent, wxID_ANY, wxDefaultPosition, wxSize(0, 0))
+    :parent_(parent)
 {
     if(!title.IsEmpty())
         {
@@ -50,6 +50,6 @@ SingleChoicePopupMenu::SingleChoicePopupMenu
 // WX !! Can't be const because PopupMenu() isn't.
 int SingleChoicePopupMenu::Choose()
 {
-    int const selection_index = GetPopupMenuSelectionFromUser(menu_);
+    int const selection_index = parent_.GetPopupMenuSelectionFromUser(menu_);
     return selection_index != wxID_NONE ? selection_index : -1;
 }

--- a/single_choice_popup_menu.hpp
+++ b/single_choice_popup_menu.hpp
@@ -29,7 +29,6 @@
 #include <wx/arrstr.h>                  // wxArrayString
 #include <wx/menu.h>
 #include <wx/string.h>
-#include <wx/window.h>
 
 /// Design notes for class SingleChoicePopupMenu.
 ///
@@ -41,21 +40,19 @@
 /// the same character as its own accelerator.
 
 class SingleChoicePopupMenu
-    :public wxWindow
 {
   public:
     SingleChoicePopupMenu
         (wxArrayString const& choices
         ,wxString const&      title  = wxEmptyString
-        ,wxWindow*            parent = &TopWindow()
+        ,wxWindow&            parent = TopWindow()
         );
-
-    ~SingleChoicePopupMenu() override = default;
 
     int Choose();
 
   private:
     wxMenu menu_;
+    wxWindow& parent_;
 };
 
 #endif // single_choice_popup_menu_hpp

--- a/single_choice_popup_menu.hpp
+++ b/single_choice_popup_menu.hpp
@@ -55,10 +55,7 @@ class SingleChoicePopupMenu
     int Choose();
 
   private:
-    void UponMenuChoice(wxCommandEvent&);
-
     wxMenu menu_;
-    int selection_index_;
 };
 
 #endif // single_choice_popup_menu_hpp


### PR DESCRIPTION
I'd recommend reviewing this commit-by-commit as the total diff is not very clear.

The first commit should, IMO, definitely be applied as it's just unnecessary to duplicate the functionality already present in wxWidgets.

The second one is a sort of micro-optimization, but could also preserve us from some problems due to showing a menu in an invisible (because using the size 0*0) window, so IMHO it's worth applying too.

Finally, the third one is the one that really fixes the problem. As its commit message says, it could be done in `census_view.cpp` itself, independently of the other two commits, if you'd prefer it.