### PR TITLE
Drop unnecessary empty message in static_assert

### DIFF
--- a/actuarial_table.cpp
+++ b/actuarial_table.cpp
@@ -212,9 +212,9 @@ void actuarial_table::find_table()
     // TODO ?? Assert endianness too? SOA tables are not portable;
     // probably they can easily be read only on x86 hardware.
 
-    static_assert(8 == CHAR_BIT, "");
-    static_assert(4 == sizeof(int), "");
-    static_assert(2 == sizeof(short int), "");
+    static_assert(8 == CHAR_BIT);
+    static_assert(4 == sizeof(int));
+    static_assert(2 == sizeof(short int));
 
     // 27.4.3.2/2 requires that this be interpreted as invalid.
     // Reinitialize it here for robustness, even though the ctor
@@ -224,7 +224,7 @@ void actuarial_table::find_table()
     int const index_record_length(58);
     char index_record[index_record_length] = {0};
 
-    static_assert(sizeof(std::int32_t) <= sizeof(int), "");
+    static_assert(sizeof(std::int32_t) <= sizeof(int));
     while(index_ifs)
         {
         int index_table_number = deserialize_cast<std::int32_t>(index_record);

--- a/alert.cpp
+++ b/alert.cpp
@@ -195,7 +195,7 @@ class alarum_buf
 template<typename T>
 inline std::ostream& alert_stream()
 {
-    static_assert(std::is_base_of<alert_buf,T>::value, "");
+    static_assert(std::is_base_of<alert_buf,T>::value);
     static T buffer_;
     static std::ostream stream_(&buffer_);
     stream_.clear();

--- a/any_member.hpp
+++ b/any_member.hpp
@@ -622,7 +622,6 @@ void MemberSymbolTable<ClassType>::ascribe
             <MemberSymbolTable<ClassType>
             ,ClassType
             >::value
-        ,""
         );
     static_assert
         (
@@ -630,7 +629,6 @@ void MemberSymbolTable<ClassType>::ascribe
             <SameOrBaseClassType
             ,ClassType
             >::value
-        ,""
         );
 
     ClassType* class_object = static_cast<ClassType*>(this);

--- a/authenticity.hpp
+++ b/authenticity.hpp
@@ -34,7 +34,7 @@
 #include <vector>
 
 // The gnu libc md5 implementation seems to assume this:
-static_assert(8 == CHAR_BIT || 16 == CHAR_BIT, "");
+static_assert(8 == CHAR_BIT || 16 == CHAR_BIT);
 // so md5 output is 128 bits == 16 8-bit bytes or 8 16-bit bytes:
 enum {md5len = 128 / CHAR_BIT};
 

--- a/bourn_cast.hpp
+++ b/bourn_cast.hpp
@@ -76,7 +76,7 @@ inline To bourn_cast(From from, std::false_type, std::false_type)
 {
     using   to_traits = std::numeric_limits<To  >;
     using from_traits = std::numeric_limits<From>;
-    static_assert(!to_traits::is_integer && !from_traits::is_integer, "");
+    static_assert(!to_traits::is_integer && !from_traits::is_integer);
 
     if(std::isnan(from))
         return to_traits::quiet_NaN();
@@ -103,10 +103,10 @@ inline To bourn_cast(From from, std::false_type, std::true_type)
 {
     using   to_traits = std::numeric_limits<To  >;
     using from_traits = std::numeric_limits<From>;
-    static_assert(!to_traits::is_integer && from_traits::is_integer, "");
+    static_assert(!to_traits::is_integer && from_traits::is_integer);
 
     // If this assertion fails, the comparisons below may be UB.
-    static_assert(from_traits::digits < to_traits::max_exponent, "");
+    static_assert(from_traits::digits < to_traits::max_exponent);
 
     if(from < to_traits::lowest())
         throw std::runtime_error("Cast would transgress lower limit.");
@@ -172,7 +172,7 @@ inline To bourn_cast(From from, std::true_type, std::false_type)
 {
     using   to_traits = std::numeric_limits<To  >;
     using from_traits = std::numeric_limits<From>;
-    static_assert(to_traits::is_integer && !from_traits::is_integer, "");
+    static_assert(to_traits::is_integer && !from_traits::is_integer);
 
     From const limit = std::ldexp(From(1), to_traits::digits);
 
@@ -228,7 +228,7 @@ inline To bourn_cast(From from, std::true_type, std::true_type)
 {
     using   to_traits = std::numeric_limits<To  >;
     using from_traits = std::numeric_limits<From>;
-    static_assert(to_traits::is_integer && from_traits::is_integer, "");
+    static_assert(to_traits::is_integer && from_traits::is_integer);
 
     if(! to_traits::is_signed && from < 0)
         throw std::runtime_error("Cannot cast negative to unsigned.");
@@ -314,17 +314,17 @@ inline To bourn_cast(From from)
     using   to_traits = std::numeric_limits<To  >;
     using from_traits = std::numeric_limits<From>;
 
-    static_assert(  to_traits::is_specialized, "");
-    static_assert(from_traits::is_specialized, "");
+    static_assert(  to_traits::is_specialized);
+    static_assert(from_traits::is_specialized);
 
-    static_assert(2 ==   to_traits::radix, "");
-    static_assert(2 == from_traits::radix, "");
+    static_assert(2 ==   to_traits::radix);
+    static_assert(2 == from_traits::radix);
 
     constexpr bool   to_integer =   to_traits::is_integer;
     constexpr bool from_integer = from_traits::is_integer;
 
-    static_assert(  to_integer ||   to_traits::is_iec559, "");
-    static_assert(from_integer || from_traits::is_iec559, "");
+    static_assert(  to_integer ||   to_traits::is_iec559);
+    static_assert(from_integer || from_traits::is_iec559);
 
     return bourn_cast<To,From>
         (from

--- a/bourn_cast_test.cpp
+++ b/bourn_cast_test.cpp
@@ -215,8 +215,8 @@ void test_floating_conversions(char const* file, int line)
     using   to_traits = std::numeric_limits<To  >;
     using from_traits = std::numeric_limits<From>;
 
-    static_assert(  to_traits::is_iec559, "");
-    static_assert(from_traits::is_iec559, "");
+    static_assert(  to_traits::is_iec559);
+    static_assert(from_traits::is_iec559);
 
     // std::isnormal values representable in any IEC559 'arithmetic
     // format' (i.e., excluding the binary16 'interchange format').
@@ -311,12 +311,12 @@ void test_conv_fpint(char const* file, int line)
     using i_traits = std::numeric_limits<I>;
     using f_traits = std::numeric_limits<F>;
 
-    static_assert(i_traits::is_integer, "");
-    static_assert(f_traits::is_iec559, "");
+    static_assert(i_traits::is_integer);
+    static_assert(f_traits::is_iec559);
 
     // Make sure 'digits' comparisons below are valid.
-    static_assert(2 == i_traits::radix, "");
-    static_assert(2 == f_traits::radix, "");
+    static_assert(2 == i_traits::radix);
+    static_assert(2 == f_traits::radix);
 
     // Integral to floating and back.
 
@@ -646,8 +646,8 @@ void mete_static()
 {
     enum {N = 1000000};
     using from_traits = std::numeric_limits<From>;
-    static_assert(from_traits::is_specialized, "");
-    static_assert(N < from_traits::max(), "");
+    static_assert(from_traits::is_specialized);
+    static_assert(N < from_traits::max());
     To volatile z(0);
     for(From j = 0; j < N; ++j)
         {
@@ -663,8 +663,8 @@ void mete_bourn()
 {
     enum {N = 1000000};
     using from_traits = std::numeric_limits<From>;
-    static_assert(from_traits::is_specialized, "");
-    static_assert(N < from_traits::max(), "");
+    static_assert(from_traits::is_specialized);
+    static_assert(N < from_traits::max());
     To volatile z(0);
     for(From j = 0; j < N; ++j)
         {

--- a/callback.hpp
+++ b/callback.hpp
@@ -96,9 +96,9 @@
 template<typename FunctionPointer>
 class LMI_SO callback final
 {
-    static_assert(std::is_pointer<FunctionPointer>::value, "");
+    static_assert(std::is_pointer<FunctionPointer>::value);
     typedef typename std::remove_pointer<FunctionPointer>::type f_type;
-    static_assert(std::is_function<f_type>::value, "");
+    static_assert(std::is_function<f_type>::value);
 
   public:
     callback() = default;

--- a/contains_test.cpp
+++ b/contains_test.cpp
@@ -39,14 +39,14 @@ struct LacksFind {            };
 
 void test_has_member_find()
 {
-    static_assert( has_member_find<HasFind  >::value, "");
-    static_assert(!has_member_find<LacksFind>::value, "");
+    static_assert( has_member_find<HasFind  >::value);
+    static_assert(!has_member_find<LacksFind>::value);
 
-    static_assert( has_member_find<std::string>::value, "");
+    static_assert( has_member_find<std::string>::value);
 
-    static_assert( has_member_find<std::map   <int,int>>::value, "");
-    static_assert( has_member_find<std::set   <int    >>::value, "");
-    static_assert(!has_member_find<std::vector<int    >>::value, "");
+    static_assert( has_member_find<std::map   <int,int>>::value);
+    static_assert( has_member_find<std::set   <int    >>::value);
+    static_assert(!has_member_find<std::vector<int    >>::value);
 }
 
 /// Test standard "containers" for which find() makes sense.

--- a/database_view_editor.cpp
+++ b/database_view_editor.cpp
@@ -282,7 +282,7 @@ void DatabaseTableAdapter::ConvertValue
     // If the following assert fails, then it probably means that
     // the number of axes has been changed and the change should
     // be reflected in the code above.
-    static_assert(eda_max == 7, "");
+    static_assert(eda_max == 7);
 }
 
 unsigned int DatabaseTableAdapter::DoGetDimension() const
@@ -336,6 +336,6 @@ MultiDimTableAny::AxesAny DatabaseTableAdapter::DoGetAxesAny()
     // If the following assert fails, then it probably means that
     // the number of axes has been changed and the change should
     // be reflected in the code above.
-    static_assert(eda_max == 7, "");
+    static_assert(eda_max == 7);
     return axes;
 }

--- a/database_view_editor.hpp
+++ b/database_view_editor.hpp
@@ -67,7 +67,6 @@ class DatabaseTableAdapter
         (
            static_cast<int>(DatabaseTableAdapter::eda_max)
         == static_cast<int>(e_number_of_axes)
-        ,""
         );
   public:
     DatabaseTableAdapter(database_entity* db_value = nullptr);

--- a/group_quote_pdf_gen_wx.cpp
+++ b/group_quote_pdf_gen_wx.cpp
@@ -256,7 +256,7 @@ column_definition const column_definitions[] =
     ,{"Total\n%s\nPremium"             ,   "$9,999,999,999.00"} // e_col_total_premium
     };
 
-static_assert(sizeof column_definitions / sizeof(column_definitions[0]) == e_col_max, "");
+static_assert(sizeof column_definitions / sizeof(column_definitions[0]) == e_col_max);
 
 class group_quote_pdf_generator_wx
     :public group_quote_pdf_generator

--- a/ieee754.hpp
+++ b/ieee754.hpp
@@ -42,7 +42,7 @@
 template<typename T>
 T implausible_value(T const& t = -9.99999e35)
 {
-    static_assert(::std::is_floating_point<T>::value, "");
+    static_assert(::std::is_floating_point<T>::value);
 
     if(std::numeric_limits<T>::has_quiet_NaN)
         {
@@ -70,8 +70,8 @@ T implausible_value(T const& t = -9.99999e35)
 template<typename T>
 inline T infinity()
 {
-    static_assert(::std::is_floating_point<T>::value, "");
-    static_assert(std::numeric_limits<T>::has_infinity, "");
+    static_assert(::std::is_floating_point<T>::value);
+    static_assert(std::numeric_limits<T>::has_infinity);
     static T const volatile z = std::numeric_limits<T>::infinity();
     return z;
 }
@@ -102,7 +102,7 @@ inline T infinity()
 template<typename T>
 inline bool is_infinite(T t)
 {
-    static_assert(::std::is_floating_point<T>::value, "");
+    static_assert(::std::is_floating_point<T>::value);
     static T const volatile pos_inf =  std::numeric_limits<T>::infinity();
     static T const volatile neg_inf = -std::numeric_limits<T>::infinity();
     static bool const has_inf = std::numeric_limits<T>::has_infinity;

--- a/input_sequence.cpp
+++ b/input_sequence.cpp
@@ -213,7 +213,7 @@ void InputSequence::initialize_from_vector(std::vector<T> const& v)
 {
     bool const T_is_double = std::is_same<T,double     >::value;
     bool const T_is_string = std::is_same<T,std::string>::value;
-    static_assert(T_is_double || T_is_string, "");
+    static_assert(T_is_double || T_is_string);
 
     ValueInterval default_interval;
     default_interval.value_is_keyword = T_is_string;

--- a/math_functors.hpp
+++ b/math_functors.hpp
@@ -79,7 +79,7 @@ template<typename T>
 struct mean
     :public std::binary_function<T, T, T>
 {
-    static_assert(std::is_floating_point<T>::value, "");
+    static_assert(std::is_floating_point<T>::value);
     T operator()(T const& x, T const& y) const
         {return 0.5 * x + 0.5 * y;}
 };
@@ -109,8 +109,8 @@ struct mean
 template<typename T, int n>
 struct i_upper_n_over_n_from_i
 {
-    static_assert(std::is_floating_point<T>::value, "");
-    static_assert(0 < n, "");
+    static_assert(std::is_floating_point<T>::value);
+    static_assert(0 < n);
     T operator()(T const& i) const
         {
         if(i < -1.0)
@@ -135,7 +135,7 @@ template<typename T>
 struct i_upper_12_over_12_from_i
     :public std::unary_function<T,T>
 {
-    static_assert(std::is_floating_point<T>::value, "");
+    static_assert(std::is_floating_point<T>::value);
     T operator()(T const& i) const
         {
         return i_upper_n_over_n_from_i<double,12>()(i);
@@ -146,8 +146,8 @@ template<typename T, int n>
 struct i_from_i_upper_n_over_n
     :public std::unary_function<T,T>
 {
-    static_assert(std::is_floating_point<T>::value, "");
-    static_assert(0 < n, "");
+    static_assert(std::is_floating_point<T>::value);
+    static_assert(0 < n);
     T operator()(T const& i) const
         {
         // naively:    (1+i)^n - 1
@@ -161,7 +161,7 @@ template<typename T>
 struct i_from_i_upper_12_over_12
     :public std::unary_function<T,T>
 {
-    static_assert(std::is_floating_point<T>::value, "");
+    static_assert(std::is_floating_point<T>::value);
     T operator()(T const& i) const
         {
         return i_from_i_upper_n_over_n<double,12>()(i);
@@ -172,8 +172,8 @@ template<typename T, int n>
 struct d_upper_n_from_i
     :public std::unary_function<T,T>
 {
-    static_assert(std::is_floating_point<T>::value, "");
-    static_assert(0 < n, "");
+    static_assert(std::is_floating_point<T>::value);
+    static_assert(0 < n);
     T operator()(T const& i) const
         {
         if(i < -1.0)
@@ -198,7 +198,7 @@ template<typename T>
 struct d_upper_12_from_i
     :public std::unary_function<T,T>
 {
-    static_assert(std::is_floating_point<T>::value, "");
+    static_assert(std::is_floating_point<T>::value);
     T operator()(T const& i) const
         {
         return d_upper_n_from_i<double,12>()(i);
@@ -214,8 +214,8 @@ struct d_upper_12_from_i
 template<typename T, int n>
 struct net_i_from_gross
 {
-    static_assert(std::is_floating_point<T>::value, "");
-    static_assert(0 < n, "");
+    static_assert(std::is_floating_point<T>::value);
+    static_assert(0 < n);
     T operator()(T const& i, T const& spread, T const& fee) const
         {
         static long double const reciprocal_n = 1.0L / n;
@@ -265,7 +265,7 @@ template<typename T>
 struct coi_rate_from_q
     :public std::binary_function<T,T,T>
 {
-    static_assert(std::is_floating_point<T>::value, "");
+    static_assert(std::is_floating_point<T>::value);
     T operator()(T const& q, T const& max_coi) const
         {
         if(!(0.0 <= max_coi && max_coi <= 1.0))

--- a/math_functors_test.cpp
+++ b/math_functors_test.cpp
@@ -49,7 +49,7 @@ template<typename T>
 struct i_upper_12_over_12_from_i_naive
     :public std::unary_function<T,T>
 {
-    static_assert(std::is_floating_point<T>::value, "");
+    static_assert(std::is_floating_point<T>::value);
     T operator()(T const& i) const
         {
         long double z = -1.0L + std::pow((1.0L + i), 1.0L / 12.0L);
@@ -61,7 +61,7 @@ template<typename T>
 struct i_from_i_upper_12_over_12_naive
     :public std::unary_function<T,T>
 {
-    static_assert(std::is_floating_point<T>::value, "");
+    static_assert(std::is_floating_point<T>::value);
     T operator()(T const& i) const
         {
         long double z = -1.0L + std::pow((1.0L + i), 12.0L);
@@ -73,7 +73,7 @@ template<typename T>
 struct d_upper_12_from_i_naive
     :public std::unary_function<T,T>
 {
-    static_assert(std::is_floating_point<T>::value, "");
+    static_assert(std::is_floating_point<T>::value);
     T operator()(T const& i) const
         {
         long double z = 12.0L * (1.0L - std::pow(1.0L + i, -1.0L / 12.0L));
@@ -84,7 +84,7 @@ struct d_upper_12_from_i_naive
 template<typename T, int n>
 struct net_i_from_gross_naive
 {
-    static_assert(std::is_floating_point<T>::value, "");
+    static_assert(std::is_floating_point<T>::value);
     T operator()(T const& i, T const& spread, T const& fee) const
         {
         static long double const reciprocal_n = 1.0L / n;
@@ -104,7 +104,7 @@ template<typename T>
 struct coi_rate_from_q_naive
     :public std::binary_function<T,T,T>
 {
-    static_assert(std::is_floating_point<T>::value, "");
+    static_assert(std::is_floating_point<T>::value);
     T operator()(T const& q, T const& max_coi) const
         {
         if(0.0 == q)
@@ -129,7 +129,7 @@ struct coi_rate_from_q_naive
 template<typename T, int n>
 struct i_upper_n_over_n_from_i_naive
 {
-    static_assert(std::is_floating_point<T>::value, "");
+    static_assert(std::is_floating_point<T>::value);
     T operator()(T const& i) const
         {
         return T(-1) + std::pow((T(1) + i), T(1) / n);
@@ -142,7 +142,7 @@ struct i_upper_n_over_n_from_i_naive
 template<typename T, int n>
 struct i_upper_n_over_n_from_i_T
 {
-    static_assert(std::is_floating_point<T>::value, "");
+    static_assert(std::is_floating_point<T>::value);
     T operator()(T const& i) const
         {
         static T const reciprocal_n = T(1) / n;

--- a/mc_enum.hpp
+++ b/mc_enum.hpp
@@ -98,7 +98,7 @@ class mc_enum
     ,private boost::equality_comparable<mc_enum<T>,T>
     ,private boost::equality_comparable<mc_enum<T>,std::string>
 {
-    static_assert(std::is_enum<T>::value, "");
+    static_assert(std::is_enum<T>::value);
 
     friend class mc_enum_test;
     template<typename U> friend std::vector<std::string> const& all_strings();

--- a/mc_enum.tpp
+++ b/mc_enum.tpp
@@ -39,7 +39,7 @@ mc_enum<T>::mc_enum()
     ,value_(e()[0])
 {
     typedef mc_enum_key<T> metadata;
-    static_assert(0 < metadata::n_, "");
+    static_assert(0 < metadata::n_);
 }
 
 template<typename T>

--- a/mc_enum_metadata.hpp
+++ b/mc_enum_metadata.hpp
@@ -109,7 +109,7 @@ struct mc_enum_key
 template<typename T, std::size_t N, T const (&E)[N], char const*const (&C)[N]>
 struct mc_enum_data
 {
-    static_assert(0 < N, "");
+    static_assert(0 < N);
 
     static std::size_t const n_ = N;
     static T    const*        e() {return E;}

--- a/multidimgrid_safe.hpp
+++ b/multidimgrid_safe.hpp
@@ -259,7 +259,7 @@ template<typename AdjustControl, typename BaseAxisType = MultiDimAxisAny>
 class MultiDimAdjustableAxis
     :public BaseAxisType
 {
-    static_assert(std::is_base_of<MultiDimAxisAny,BaseAxisType>::value, "");
+    static_assert(std::is_base_of<MultiDimAxisAny,BaseAxisType>::value);
 
   protected:
     typedef AdjustControl AxisAdjustControl;

--- a/mvc_controller.tpp
+++ b/mvc_controller.tpp
@@ -69,8 +69,8 @@ T const& MvcController::ModelReference(std::string const& name) const
 template<typename T>
 T& MvcController::WindowFromXrcName(char const* name) const
 {
-    static_assert(!std::is_pointer<T>::value, "");
-    static_assert(std::is_base_of<wxWindow,T>::value, "");
+    static_assert(!std::is_pointer<T>::value);
+    static_assert(std::is_base_of<wxWindow,T>::value);
 
     wxWindow* w = FindWindow(wxXmlResource::GetXRCID(name));
     if(!w)

--- a/numeric_io_cast.hpp
+++ b/numeric_io_cast.hpp
@@ -108,7 +108,7 @@ To numeric_io_cast(From from, To = To())
 
 /// A compile-time failure iff this template is ever instantiated is
 /// desired, but the straightforward
-///   static_assert(0, "");
+///   static_assert(0);
 /// can fail even if it's never instantiated; instead, it is asserted
 /// that both template parameters are void, which 14.1/7 forbids.
 /// To make assurance doubly sure, a run-time exception is thrown in
@@ -117,8 +117,8 @@ To numeric_io_cast(From from, To = To())
 template<typename To, typename From>
 struct numeric_converter
 {
-    static_assert(std::is_void<To  >::value, "");
-    static_assert(std::is_void<From>::value, "");
+    static_assert(std::is_void<To  >::value);
+    static_assert(std::is_void<From>::value);
 
     To operator()(From const&) const
         {
@@ -132,7 +132,7 @@ struct numeric_converter
 template<typename To>
 struct numeric_converter<To, std::string>
 {
-    static_assert(std::is_arithmetic<To>::value, "");
+    static_assert(std::is_arithmetic<To>::value);
 
     typedef std::string From;
     To operator()(From const& from) const
@@ -201,7 +201,7 @@ struct numeric_converter<To, char const*>
 template<typename From>
 struct numeric_converter<std::string, From>
 {
-    static_assert(std::is_arithmetic<From>::value, "");
+    static_assert(std::is_arithmetic<From>::value);
 
     typedef std::string To;
     To operator()(From const& from) const

--- a/numeric_io_test.cpp
+++ b/numeric_io_test.cpp
@@ -98,7 +98,7 @@ void mete_infinity()
 // that deviates from that standard is probably so rare that it can
 // reasonably be ignored, with an appropriate runtime message.
 
-static_assert(std::numeric_limits<double>::is_iec559, "");
+static_assert(std::numeric_limits<double>::is_iec559);
 
 int test_main(int, char*[])
 {

--- a/numeric_io_traits.hpp
+++ b/numeric_io_traits.hpp
@@ -57,7 +57,7 @@
 template<typename T>
 inline int floating_point_decimals(T t)
 {
-    static_assert(std::is_floating_point<T>::value, "");
+    static_assert(std::is_floating_point<T>::value);
 #if defined LMI_MSVCRT
     // COMPILER !! This C runtime not only writes infinity as "1.#INF"
     // instead of "inf" but also "respects" the precision specifier

--- a/rate_table.cpp
+++ b/rate_table.cpp
@@ -82,7 +82,7 @@ using std::uint64_t;
 // The SOA binary format uses IEEE 754 for the floating point values
 // representation and the code in this file won't work correctly if it is
 // different from their in memory representation.
-static_assert(std::numeric_limits<double>::is_iec559, "");
+static_assert(std::numeric_limits<double>::is_iec559);
 
 // Helper functions used to swap bytes on big endian platforms.
 //

--- a/round_to.hpp
+++ b/round_to.hpp
@@ -253,7 +253,7 @@ template<typename RealType>
 class round_to
     :public std::unary_function<RealType,RealType>
 {
-    static_assert(std::is_floating_point<RealType>::value, "");
+    static_assert(std::is_floating_point<RealType>::value);
 
   public:
     /// The default ctor only makes the class DefaultConstructible;

--- a/safely_dereference_as.hpp
+++ b/safely_dereference_as.hpp
@@ -68,7 +68,7 @@
 template<typename T, typename U>
 T& safely_dereference_as(U* u)
 {
-    static_assert(std::is_base_of<U,T>::value, "");
+    static_assert(std::is_base_of<U,T>::value);
     if(!u)
         {
         std::ostringstream oss;

--- a/stratified_charges.cpp
+++ b/stratified_charges.cpp
@@ -243,7 +243,7 @@ namespace
         ,"stratified_last"
         };
 
-    static_assert(sizeof s_stratified_nodes / sizeof(char const*) == 1 + e_stratified_last, "");
+    static_assert(sizeof s_stratified_nodes / sizeof(char const*) == 1 + e_stratified_last);
 } // Unnamed namespace.
 
 stratified_entity& stratified_charges::raw_entity(e_stratified e)

--- a/stream_cast.hpp
+++ b/stream_cast.hpp
@@ -100,9 +100,8 @@ To stream_cast(From from, To = To())
     static_assert
         (   !std::is_arithmetic<From>::value
         ||  !std::is_arithmetic<To  >::value
-        ,""
         );
-    static_assert(!std::is_pointer<To>::value, "");
+    static_assert(!std::is_pointer<To>::value);
 
     std::stringstream interpreter;
     std::ostringstream err;

--- a/tn_range.hpp
+++ b/tn_range.hpp
@@ -234,7 +234,7 @@ class tn_range
     ,private boost::equality_comparable<tn_range<Number,Trammel>,Number>
     ,private boost::equality_comparable<tn_range<Number,Trammel>,std::string>
 {
-    static_assert(std::is_base_of<trammel_base<Number>,Trammel>::value, "");
+    static_assert(std::is_base_of<trammel_base<Number>,Trammel>::value);
 
     friend class tn_range_test;
 

--- a/tn_range.tpp
+++ b/tn_range.tpp
@@ -108,7 +108,7 @@ namespace
     template<typename T>
     T signum(T t)
     {
-        static_assert(std::is_arithmetic<T>::value, "");
+        static_assert(std::is_arithmetic<T>::value);
         return (0 == t) ? 0 : std::signbit(t) ? -1 : 1;
     }
 
@@ -179,7 +179,7 @@ namespace
     template<typename T>
     struct is_exact_integer_tester<T,true>
     {
-        static_assert(std::is_floating_point<T>::value, "");
+        static_assert(std::is_floating_point<T>::value);
         bool operator()(T t)
             {
             static T z0 = std::pow
@@ -208,7 +208,7 @@ namespace
     template<typename T>
     T adjust_bound(T t, T direction)
     {
-        static_assert(std::is_floating_point<T>::value, "");
+        static_assert(std::is_floating_point<T>::value);
         if(is_exact_integer(t))
             {
             return t;
@@ -251,7 +251,7 @@ namespace
     template<typename T>
     struct bound_adjuster<T,-1>
     {
-        static_assert(std::is_floating_point<T>::value, "");
+        static_assert(std::is_floating_point<T>::value);
         T operator()(T t)
             {
             static T const extremum = -std::numeric_limits<T>::max();
@@ -262,7 +262,7 @@ namespace
     template<typename T>
     struct bound_adjuster<T,1>
     {
-        static_assert(std::is_floating_point<T>::value, "");
+        static_assert(std::is_floating_point<T>::value);
         T operator()(T t)
             {
             static T const extremum = std::numeric_limits<T>::max();

--- a/tn_range_test_aux.hpp
+++ b/tn_range_test_aux.hpp
@@ -37,7 +37,7 @@ template<typename T>
 class percentage_trammel
     :public trammel_base<T>
 {
-    static_assert(100 <= std::numeric_limits<T>::max(), "");
+    static_assert(100 <= std::numeric_limits<T>::max());
     T nominal_minimum() const override {return   0;}
     T default_value()   const override {return   0;}
     T nominal_maximum() const override {return 100;}

--- a/tn_range_type_trammels.hpp
+++ b/tn_range_type_trammels.hpp
@@ -109,7 +109,7 @@ template<typename T>
 class date_trammel
     :public trammel_base<T>
 {
-    static_assert(std::is_same<calendar_date,T>::value, "");
+    static_assert(std::is_same<calendar_date,T>::value);
 
     T nominal_minimum() const override {return gregorian_epoch();}
     T default_value()   const override {return today          ();}

--- a/value_cast.hpp
+++ b/value_cast.hpp
@@ -229,7 +229,7 @@ struct value_cast_chooser<To,From,e_stream>
 template<typename To, typename From>
 To value_cast(From const& from)
 {
-    static_assert(!std::is_pointer<To>::value, "");
+    static_assert(!std::is_pointer<To>::value);
     return value_cast_chooser<To,From>()(from);
 }
 

--- a/view_ex.tpp
+++ b/view_ex.tpp
@@ -49,7 +49,7 @@
 template<typename ViewType>
 std::string ViewName()
 {
-    static_assert(std::is_base_of<wxView,ViewType>::value, "");
+    static_assert(std::is_base_of<wxView,ViewType>::value);
     return lmi::TypeInfo(typeid(ViewType)).Name();
 }
 

--- a/wx_utility.hpp
+++ b/wx_utility.hpp
@@ -78,10 +78,10 @@ void Connect
     ,wxEvtHandler*   event_sink = nullptr
     )
 {
-    static_assert(std::is_same<void,Return>::value, "");
-    static_assert(std::is_base_of<wxEvtHandler,Class>::value, "");
+    static_assert(std::is_same<void,Return>::value);
+    static_assert(std::is_base_of<wxEvtHandler,Class>::value);
     typedef typename std::remove_reference<Argument>::type argument_type;
-    static_assert(std::is_base_of<wxEvent,argument_type>::value, "");
+    static_assert(std::is_base_of<wxEvent,argument_type>::value);
 
     if(!object)
         {

--- a/xml_serializable.tpp
+++ b/xml_serializable.tpp
@@ -43,8 +43,8 @@ xml_serializable<T>::~xml_serializable()
     // Assert that static_cast<T cv&> doesn't engender undefined
     // behavior, and that class T provides the expected operator[]()
     // and member_names() functions.
-    static_assert(std::is_base_of<xml_serializable <T>,T>::value, "");
-    static_assert(std::is_base_of<MemberSymbolTable<T>,T>::value, "");
+    static_assert(std::is_base_of<xml_serializable <T>,T>::value);
+    static_assert(std::is_base_of<MemberSymbolTable<T>,T>::value);
 }
 
 template<typename T>

--- a/xml_serialize.hpp
+++ b/xml_serialize.hpp
@@ -56,7 +56,7 @@ namespace xml_serialize
 template<typename T>
 struct xml_io
 {
-    static_assert(!std::is_enum<T>::value, ""); // Prefer mc_enum.
+    static_assert(!std::is_enum<T>::value); // Prefer mc_enum.
 
     static void to_xml(xml::element& e, T const& t)
     {
@@ -89,7 +89,7 @@ template<typename T>
 struct xml_sequence_io
 {
     typedef typename T::value_type item_t;
-    static_assert(std::is_same<T,std::vector<item_t>>::value, "");
+    static_assert(std::is_same<T,std::vector<item_t>>::value);
 
     static void to_xml(xml::element& e, T const& t)
     {


### PR DESCRIPTION
C++17 allows to use the so called "terse static assert" without an
explicitly specified message, so don't bother passing it the meaningless
empty string.

No real changes (except possibly better compile-time diagnostics in case
of an assert failure), just clean up the code.