### PR TITLE
Use std::uncaught_exceptions() instead of uncaught_exception()

### DIFF
--- a/main_wx_test.cpp
+++ b/main_wx_test.cpp
@@ -760,7 +760,7 @@ void SkeletonTest::OnAssertFailure
     // another exception is already in flight as this would just result in the
     // program termination without any useful information about the reason of
     // the failure whatsoever.
-    if(is_running_tests_ && !std::uncaught_exception())
+    if(is_running_tests_ && !std::uncaught_exceptions())
         {
         throw test_assertion_failure_exception(msg ? msg : cond, file, line, func);
         }

--- a/wx_test_document.hpp
+++ b/wx_test_document.hpp
@@ -68,7 +68,7 @@ class wx_test_document_base
         // test failure, as this is not a bug in the test code then.
         if(opened_)
             {
-            if(std::uncaught_exception())
+            if(std::uncaught_exceptions())
                 {
                 // Moreover, in case of exception, try to close the window to
                 // avoid showing message boxes asking the user if it should be


### PR DESCRIPTION
In C++17, uncaught_exception(), returning bool, is deprecated and a new
uncaught_exceptions(), returning int, should be used instead.

This notably avoids deprecation warnings from MSVS 2017.