### PR TITLE
Use Ubuntu 18.04 only for WSL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -83,7 +83,10 @@ and execute the installation script:
 
   C:\cache_for_lmi\install_wsl.ps1
 
-Select preferred OS or simply press Enter to install Ubuntu 18.04.
+Note: Only Ubuntu 18.04 is supported now because non-Debian-based OS won't work,
+as we use apt, Debian and Ubuntu 16.04 uses the i686-w64-mingw32-g++ package of
+lower version than required, so can't be used too.
+
 After a few minutes, you should see something like this at the end:
 
   "WSL installation seems to have succeeded"

--- a/install_wsl.ps1
+++ b/install_wsl.ps1
@@ -32,41 +32,9 @@ if ((Test-Path -Path $wsl_registry) -And `
     (Get-ChildItem $wsl_registry).Length -gt 0) {
     Write-Output 'WSL OS already installed:'
     Write-Output (Get-ChildItem $wsl_registry | ForEach-Object {Get-ItemProperty $_.PSPath}).DistributionName
+    Write-Output 'Note: Only "Ubuntu 18.04" is currently supported.'
     return
 }
-
-# Select a Debian-compatible OS: our build scripts use apt.
-$os_list = @(
-    @{
-        name = 'Ubuntu 18.04'
-        filename = 'Ubuntu_18_04.appx'
-        uri = 'https://aka.ms/wsl-ubuntu-1804'
-    }
-    @{
-        name = 'Ubuntu 16.04'
-        filename = 'Ubuntu_16_04.appx'
-        uri = 'https://aka.ms/wsl-ubuntu-1604'
-    }
-    @{
-        name = 'Debian GNU/Linux'
-        filename = 'Debian_GNU_Linux.appx'
-        uri = 'https://aka.ms/wsl-debian-gnulinux'
-    }
-)
-
-$options = @()
-for ($i=1; $i -le $os_list.Length; $i++) {
-    $os_name = $os_list[$i-1].name
-    $d = [System.Management.Automation.Host.ChoiceDescription]::new("&$i. $os_name")
-    $options += $d
-}
-
-$title = 'Please select the OS to install'
-$description = "Note: Non-Debian-based OS won't work, as we use apt."
-
-$opt = $host.UI.PromptForChoice($title, $description, $options, 0)
-$os = $os_list[$opt]
-Write-Output ('"' + $os.name + '" was chosen.')
 
 # Create the download directory.
 $dir = 'C:\cache_for_lmi\downloads\'
@@ -75,14 +43,15 @@ If (!(Test-Path -Path $dir)) {
 }
 
 # Download the OS distribution.
-$path = 'C:\cache_for_lmi\downloads\' + $os.filename
+$path = 'C:\cache_for_lmi\downloads\Ubuntu_18_04.appx'
 If (!(Test-Path -Path $path)) {
-    Write-Output ('Downloading "' + $os.name + '"...')
-    Invoke-WebRequest -Uri $os.uri -OutFile $path -UseBasicParsing
+    Write-Output ('Downloading "Ubuntu 18.04"...')
+    $os_uri = 'https://aka.ms/wsl-ubuntu-1804'
+    Invoke-WebRequest -Uri $os_uri -OutFile $path -UseBasicParsing
 }
 
 # Install the OS.
-Write-Output ('Installing "' + $os.name + '"...')
+Write-Output ('Installing "Ubuntu 18.04"...')
 Add-AppxPackage -Path $path
 
 Write-Output 'WSL installation seems to have succeeded'


### PR DESCRIPTION
Only Ubuntu 18.04 is supported now because non-Debian-based OS won't
work, as we use apt, Debian and Ubuntu 16.04 uses the
i686-w64-mingw32-g++ package of lower version than required, so can't
be used too.