### PR TITLE
Fix group quotes output to conform to pagination logic

### DIFF
--- a/group_quote_pdf_gen_wx.cpp
+++ b/group_quote_pdf_gen_wx.cpp
@@ -753,7 +753,8 @@ void group_quote_pdf_generator_wx::save(std::string const& output_filename)
 
         table_gen.output_row(pos_y, visible_values);
 
-        if(last_row_y <= pos_y)
+        // If there is no space left for another row, start a new page.
+        if(last_row_y <= pos_y + table_gen.row_height())
             {
             output_page_number_and_version(pdf_writer, total_pages, current_page);
 


### PR DESCRIPTION
Actually output the number of rows we're supposed to output per page
according to compute_pages_for_table_rows() logic instead of (almost
always) outputting one more than computed.

Do this by checking whether the next row will fit into the available
space before outputting it and not after.

This also fixes assertions about the footer not fitting on the last page
which actually happened because, for big enough censuses, we outputted
one less page than planned due to the off-by-1 error above.