### PR TITLE
Include <climits> before using CHAR_BIT

### DIFF
--- a/main_common.hpp
+++ b/main_common.hpp
@@ -24,6 +24,7 @@
 
 #include "config.hpp"
 
+#include <climits>
 #include <cstdint>
 #include <cstdlib>                      // EXIT_SUCCESS, EXIT_FAILURE
 


### PR DESCRIPTION
This symbol is apparently indirectly defined by including <cstdint> or
<cstdlib> with the other compilers, but not when using g++8 under Linux.

Include the header guaranteed to define it to fix compilation in this
configuration.