### PR TITLE
Suppress gcc 7 warnings in Boost.Regex in the header too

### DIFF
--- a/boost_regex.hpp
+++ b/boost_regex.hpp
@@ -26,6 +26,10 @@
 
 #if defined __GNUC__
 #   pragma GCC diagnostic push
+#   if 7 <= __GNUC__
+#       pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#       pragma GCC diagnostic ignored "-Wregister"
+#   endif // 7 <= __GNUC__
 #   pragma GCC diagnostic ignored "-Wshadow"
 #endif // defined __GNUC__
 #include <boost/regex.hpp>

--- a/workhorse.make
+++ b/workhorse.make
@@ -492,8 +492,6 @@ boost_dependent_objects := \
   regex_test.o \
   test_coding_rules.o \
 
-$(boost_dependent_objects): gcc_common_extra_warnings += -Wno-implicit-fallthrough
-$(boost_dependent_objects): gcc_common_extra_warnings += -Wno-register
 $(boost_dependent_objects): gcc_common_extra_warnings += -Wno-unused-local-typedefs
 
 # The boost regex library improperly defines "NOMINMAX":


### PR DESCRIPTION
Instead of doing it at the makefile level, just suppress the new
warnings given by gcc 7 in Boost headers in the same way as it was
already done for -Wshadow.