### PR TITLE
Stop using wxDCFontChanger when not actually changing fonts

### DIFF
--- a/ledger_pdf_generator_wx.cpp
+++ b/ledger_pdf_generator_wx.cpp
@@ -1404,24 +1404,14 @@ class standard_page : public numbered_page
                 // rendered as part of the page body.
                 page_body_cell_->Detach(cell);
 
-                // Initializing wxHtmlWinParser changes the font of the DC, so
-                // ensure that we preserve the original font.
-                wxDCFontChanger preserve_font(writer.dc(), *wxNORMAL_FONT);
-
-                // And attach it to another HTML document representing just
-                // the header contents.
+                // And convert it to self-containing HTML document representing
+                // just the header contents.
                 //
                 // Note that we can't just use this cell on its own, we
                 // must let wxHtmlWinParser build the usual structure as
                 // wxHTML relies on having extra cells in its DOM, notably
                 // the wxHtmlFontCell setting the initial document font.
-                wxHtmlWinParser html_parser;
-                writer.initialize_html_parser(html_parser);
-                html_parser.InitParser(wxString{});
-                header_cell_.reset
-                    (static_cast<wxHtmlContainerCell*>(html_parser.GetProduct())
-                    );
-                header_cell_->InsertCell(cell);
+                header_cell_ = writer.make_html_from(cell);
 
                 break;
                 }

--- a/pdf_writer_wx.cpp
+++ b/pdf_writer_wx.cpp
@@ -350,6 +350,33 @@ std::unique_ptr<wxHtmlContainerCell> pdf_writer_wx::parse_html(html::text&& html
         );
 }
 
+/// Construct a self-contained HTML document from the given cell.
+///
+/// The function takes ownership of its argument and attaches it to the new,
+/// empty, HTML document using the same parameters (i.e. fonts) as all the
+/// other HTML created by output_html().
+
+std::unique_ptr<wxHtmlContainerCell>
+pdf_writer_wx::make_html_from(wxHtmlCell* cell)
+{
+    // Initializing wxHtmlWinParser changes the font of the DC, so
+    // ensure that we preserve the original font.
+    wxDCFontChanger preserve_font(writer.dc(), *wxNORMAL_FONT);
+
+    wxHtmlWinParser html_parser;
+    initialize_html_parser(html_parser);
+    html_parser.InitParser(wxString{});
+
+    auto document_cell = std::make_unique<wxHtmlContainerCell>
+        (static_cast<wxHtmlContainerCell*>(html_parser.GetProduct())
+        );
+
+    // Give ownership of the cell to the new document.
+    document_cell->InsertCell(cell);
+
+    return document_cell;
+}
+
 int pdf_writer_wx::get_horz_margin() const
 {
     return horz_margin;

--- a/pdf_writer_wx.hpp
+++ b/pdf_writer_wx.hpp
@@ -108,9 +108,9 @@ class pdf_writer_wx
 
     // Helper methods for working with HTML contents.
 
-    void initialize_html_parser(wxHtmlWinParser& html_parser);
-
     std::unique_ptr<wxHtmlContainerCell> parse_html(html::text&& html);
+
+    std::unique_ptr<wxHtmlContainerCell> make_html_from(wxHtmlCell* cell);
 
     // Page metrics: the page width and height are the size of the page region
     // reserved for the normal contents, excluding horizontal and vertical
@@ -124,6 +124,8 @@ class pdf_writer_wx
     int get_page_bottom() const;
 
   private:
+    void initialize_html_parser(wxHtmlWinParser& html_parser);
+
     wxPrintData print_data_;
     wxPdfDC pdf_dc_;
 


### PR DESCRIPTION
Use a new simpler and more clear `dc_font_preserver` class instead.