### PR TITLE
Avoid accidentally focusing wrong window in GUI tests

### DIFF
--- a/main_wx_test.cpp
+++ b/main_wx_test.cpp
@@ -566,7 +566,7 @@ void wx_base_test_case::skip_if_not_distribution()
 wxWindow* wx_test_focus_controller_child(MvcController& dialog, char const* name)
 {
     // First find the window anywhere inside the dialog.
-    wxWindow* const w = wxWindow::FindWindowByName(name, &dialog);
+    wxWindow* const w = dialog.FindWindow(name);
     LMI_ASSERT_WITH_MSG(w, "window named \"" << name << "\" not found");
 
     // Then find the book control containing it by walking up the window chain

--- a/wx_test_input_sequences.cpp
+++ b/wx_test_input_sequences.cpp
@@ -97,7 +97,7 @@ LMI_WX_TEST_CASE(input_sequences)
             wxYield();
 
             char const* const field_name = test_data_.field;
-            if(!wxWindow::FindWindowByName(field_name, dialog))
+            if(!dialog->FindWindow(field_name))
                 {
                 // Check whether the field name is valid at all. If it
                 // isn't, then the input model must have changed, so


### PR DESCRIPTION
Use wxWindow::FindWindow(), which considers only the name of the window,
instead of FindWindowByName(), which falls back to the window label if
no window with the given name is found. This behaviour was unhelpful as
the function could find a wrong window (e.g. the static label preceding
the control instead of the control itself) if a label, instead of name,
was accidentally used as its argument.