### PR TITLE
Add pdf_writer_wx::save() to explicitly save PDF documents

### DIFF
--- a/group_quote_pdf_gen_wx.cpp
+++ b/group_quote_pdf_gen_wx.cpp
@@ -794,6 +794,8 @@ void group_quote_pdf_generator_wx::save(std::string const& output_filename)
 
     LMI_ASSERT(current_page == total_pages);
     output_page_number_and_version(pdf_writer, total_pages, current_page);
+
+    std::move(pdf_writer).save();
 }
 
 int group_quote_pdf_generator_wx::compute_pages_for_table_rows

--- a/pdf_writer_wx.hpp
+++ b/pdf_writer_wx.hpp
@@ -52,7 +52,16 @@ class pdf_writer_wx
     pdf_writer_wx(pdf_writer_wx const&) = delete;
     pdf_writer_wx& operator=(pdf_writer_wx const&) = delete;
 
+    // Dtor checks if save() had been called, so don't forget to do it.
     ~pdf_writer_wx();
+
+    // Save the PDF to the output file name specified in the ctor.
+    //
+    // This object becomes unusable after saving, i.e. no other methods can be
+    // called on it. To help with preventing using any of them accidentally,
+    // this method is rvalue-reference-qualified, meaning that calling
+    // std::move() is required to call it.
+    void save() &&;
 
     // High level functions which should be preferably used if possible.
     int output_html
@@ -73,7 +82,7 @@ class pdf_writer_wx
         );
 
     // Accessors allowing to use lower level wxDC API directly.
-    wxDC& dc() { return pdf_dc_; }
+    wxDC& dc();
 
     // Page metrics: the page width and height are the size of the page region
     // reserved for the normal contents, excluding horizontal and vertical
@@ -95,6 +104,9 @@ class pdf_writer_wx
     wxHtmlWinParser html_parser_;
 
     wxSize const total_page_size_;
+
+    // Set to true after save() was called.
+    bool was_saved_{false};
 };
 
 #endif // pdf_writer_wx_hpp


### PR DESCRIPTION
Instead of always calling wxPdfDC::EndDoc() in pdf_writer_wx dtor, only
do it from the newly added save() method. This ensures that the PDF file
is not saved at all if an error occurs while generating it, instead of
creating an invalid (incomplete, and possibly empty) file.

Add various safety run-time checks to ensure that save() is called once
and once only and that no other methods of pdf_writer_wx are called
after it.

Update all code using pdf_writer_wx to call save(). For pdf_illustration
class this involved replacing "writer_" member variable with a "writer"
local one and, as consequence, passing the output file name parameter to
render_all() method instead of ctor -- which is more logical in any case
as only render_all() really creates the output and, in principle, could
be called multiple times with different file names on the same object.