### PR TITLE
Add support for headers on continuation pages

### DIFF
--- a/ledger_pdf_generator_wx.cpp
+++ b/ledger_pdf_generator_wx.cpp
@@ -1031,8 +1031,7 @@ class page_with_footer : public page
 
         auto y = footer_top_;
 
-        auto const& upper_template = get_upper_footer_template_name();
-        if(!upper_template.empty())
+        if(auto const& upper_template = get_upper_footer_template_name(); !upper_template.empty())
             {
             y += pdf_dc.GetCharHeight();
 

--- a/ledger_pdf_generator_wx.cpp
+++ b/ledger_pdf_generator_wx.cpp
@@ -1933,7 +1933,7 @@ class standard_supplemental_report : public page_with_tabular_report
     }
 
     // Helper function used by the ctor to initialize the const columns_ field.
-    illustration_table_columns build_columns
+    static illustration_table_columns build_columns
         (html_interpolator const& interpolate_html
         )
     {

--- a/pdf_writer_wx.cpp
+++ b/pdf_writer_wx.cpp
@@ -101,10 +101,6 @@ pdf_writer_wx::pdf_writer_wx
             .FaceName("Helvetica")
         );
 
-    // Create an HTML parser to allow easily adding HTML contents to the output.
-    html_parser_.SetDC(&pdf_dc_);
-    html_parser_.SetFonts("Helvetica", "Courier", font_sizes.data());
-
     // Create the virtual file system object for loading images referenced from
     // HTML and interpret relative paths from the data directory.
     html_vfs_.reset(new wxFileSystem());
@@ -112,7 +108,9 @@ pdf_writer_wx::pdf_writer_wx
         (global_settings::instance().data_directory().string()
         ,true // argument is a directory, not file path
         );
-    html_parser_.SetFS(html_vfs_.get());
+
+    // Create an HTML parser to allow easily adding HTML contents to the output.
+    initialize_html_parser(html_parser_);
 }
 
 /// Start a new page in the output PDF document.
@@ -325,6 +323,14 @@ int pdf_writer_wx::output_html
         }
 
     return height;
+}
+
+void pdf_writer_wx::initialize_html_parser(wxHtmlWinParser& html_parser)
+{
+    html_parser.SetDC(&pdf_dc_);
+    DoSetFonts(html_parser, html_font_sizes_);
+
+    html_parser.SetFS(html_vfs_.get());
 }
 
 std::unique_ptr<wxHtmlContainerCell> pdf_writer_wx::parse_html(html::text&& html)

--- a/pdf_writer_wx.cpp
+++ b/pdf_writer_wx.cpp
@@ -197,7 +197,7 @@ void pdf_writer_wx::output_image
 std::vector<int> pdf_writer_wx::paginate_html
     (int                          page_width
     ,int                          page_height
-    ,wxString const&              html_str
+    ,wxHtmlContainerCell&         cell
     )
 {
     wxHtmlDCRenderer renderer;
@@ -205,11 +205,7 @@ std::vector<int> pdf_writer_wx::paginate_html
     renderer.SetSize(page_width, page_height);
     DoSetFonts(renderer, html_font_sizes_);
 
-    // Note that we parse HTML twice: here and then again in output_html(),
-    // which is inefficient. Unfortunately currently there is no way to share
-    // neither the parser, nor the result of calling Parse() between
-    // wxHtmlDCRenderer and output_html().
-    renderer.SetHtmlText(html_str);
+    renderer.SetHtmlCell(cell);
 
     std::vector<int> page_breaks;
     for(int pos = 0;;)
@@ -237,7 +233,7 @@ int pdf_writer_wx::output_html
     (int                          x
     ,int                          y
     ,int                          width
-    ,wxString const&              html_str
+    ,wxHtmlContainerCell&         cell
     ,int                          from
     ,int                          to
     ,oenum_render_or_only_measure output_mode
@@ -249,12 +245,7 @@ int pdf_writer_wx::output_html
     // font which is changed by rendering the HTML contents.
     wxDCFontChanger preserve_font(pdf_dc_, wxFont());
 
-    std::unique_ptr<wxHtmlContainerCell> const cell
-        (static_cast<wxHtmlContainerCell*>(html_parser_.Parse(html_str))
-        );
-    LMI_ASSERT(cell);
-
-    cell->Layout(width);
+    cell.Layout(width);
     switch(output_mode)
         {
         case oe_render:
@@ -269,7 +260,7 @@ int pdf_writer_wx::output_html
 
             // "Scroll" the cell upwards by "from" by subtracting it from the
             // vertical position.
-            cell->Draw(pdf_dc_, x, y - from, y, y + to - from, rendering_info);
+            cell.Draw(pdf_dc_, x, y - from, y, y + to - from, rendering_info);
             }
             break;
         case oe_only_measure:
@@ -277,7 +268,7 @@ int pdf_writer_wx::output_html
             break;
         }
 
-    return cell->GetHeight();
+    return cell.GetHeight();
 }
 
 /// Convenient overload when rendering, or measuring, HTML text known to fit on
