### PR TITLE
Fix and simplify simplify_floating_point()

### DIFF
--- a/numeric_io_traits.hpp
+++ b/numeric_io_traits.hpp
@@ -92,12 +92,15 @@ inline int floating_point_decimals(T t)
 inline std::string simplify_floating_point(std::string const& s)
 {
     std::string::const_reverse_iterator ri = s.rbegin();
-  loop:
-    switch(*ri)
+    for(;ri != s.rend(); ++ri)
         {
-        case '0': if(++ri != s.rend()) goto loop;
-        case '.': ++ri;
-        default : ;
+        if(*ri != '0')
+            {
+            if(*ri == '.')
+                ++ri;
+
+            break;
+            }
         }
     return std::string(s.begin(), ri.base());
 }


### PR DESCRIPTION
Don't dereference an invalid iterator for strings consisting only of
zeroes in simplify_floating_point(): the reverse iterator was
incremented after reaching the beginning of the string, making it
invalid, and then used in std::string ctor.

Fix this by avoiding the confusing goto inside switch statement and
using a straightforward loop instead.