### PR TITLE
Fix warning about comparing double with bool in group quotes code

### DIFF
--- a/group_quote_pdf_gen_wx.cpp
+++ b/group_quote_pdf_gen_wx.cpp
@@ -522,13 +522,14 @@ void group_quote_pdf_generator_wx::add_ledger(Ledger const& ledger)
     // mandatory (unismoke) and voluntary (smoker-distinct) rates in
     // the same plancode, when they should have used distinct subplans
     // because they serve different market segments.
+    bool const individual_selection = invar.GroupIndivSelection != 0.0;
     if(0 == row_num_)
         {
-        individual_selection_ = invar.GroupIndivSelection;
+        individual_selection_ = individual_selection;
         }
     else
         {
-        if(invar.GroupIndivSelection != individual_selection_)
+        if(individual_selection != individual_selection_)
             {
             alarum()
                 << "Group quotes cannot mix mandatory and voluntary on the same plan."


### PR DESCRIPTION
LedgerInvariant::GroupIndivSelection field has type double and was first
implicitly converted to group_quote_pdf_gen_wx::individual_selection of
type bool, which was already not very clear but didn't trigger any
warnings, and was also compared with bool, which did result in a warning
from MSVS about unsafe comparison.

Fix the warning by converting the double value to boolean once, and
explicitly, and then only compare booleans with each other.

Alternatively, the type of individual_selection_ could be changed to
"double", but it seems better to keep it as boolean, as this is what it
really is.