### PR TITLE
Cache items of wxItemContainer in MvcController

### DIFF
--- a/mvc_controller.cpp
+++ b/mvc_controller.cpp
@@ -353,7 +353,11 @@ void MvcController::ConditionallyEnableItems
             itembox->Set(cached_items);
             }
 
-        itembox->SetStringSelection(datum->str(datum->ordinal()));
+        auto const& selected_string = datum->str(datum->ordinal());
+        if(itembox->GetStringSelection() != selected_string)
+            {
+            itembox->SetStringSelection(selected_string);
+            }
         }
     else
         {

--- a/mvc_controller.cpp
+++ b/mvc_controller.cpp
@@ -331,19 +331,28 @@ void MvcController::ConditionallyEnableItems
         }
     else if(itembox)
         {
-        // WX !! wxWindowUpdateLocker doesn't seem to help much.
-        wxWindowUpdateLocker u(&control);
-        itembox->Clear();
-        // WX !! Append(wxArrayString const&) "may be much faster"
-        // according to wx online help, but that seems untrue: its
-        // implementation just uses a loop.
+        auto& cached_items = itemboxes_cache_[name];
+
+        std::vector<wxString> items;
+        items.reserve(datum->cardinality());
+
         for(int j = 0; j < datum->cardinality(); ++j)
             {
             if(datum->is_allowed(j))
                 {
-                itembox->Append(datum->str(j));
+                items.push_back(datum->str(j));
                 }
             }
+
+        wxWindowUpdateLocker u(&control);
+
+        if(items != cached_items)
+            {
+            std::swap(cached_items, items);
+
+            itembox->Set(cached_items);
+            }
+
         itembox->SetStringSelection(datum->str(datum->ordinal()));
         }
     else

--- a/mvc_controller.hpp
+++ b/mvc_controller.hpp
@@ -30,6 +30,7 @@
 
 #include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 class MvcModel;
@@ -374,6 +375,9 @@ namespace model_view_controller{} // doxygen workaround.
 ///
 /// view_: Reference to View.
 ///
+/// itemboxes_cache_: Cached items of wxItemContainer instances,
+/// identified by their names, in the View.
+///
 /// last_focused_window_: Points to the last window, other than a
 /// 'Cancel' pushbutton, that had gained focus without losing it
 /// immediately due to UponRefocusInvalidControl(). This is the one
@@ -462,6 +466,8 @@ class MvcController final
 
     MvcModel& model_;
     MvcView const& view_;
+
+    std::unordered_map<std::string, std::vector<wxString>> itemboxes_cache_;
 
     wxWindow* last_focused_window_;
 


### PR DESCRIPTION
Store items of itemboxes in MvcController and update the item list only
when its changed to speed up the ConditionallyEnableItems function.

This commit with previous time measurement commit (to compare time `before` and `after`):
https://github.com/thesiv/lmi/commit/765597ce065c2f464e419f926efe7f51bf6ae3b2

You can benchmark this the changes of this commit using this commit:
[Add time measurement for mvc_controller profiling](https://github.com/thesiv/lmi/commit/75206e5865622ce505f1120d8162765624e45ef2)
Also there is the development branch:
[speed_up_mvc_controller_dev](https://github.com/thesiv/lmi/commits/speed_up_mvc_controller_dev)