### PR TITLE
Use correct scaling factors for the official image logo size

### DIFF
--- a/cover.mst
+++ b/cover.mst
@@ -133,7 +133,7 @@ it roughly where we want it to appear.
 <br></br>
 <br></br>
 
-<p align="center"><img inv_factor="0.6" src="company_logo.png"></img></p>
+<p align="center"><img inv_factor="0.45" src="company_logo.png"></img></p>
 
 <br></br>
 <br></br>

--- a/ill_reg_column_headings.mst
+++ b/ill_reg_column_headings.mst
@@ -20,7 +20,7 @@
 }}
 
 <!-- No header for this page, just the logo -->
-<img inv_factor="0.36" src="company_logo.png"></img>
+<img inv_factor="0.27" src="company_logo.png"></img>
 
 <p align="center">
 Column Headings and Key Terms Used in This Illustration

--- a/ill_reg_header.mst
+++ b/ill_reg_header.mst
@@ -19,7 +19,7 @@
     snail: Chicares, 186 Belle Woods Drive, Glastonbury CT 06033, USA
 }}
 
-<img inv_factor="0.36" src="company_logo.png"></img>
+<img inv_factor="0.27" src="company_logo.png"></img>
 
 <font size=-1>
 <p align="center">

--- a/ill_reg_narr_summary2.mst
+++ b/ill_reg_narr_summary2.mst
@@ -20,7 +20,7 @@
 }}
 
 <!-- No header for this page, just the logo -->
-<img inv_factor="0.36" src="company_logo.png"></img>
+<img inv_factor="0.27" src="company_logo.png"></img>
 
 <p align="center">NARRATIVE SUMMARY (Continued)</p>
 

--- a/nasd_header_upper.mst
+++ b/nasd_header_upper.mst
@@ -19,7 +19,7 @@
     snail: Chicares, 186 Belle Woods Drive, Glastonbury CT 06033, USA
 }}
 
-<img inv_factor="0.36" src="company_logo.png"></img>
+<img inv_factor="0.27" src="company_logo.png"></img>
 
 <br></br>
 <br></br>

--- a/reg_d_group_header_upper.mst
+++ b/reg_d_group_header_upper.mst
@@ -19,7 +19,7 @@
     snail: Chicares, 186 Belle Woods Drive, Glastonbury CT 06033, USA
 }}
 
-<img inv_factor="0.36" src="company_logo.png"></img>
+<img inv_factor="0.27" src="company_logo.png"></img>
 
 <br></br>
 <br></br>

--- a/reg_d_indiv_header.mst
+++ b/reg_d_indiv_header.mst
@@ -19,7 +19,7 @@
     snail: Chicares, 186 Belle Woods Drive, Glastonbury CT 06033, USA
 }}
 
-<img inv_factor="0.36" src="company_logo.png"></img>
+<img inv_factor="0.27" src="company_logo.png"></img>
 
 <font size="-1">
 

--- a/reg_d_indiv_notes1.mst
+++ b/reg_d_indiv_notes1.mst
@@ -20,7 +20,7 @@
 }}
 
 {{! No header on this page, but still use the logo. }}
-<img inv_factor="0.36" src="company_logo.png"></img>
+<img inv_factor="0.27" src="company_logo.png"></img>
 
 <p align="center"><font size="+1"><b>Explanatory Notes</b></font></p>
 

--- a/reg_d_indiv_notes2.mst
+++ b/reg_d_indiv_notes2.mst
@@ -20,7 +20,7 @@
 }}
 
 {{! No header on this page, but still use the logo. }}
-<img inv_factor="0.36" src="company_logo.png"></img>
+<img inv_factor="0.27" src="company_logo.png"></img>
 
 <p align="center"><font size="+1"><b>Explanatory Notes</b></font></p>
 


### PR DESCRIPTION
For the image of the 400*87 pixels, use the scaling factors resulting in
the same image size in the PDF as with the old illustration system.