### PR TITLE
Fix initializing a new HTML document containing the given cell

### DIFF
--- a/pdf_writer_wx.cpp
+++ b/pdf_writer_wx.cpp
@@ -388,9 +388,10 @@ pdf_writer_wx::make_html_from(wxHtmlCell* cell)
     initialize_html_parser(html_parser);
     html_parser.InitParser(wxString{});
 
-    auto document_cell = std::make_unique<wxHtmlContainerCell>
-        (static_cast<wxHtmlContainerCell*>(html_parser.GetProduct())
-        );
+    // Take ownership of the DOM containing just the initial colors and font.
+    std::unique_ptr<wxHtmlContainerCell> document_cell
+        {static_cast<wxHtmlContainerCell*>(html_parser.GetProduct())
+        };
 
     // Give ownership of the cell to the new document.
     document_cell->InsertCell(cell);


### PR DESCRIPTION
make_html_from() function didn't do anything useful as it made a shallow
copy of the new document it created (leaking the original one in the
process) instead of simply taking ownership of it.

This meant that the object returned from this function did not contain
the color and font cells which was the sole reason for its existence in
the first place and, due to this, the header cells created using this
function didn't use the correct initial font, resulting in visibly wrong
appearance, which is fixed by this change.