### PR TITLE
Improve error reporting for pdf generaion

### DIFF
--- a/pdf_command_wx.cpp
+++ b/pdf_command_wx.cpp
@@ -826,7 +826,7 @@ class pdf_illustration : protected html_interpolator, protected pdf_writer_wx
                 {
                 i->pre_render();
                 }
-            catch(const std::runtime_error& e)
+            catch(std::runtime_error const& e)
                 {
                 std::ostringstream oss;
                 oss
@@ -862,7 +862,7 @@ class pdf_illustration : protected html_interpolator, protected pdf_writer_wx
 
                 i->render();
                 }
-            catch(const std::runtime_error& e)
+            catch(std::runtime_error const& e)
                 {
                 std::ostringstream oss;
                 oss


### PR DESCRIPTION
If an exception was thrown while generating a pdf document, rethrow
std::runtime_exception whith the added name of the current page.