### PR TITLE
Use relative URLs for wxWidgets submodules in install script

### DIFF
--- a/install_wx.sh
+++ b/install_wx.sh
@@ -52,13 +52,48 @@ then
     cd $wx_dir
 else
     cd $wx_dir
-    git rev-parse --quiet --verify "$wx_commit_sha^{commit}" >/dev/null || git fetch $wx_git_url
+    if [ `git rev-parse HEAD` = $wx_commit_sha ]
+    then
+        # Don't bother updating anything if we already had the correct version
+        # of the tree.
+        skip_update=1
+    else
+        # Get the missing commit from the upstream repository if we don't have
+        # it yet.
+        if ! git rev-parse --quiet --verify "$wx_commit_sha^{commit}" >/dev/null
+        then
+            git fetch $wx_git_url
+        fi
+    fi
+
+    [ -n "$skip_update" ] || git checkout $wx_commit_sha
 fi
 
-if [ `git rev-parse HEAD` != $wx_commit_sha ]
+if [ "$skip_update" != 1 ]
 then
-    git checkout $wx_commit_sha
-    git submodule update --init
+    # Initialize all the not yet initialized submodules (except for the known
+    # exceptions, i.e. the submodules that we know that we won't need). This
+    # will be necessary after the initial clone, but may also need doing after
+    # updating an existing working tree if a new submodule is added upstream.
+    git submodule status | grep '^-' | cut -d' ' -f2 | while read -r subpath
+    do
+        case $subpath in
+            src/jpeg | src/tiff)
+                continue
+                ;;
+        esac
+
+        suburl=`git config --file .gitmodules --get submodule.${subpath}.url`
+
+        # Configure the submodule to use URL relative to the one used for the
+        # super-repository itself: this doesn't change anything when using the
+        # canonical wxWidgets GitHub URL, but allows to download submodules
+        # from a local mirror when wxWidgets itself is being cloned from such
+        # a mirror, avoiding (slow and possibly unreliable) network access.
+        git config submodule.${subpath}.url ${wx_git_url%/*}/${suburl##*/}
+
+        git submodule update --init $subpath
+    done
 fi
 
 [ "$wx_skip_clean" = 1 ] || git clean -dfx


### PR DESCRIPTION
Using relative URLs allows to set up local submodules mirrors, which
will now be used when cloning using an URL of a local mirror as
wx_git_url, instead of always cloning the submodules from GitHub,
without changing anything for the simple use case of the default
wx_git_url, i.e. when cloning everything from GitHub.

Also optimize submodule updating a bit by skipping the submodules not
used in lmi-specific build of wxWidgets.