### PR TITLE
Avoid assertions due to invalid font during PDF generation

### DIFF
--- a/ledger_pdf_generator_wx.cpp
+++ b/ledger_pdf_generator_wx.cpp
@@ -1397,7 +1397,7 @@ class standard_page : public numbered_page
 
                 // Initializing wxHtmlWinParser changes the font of the DC, so
                 // ensure that we preserve the original font.
-                wxDCFontChanger preserve_font(writer.dc(), wxFont());
+                wxDCFontChanger preserve_font(writer.dc(), *wxNORMAL_FONT);
 
                 // And attach it to another HTML document representing just
                 // the header contents.

--- a/pdf_writer_wx.cpp
+++ b/pdf_writer_wx.cpp
@@ -241,7 +241,7 @@ int pdf_writer_wx::output_html
 
     // We don't really want to change the font, but to preserve the current DC
     // font which is changed by rendering the HTML contents.
-    wxDCFontChanger preserve_font(pdf_dc_, wxFont());
+    wxDCFontChanger preserve_font(pdf_dc_, *wxNORMAL_FONT);
 
     cell.Layout(width);
     switch(output_mode)
@@ -337,7 +337,7 @@ std::unique_ptr<wxHtmlContainerCell> pdf_writer_wx::parse_html(html::text&& html
 {
     // We don't really want to change the font, but to preserve the current DC
     // font which is changed by parsing the HTML contents.
-    wxDCFontChanger preserve_font(pdf_dc_, wxFont());
+    wxDCFontChanger preserve_font(pdf_dc_, *wxNORMAL_FONT);
 
     return std::unique_ptr<wxHtmlContainerCell>
         (static_cast<wxHtmlContainerCell*>


### PR DESCRIPTION
Don't pass invalid font to wxDCFontChanger, in some circumstances it can
be used before it's changed to something else, so use the default font
instead.

Another possibility would be to stop using wxDCFontChanger entirely and
replace it with some (non-existent) wxDCFontPreserver that would just
restore the original font in its dtor but wouldn't change the font in
its ctor at all. However it's not clear if introducing a separate class
is really worth it, so for now continue using wxDCFontChanger.