@@ -294,11 +285,25 @@ int pdf_writer_wx::output_html
     ,oenum_render_or_only_measure output_mode
     )
 {
+    auto const cell{parse_html(std::move(html))};
+    LMI_ASSERT(cell);
+
+    return output_html(x, y, width, *cell, output_mode);
+}
+
+int pdf_writer_wx::output_html
+    (int                          x
+    ,int                          y
+    ,int                          width
+    ,wxHtmlContainerCell&         cell
+    ,oenum_render_or_only_measure output_mode
+    )
+{
     int const height = output_html
         (x
         ,y
         ,width
-        ,wxString::FromUTF8(std::move(html).as_html())
+        ,cell
         ,0
         ,get_total_height()
         ,output_mode
@@ -320,6 +325,19 @@ int pdf_writer_wx::output_html
         }
 
     return height;
+}
+
+std::unique_ptr<wxHtmlContainerCell> pdf_writer_wx::parse_html(html::text&& html)
+{
+    return std::unique_ptr<wxHtmlContainerCell>
+        (static_cast<wxHtmlContainerCell*>
+            (html_parser_.Parse
+                (wxString::FromUTF8
+                    (std::move(html).as_html()
+                    )
+                )
+            )
+        );
 }
 
 int pdf_writer_wx::get_horz_margin() const

--- a/pdf_writer_wx.hpp
+++ b/pdf_writer_wx.hpp
@@ -108,6 +108,8 @@ class pdf_writer_wx
 
     // Helper methods for working with HTML contents.
 
+    void initialize_html_parser(wxHtmlWinParser& html_parser);
+
     std::unique_ptr<wxHtmlContainerCell> parse_html(html::text&& html);
 
     // Page metrics: the page width and height are the size of the page region

--- a/pdf_writer_wx.hpp
+++ b/pdf_writer_wx.hpp
@@ -64,16 +64,24 @@ class pdf_writer_wx
     std::vector<int> paginate_html
         (int                          page_width
         ,int                          page_height
-        ,wxString const&              html_str
+        ,wxHtmlContainerCell&         cell
         );
 
     int output_html
         (int                          x
         ,int                          y
         ,int                          width
-        ,wxString const&              html_str
+        ,wxHtmlContainerCell&         cell
         ,int                          from
         ,int                          to
+        ,oenum_render_or_only_measure output_mode = oe_render
+        );
+
+    int output_html
+        (int                          x
+        ,int                          y
+        ,int                          width
+        ,wxHtmlContainerCell&         cell
         ,oenum_render_or_only_measure output_mode = oe_render
         );
 
@@ -97,6 +105,10 @@ class pdf_writer_wx
     void next_page();
 
     wxDC& dc();
+
+    // Helper methods for working with HTML contents.
+
+    std::unique_ptr<wxHtmlContainerCell> parse_html(html::text&& html);
 
     // Page metrics: the page width and height are the size of the page region
     // reserved for the normal contents, excluding horizontal and vertical

--- a/reg_d_indiv_notes1.mst
+++ b/reg_d_indiv_notes1.mst
@@ -19,10 +19,12 @@
     snail: Chicares, 186 Belle Woods Drive, Glastonbury CT 06033, USA
 }}
 
-{{! No header on this page, but still use the logo. }}
-<img inv_factor="0.27" src="company_logo.png"></img>
+<header>
+  {{! No header on this page, but still use the logo. }}
+  <img inv_factor="0.27" src="company_logo.png"></img>
 
-<p align="center"><font size="+1"><b>Explanatory Notes</b></font></p>
+  <p align="center"><font size="+1"><b>Explanatory Notes</b></font></p>
+</header>
 
 <font size="-1">
 


### PR DESCRIPTION
This PR contains some refactorings of the PDF generation code (notably, it passes the interpolator object to the page ctor) and adds support for drawing headers on the continuation pages, i.e. physical pages other than the first one corresponding to a single logical page.

It also implements a not insignificant optimization by parsing HTML contents of the pages only once and then keeping it, instead of doing it twice as was done before. I didn't have time to remeasure everything with the latest version, but in my preliminary tests I saw ~20% speed up which is nice, especially because this had to be done anyhow.

As a reminder, this PR depends on using a very recent wxWidgets version (such as wxWidgets/wxWidgets@f741031e69de73d5816cc56e99c9beba3ac820de) for the required changes to wxHTML.