### PR TITLE
Automatically restore the main frame geometry

### DIFF
--- a/skeleton.cpp
+++ b/skeleton.cpp
@@ -98,6 +98,7 @@
 #include <wx/textdlg.h>                 // wxGetTextFromUser()
 #include <wx/toolbar.h>
 #include <wx/utils.h>                   // wxMilliSleep(), wxSafeYield()
+#include <wx/persist/toplevel.h>
 #include <wx/xrc/xmlres.h>
 
 #include <iterator>                     // insert_iterator
@@ -745,8 +746,12 @@ bool Skeleton::OnInit()
 
         frame_->Bind(wxEVT_MENU_OPEN, &Skeleton::UponMenuOpen, this);
         frame_->DragAcceptFiles(true);
-        frame_->Centre(wxBOTH);
-        frame_->Maximize(true);
+
+        if(!wxPersistentRegisterAndRestore(frame_, "lmi_main"))
+            {
+            frame_->Centre(wxBOTH);
+            frame_->Maximize(true);
+            }
 
         if
             (  custom_io_0_run_if_file_exists(doc_manager_)


### PR DESCRIPTION
Use wxWidgets persistent objects support to preserve the position and
size of the main frame between executions.