### PR TITLE
Fix initial font after detaching the header HTML cell

### DIFF
--- a/ledger_pdf_generator_wx.cpp
+++ b/ledger_pdf_generator_wx.cpp
@@ -454,7 +454,17 @@ static char const* const header_cell_id = "_lmi_page_header_id";
 TAG_HANDLER_BEGIN(page_header, "HEADER")
     TAG_HANDLER_PROC(tag)
     {
-        auto container = m_WParser->GetContainer();
+        // Although the header typically occurs at the very beginning of the
+        // HTML template, it doesn't mean that the current container is empty,
+        // quite on the contrary, it typically isn't because it contains the
+        // cells setting the initial colours and font for the HTML body and we
+        // must not make these cells part of the header cell as otherwise they
+        // would be removed from the containing HTML document later and it
+        // would use default font instead of the one set by pdf_writer_wx.
+        // So first, close the existing container and open a new one which we
+        // will mark as being the actual header cell.
+        m_WParser->CloseContainer();
+        const auto container = m_WParser->OpenContainer();
 
         // Set a unique ID for this container to allow finding it later.
         container->SetId(header_cell_id);


### PR DESCRIPTION
Don't detach the initial wxHtmlColourCells and wxHtmlFontCell when
removing the header from the HTML document as this resulted in using the
default back- and foreground colours and font when rendering the part of
the document without the header later, which was wrong as it didn't use
the font explicitly set for all the HTML contents by pdf_writer_wx.

In practice, this resulted in the cells following \<header> tag using a
visible wrong font until the next font change, e.g. a \<b>, \<i> or \<u>
tag occurrence.

The fix itself is trivially simple and consists in only including the
header contents itself in the header cell container, excluding the
contents of the currently opened container which was erroneously
included before.