### PR TITLE
Use non-experimental headers for compilers with C++17 support

### DIFF
--- a/config.hpp
+++ b/config.hpp
@@ -29,6 +29,12 @@
 // Namespace alii.
 namespace boost {namespace filesystem {} }
 namespace fs = boost::filesystem;
+
+#if __cplusplus >= 201703L
+// A compiler claiming C++17 support must have C++17 standard library.
+#define LMI_COMPILER_HAS_CXX17_STDLIB
+#endif // C++17 compiler
+
 #endif // Not C++.
 
 // The msw platform-identifying macro that its vendor encourages

--- a/multidimgrid_any.hpp
+++ b/multidimgrid_any.hpp
@@ -100,8 +100,13 @@
 #include <utility>                      // pair
 #include <vector>
 
+#ifdef LMI_COMPILER_HAS_CXX17_STDLIB
+#include <any>
+namespace Exp { using std::any; }
+#else
 #include <experimental/any>
 namespace Exp {using std::experimental::any;}
+#endif
 
 class MultiDimAxisAny;
 class MultiDimAxisAnyChoice;

--- a/multidimgrid_safe.hpp
+++ b/multidimgrid_safe.hpp
@@ -33,6 +33,15 @@
 
 #include <type_traits>
 
+#ifdef LMI_COMPILER_HAS_CXX17_STDLIB
+#include <any>
+namespace Exp
+{
+    using std::any;
+    using std::any_cast;
+    using std::bad_any_cast;
+}
+#else
 #include <experimental/any>
 namespace Exp
 {
@@ -40,6 +49,7 @@ namespace Exp
     using std::experimental::any_cast;
     using std::experimental::bad_any_cast;
 }
+#endif
 
 /// MultiDim* type-safe classes
 /// ---------------------------

--- a/rate_table.cpp
+++ b/rate_table.cpp
@@ -49,8 +49,13 @@
 #include <stdexcept>
 #include <utility>                      // make_pair(), swap()
 
+#ifdef LMI_COMPILER_HAS_CXX17_STDLIB
+#include <optional>
+namespace Exp { using std::optional; }
+#else
 #include <experimental/optional>
 namespace Exp {using std::experimental::optional;}
+#endif
 
 // Note about error handling in this code: with a few exceptions (e.g.
 // strict_parse_number), most of the functions in this file throw on error.


### PR DESCRIPTION
At least MSVS, but possibly other compilers, including gcc in the
future, provides std::any and std::optional without providing their
counterparts in std::experimental namespace, so allow using the standard
classes too.