### PR TITLE
Use compressed .mst files

### DIFF
--- a/pdf_command_wx.cpp
+++ b/pdf_command_wx.cpp
@@ -296,13 +296,15 @@ class html_interpolator
 
     std::string load_partial_from_file(std::string const& file) const
     {
-        std::ifstream ifs(AddDataDir(file + ".mst"));
+        constexpr auto template_extension = ".mst";
+
+        std::ifstream ifs(AddDataDir(file + template_extension));
         if(!ifs)
             {
             alarum()
                 << "Template file \""
-                << file
-                << ".mst\" not found."
+                << file << template_extension
+                << "\" not found."
                 << std::flush
                 ;
             }

--- a/wx_checks.cpp
+++ b/wx_checks.cpp
@@ -43,6 +43,10 @@
 #   error Enable wxUSE_PRINTING_ARCHITECTURE in wx setup.
 #endif // !wxUSE_PRINTING_ARCHITECTURE
 
+#if !wxUSE_LIBLZMA
+#   error Enable wxUSE_LIBLZMA in wx setup.
+#endif // !wxUSE_LIBLZMA
+
 // Ensure that certain inappropriate options aren't used.
 
 // License not obviously compatible with GPL.


### PR DESCRIPTION
The main commit is this one:

---
Read templates from compressed .zst files instead of .mst ones

For obfuscation purposes, compress the Moustache template files and
rename them to have the .zst extension.

Update the code to decompress the files using wxWidgets LZMA support and
"make install" target to compress the .mst files with xz when installing
them.