### PR TITLE
Remove dependency on the external md5sum.exe

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -415,6 +415,7 @@ liblmi_la_SOURCES = \
     irc7702_tables.cpp \
     lmi.cpp \
     md5.cpp \
+    md5sum.cpp \
     mec_input.cpp \
     mec_server.cpp \
     mec_state.cpp \
@@ -459,6 +460,7 @@ generate_passkey_SOURCES = \
     generate_passkey.cpp \
     global_settings.cpp \
     md5.cpp \
+    md5sum.cpp \
     miscellany.cpp \
     null_stream.cpp \
     path_utility.cpp \
@@ -594,6 +596,7 @@ test_authenticity_SOURCES = \
   calendar_date.cpp \
   global_settings.cpp \
   md5.cpp \
+  md5sum.cpp \
   miscellany.cpp \
   null_stream.cpp \
   path_utility.cpp \
@@ -1329,6 +1332,7 @@ noinst_HEADERS = \
     mc_enum_types.hpp \
     mc_enum_types.xpp \
     mc_enum_types_aux.hpp \
+    md5sum.hpp \
     md5.hpp \
     mec_document.hpp \
     mec_input.hpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -44,6 +44,7 @@ bin_PROGRAMS = \
     lmi_cli \
     lmi_wx \
     elapsed_time \
+    lmi_md5sum \
     generate_passkey \
     antediluvian_cli \
     ihs_crc_comp \
@@ -453,6 +454,16 @@ libwx_new_la_LDFLAGS = -no-undefined $(AM_LDFLAGS)
 libwx_new_la_LIBADD = $(WX_LIBS)
 
 # auxiliary executables
+
+lmi_md5sum_SOURCES = \
+    getopt.cpp \
+    md5.cpp \
+    md5sum.cpp \
+    md5sum_cli.cpp
+lmi_md5sum_CXXFLAGS = $(AM_CXXFLAGS) $(BOOST_INCLUDE_FLAGS)
+lmi_md5sum_LDADD = \
+    $(BOOST_LIBS) \
+    libmain_auxiliary_common.la
 
 generate_passkey_SOURCES = \
     authenticity.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -120,6 +120,7 @@ TESTS = \
     test_materially_equal \
     test_math_functions \
     test_mc_enum \
+    test_md5sum \
     test_miscellany \
     test_mortality_rates \
     test_name_value_pairs \
@@ -923,6 +924,15 @@ test_mc_enum_SOURCES = \
   path_utility.cpp
 test_mc_enum_CXXFLAGS = $(AM_CXXFLAGS)
 test_mc_enum_LDADD = \
+  $(BOOST_LIBS)
+
+test_md5sum_SOURCES = \
+  $(common_test_objects) \
+  md5.cpp \
+  md5sum.cpp \
+  md5sum_test.cpp
+test_md5sum_CXXFLAGS = $(AM_CXXFLAGS)
+test_md5sum_LDADD = \
   $(BOOST_LIBS)
 
 test_miscellany_SOURCES = \

--- a/authenticity.cpp
+++ b/authenticity.cpp
@@ -29,6 +29,7 @@
 #include "global_settings.hpp"
 #include "handle_exceptions.hpp"
 #include "md5.hpp"
+#include "md5sum.hpp"
 #include "path_utility.hpp"             // fs::path inserter
 #include "platform_dependent.hpp"       // chdir()
 #include "system_command.hpp"
@@ -45,11 +46,6 @@
 // TODO ?? Known security hole: data files can be modified after they
 // have been validated with 'md5sum'. This problem will grow worse
 // when the binary database files are replaced with xml.
-
-namespace
-{
-    int const chars_per_formatted_hex_byte = CHAR_BIT / 4;
-}
 
 Authenticity& Authenticity::Instance()
 {
@@ -189,19 +185,25 @@ std::string Authenticity::Assay
         }
 
     // Validate all data files.
-    fs::path original_path(fs::current_path());
-    if(0 != chdir(data_path.string().c_str()))
-        {
-        oss
-            << "Unable to change directory to '"
-            << data_path
-            << "'. Try reinstalling."
-            ;
-        return oss.str();
-        }
     try
         {
-        system_command("md5sum --check --status " + std::string(md5sum_file()));
+        auto const sums = md5_read_checksum_file(data_path / md5sum_file());
+        for(auto const& s : sums)
+            {
+            auto const file_path = data_path / s.filename;
+            auto const md5 = md5_calculate_file_checksum
+                (data_path / s.filename
+                ,s.file_mode
+                );
+            if(md5 != s.md5sum)
+                {
+                    throw std::runtime_error
+                        ( "Integrity check failed for '"
+                        + s.filename.string()
+                        + "'"
+                        );
+                }
+            }
         }
     catch(...)
         {
@@ -209,15 +211,6 @@ std::string Authenticity::Assay
         oss
             << "At least one required file is missing, altered, or invalid."
             << " Try reinstalling."
-            ;
-        return oss.str();
-        }
-    if(0 != chdir(original_path.string().c_str()))
-        {
-        oss
-            << "Unable to restore directory to '"
-            << original_path
-            << "'. Try reinstalling."
             ;
         return oss.str();
         }
@@ -276,20 +269,4 @@ void authenticate_system()
         warning() << diagnostic_message << LMI_FLUSH;
         std::exit(EXIT_FAILURE);
         }
-}
-
-std::string md5_hex_string(std::vector<unsigned char> const& vuc)
-{
-    LMI_ASSERT(md5len == vuc.size());
-    std::stringstream oss;
-    oss << std::hex;
-    for(auto const& j : vuc)
-        {
-        oss
-            << std::setw(chars_per_formatted_hex_byte)
-            << std::setfill('0')
-            << static_cast<int>(j)
-            ;
-        }
-    return oss.str();
 }

--- a/authenticity.hpp
+++ b/authenticity.hpp
@@ -25,18 +25,13 @@
 #include "config.hpp"
 
 #include "calendar_date.hpp"
+#include "md5sum.hpp"
 #include "so_attributes.hpp"
 
 #include <boost/filesystem/path.hpp>
 
-#include <climits>                      // CHAR_BIT
 #include <string>
 #include <vector>
-
-// The gnu libc md5 implementation seems to assume this:
-static_assert(8 == CHAR_BIT || 16 == CHAR_BIT);
-// so md5 output is 128 bits == 16 8-bit bytes or 8 16-bit bytes:
-enum {md5len = 128 / CHAR_BIT};
 
 /// Permit running the system iff data files and date are valid.
 ///
@@ -74,10 +69,6 @@ class Authenticity final
 /// skip authentication altogether for the most-privileged password.
 
 void LMI_SO authenticate_system();
-
-/// Hex representation of an md5 sum as a string.
-
-std::string md5_hex_string(std::vector<unsigned char> const&);
 
 /// Name of file containing md5sums of secured files.
 

--- a/authenticity_test.cpp
+++ b/authenticity_test.cpp
@@ -26,6 +26,7 @@
 #include "assert_lmi.hpp"
 #include "contains.hpp"
 #include "md5.hpp"
+#include "md5sum.hpp"
 #include "miscellany.hpp"
 #include "system_command.hpp"
 #include "test_tools.hpp"

--- a/authenticity_test.cpp
+++ b/authenticity_test.cpp
@@ -110,15 +110,15 @@ PasskeyTest::~PasskeyTest()
     RemoveTestFiles(__FILE__, __LINE__);
 }
 
-/// Regrettably, invoking 'md5sum' through a shell just to confirm its
+/// Regrettably, invoking 'lmi_md5sum' through a shell just to confirm its
 /// availability writes its output to stdout; however, without this
 /// test, it would be difficult to tell whether downstream errors stem
 /// from that program's absence.
 
 void PasskeyTest::EnsureMd5sumBinaryIsFound() const
 {
-    std::cout << "  Result of 'md5sum --version':" << std::endl;
-    system_command("md5sum --version");
+    std::cout << "  Result of 'lmi_md5sum --version':" << std::endl;
+    system_command("lmi_md5sum --version");
 }
 
 void PasskeyTest::RemoveTestFiles(char const* file, int line) const
@@ -169,19 +169,19 @@ void PasskeyTest::InitializeDataFile() const
     BOOST_TEST_EQUAL("bf039dbb0e8061971a2c322c8336199c", md5_str(sum));
 }
 
-/// Write a data file to be passed to the 'md5sum' program.
+/// Write a data file to be passed to the 'lmi_md5sum' program.
 ///
 /// For production, a file with md5 sums of crucial files is provided.
 /// For this unit test, file 'coleridge' is the sole crucial file.
 ///
 /// This file consists of the md5 sum of the data file followed by two
 /// spaces and the name of the data file. Creating that file portably
-/// here by running 'md5sum' would require redirection, which isn't
-/// part of the standard C++ library, so the effect of 'md5sum' is
-/// instead emulated; testing that file here with 'md5sum' validates
-/// that emulation and guards against a bogus 'md5sum' program.
+/// here by running 'lmi_md5sum' would require redirection, which isn't
+/// part of the standard C++ library, so the effect of 'lmi_md5sum' is
+/// instead emulated; testing that file here with 'lmi_md5sum' validates
+/// that emulation and guards against a bogus 'lmi_md5sum' program.
 ///
-/// Postcondition: the file passes a test with the 'md5sum' program.
+/// Postcondition: the file passes a test with the 'lmi_md5sum' program.
 
 void PasskeyTest::InitializeMd5sumFile() const
 {
@@ -197,7 +197,7 @@ void PasskeyTest::InitializeMd5sumFile() const
     os << "  coleridge\n";
     os.close();
 
-    std::string s = "md5sum --check --status " + std::string(md5sum_file());
+    std::string s = "lmi_md5sum --check --status " + std::string(md5sum_file());
     system_command(s);
 }
 

--- a/generate_passkey.cpp
+++ b/generate_passkey.cpp
@@ -19,9 +19,10 @@
 // email: <gchicares@sbcglobal.net>
 // snail: Chicares, 186 Belle Woods Drive, Glastonbury CT 06033, USA
 
-#include "authenticity.hpp"             // md5_hex_string()
+#include "authenticity.hpp"       // md5sum_file()
 #include "main_common.hpp"
 #include "md5.hpp"
+#include "md5sum.hpp"             // md5_hex_string()
 
 #include <cstdio>
 #include <cstdlib>

--- a/install_miscellanea.make
+++ b/install_miscellanea.make
@@ -47,7 +47,6 @@ third_party_source_dir  := $(dest_dir)/src
 boost_archive    := boost_1_33_1.tar.bz2
 cgicc_archive    := cgicc-3.1.4.tar.bz2
 jing_archive     := jing-20091111.zip
-md5sum_msw_exe   := md5sum.exe
 sample_archive   := lmi-data-20050618T1440Z.tar.bz2
 trang_archive    := trang-20091111.zip
 xmlwrapp_archive := xmlwrapp-0.9.0.tar.gz
@@ -56,14 +55,12 @@ file_list := \
   $(boost_archive) \
   $(cgicc_archive) \
   $(jing_archive) \
-  $(md5sum_msw_exe) \
   $(sample_archive) \
   $(trang_archive) \
   $(xmlwrapp_archive) \
 
 boost cgicc xmlwrapp: stem = $(basename $(basename $($@_archive)))
 jing trang:           stem =            $(basename $($@_archive))
-md5sum_msw:           stem = $(md5sum_msw_exe)
 sample:               stem = data
 
 # URLs and archive md5sums #####################################################
@@ -71,7 +68,6 @@ sample:               stem = data
 $(boost_archive)-url    := $(sf_mirror)/boost/$(boost_archive)
 $(cgicc_archive)-url    := ftp://ftp.gnu.org/pub/gnu/cgicc/$(cgicc_archive)
 $(jing_archive)-url     := https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/jing-trang/$(jing_archive)
-$(md5sum_msw_exe)-url   := https://github.com/vadz/lmi/releases/download/new-cygwin-makefiles/md5sum.exe
 $(sample_archive)-url   := https://download.savannah.gnu.org/releases/lmi/$(sample_archive)
 $(trang_archive)-url    := https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/jing-trang/$(trang_archive)
 $(xmlwrapp_archive)-url := https://github.com/vslavik/xmlwrapp/releases/download/v0.9.0/$(xmlwrapp_archive)
@@ -79,7 +75,6 @@ $(xmlwrapp_archive)-url := https://github.com/vslavik/xmlwrapp/releases/download
 $(boost_archive)-md5    := 2b999b2fb7798e1737d1fff8fac602ef
 $(cgicc_archive)-md5    := 6cb5153fc9fa64b4e50c7962aa557bbe
 $(jing_archive)-md5     := 13eef193921409a1636377d1efbf9843
-$(md5sum_msw_exe)-md5   := eb574b236133e60c989c6f472f07827b
 $(sample_archive)-md5   := e7f07133abfc3b9c2252dfa3b61191bc
 $(trang_archive)-md5    := 9d31799b948c350850eb9dd14e5b832d
 $(xmlwrapp_archive)-md5 := 5e8ac678ab03b7c60ce61ac5424e0849
@@ -121,7 +116,7 @@ ad_hoc_dir_exists = \
 # Targets ######################################################################
 
 .PHONY: all
-all: boost cgicc jing md5sum_msw sample trang xmlwrapp
+all: boost cgicc jing sample trang xmlwrapp
 
 # Patches were generated according to this advice:
 #
@@ -188,28 +183,6 @@ jing: $(file_list)
 	$(MKDIR) --parents $(dest_dir)/rng
 	$(MV) $(ad_hoc_dir)/$(stem)/bin/$@.jar         $(dest_dir)/rng
 	$(MV) $(ad_hoc_dir)/$(stem)/bin/xercesImpl.jar $(dest_dir)/rng
-
-# The 'md5sum_msw' binary is redistributed to msw end users for
-# authentication, so the 'fardel' target requires it. On other
-# platforms, it cannot be executed directly, but it is needed for
-# creating a cross 'fardel' and for running cross unit tests.
-#
-# It is placed in lmi's 'third_party/bin/' subdirectory--imperatively
-# not in lmi's 'local/bin/' subdirectory, which is added to $PATH.
-# For cygwin builds, the expressly downloaded 'md5sum.exe' is kept off
-# $PATH to prevent it from shadowing cygwin's own version. However,
-# for cross builds, it cannot shadow the native 'md5sum', yet some
-# cross-built unit tests require an msw binary, so add its directory
-# to $WINEPATH to make those tests work (incidentally, 'wine' doesn't
-# find it if it's simply symlinked).
-#
-# Should the given URL ever become invalid, see:
-#   http://www.openoffice.org/dev_docs/using_md5sums.html#links
-# to find another.
-
-.PHONY: md5sum_msw
-md5sum_msw: $(file_list)
-	$(CP) --preserve $(cache_dir)/$(stem) $(third_party_bin_dir)
 
 # The 'clobber' target doesn't remove $(prefix)/data because that
 # directory might contain valuable user-customized files; hence, in

--- a/md5sum.cpp
+++ b/md5sum.cpp
@@ -1,0 +1,225 @@
+// Compute checksums of files or strings.
+//
+// Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019 Gregory W. Chicares.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//
+// http://savannah.nongnu.org/projects/lmi
+// email: <gchicares@sbcglobal.net>
+// snail: Chicares, 186 Belle Woods Drive, Glastonbury CT 06033, USA
+
+#include "pchfile.hpp"
+
+#include "assert_lmi.hpp"
+#include "md5.hpp"
+#include "md5sum.hpp"
+#include "miscellany.hpp"
+
+#include <fstream>
+#include <memory>
+
+std::vector<md5sum_for_file> md5_read_checksum_stream
+    (std::istream& is
+    ,std::string const& stream_description
+    )
+{
+    std::vector<md5sum_for_file> result_vec;
+
+    int line_number = 0;
+    auto error_with_message = [&line_number, stream_description] (char const* message)
+        {
+        std::ostringstream oss;
+        oss << "'" << stream_description << "': " << message << " at line " << line_number;
+        return oss.str();
+        };
+
+    std::string line;
+    while(std::getline(is, line))
+        {
+        ++line_number;
+
+        // The minimal length: 32(md5sum) + 2(spaces) + 1(shortest file name)
+        size_t const minimal_line_length = 35;
+
+        // Ignore comment lines, which begin with a '#' character.
+        // Empty lines are not allowed.
+        if(!line.empty() && line.front() == '#')
+            {
+            continue;
+            }
+
+        if(line.size() < minimal_line_length)
+            {
+            throw std::runtime_error(error_with_message("line too short"));
+            }
+
+        auto const space_pos = line.find(' ');
+        if(line.size() - 1 <= space_pos)
+            {
+            throw std::runtime_error(error_with_message("incorrect checksum line format"));
+            }
+
+        char const second_delimiter = line[space_pos + 1];
+        md5_file_mode file_mode;
+        if(second_delimiter == ' ')
+            {
+            file_mode = md5_file_mode::text;
+            }
+        else if(second_delimiter == '*')
+            {
+            file_mode = md5_file_mode::binary;
+            }
+        else
+            {
+            throw std::runtime_error(error_with_message("incorrect checksum line format"));
+            }
+
+        std::string md5sum = line.substr(0, space_pos);
+        std::string file = line.substr(space_pos + 2);
+
+        if(md5sum.size() != chars_per_formatted_hex_byte * md5len)
+            {
+            throw std::runtime_error(error_with_message("incorrect MD5 sum format"));
+            }
+
+        result_vec.emplace_back(std::move(file), std::move(md5sum), file_mode);
+        }
+
+    return result_vec;
+}
+
+std::vector<md5sum_for_file> md5_read_checksum_file(fs::path const& filename)
+{
+    auto const filename_string = filename.string();
+
+    std::ifstream is(filename_string);
+    if(!is)
+        {
+        std::ostringstream oss;
+        oss << "'" << filename_string << "': no such file or directory";
+        throw std::runtime_error(oss.str());
+        }
+
+    return md5_read_checksum_stream(is, filename_string);
+}
+
+std::string md5_calculate_stream_checksum
+    (std::istream& is
+    ,std::string const& stream_description
+    )
+{
+    std::vector<unsigned char> md5(md5len);
+
+    // Note that block_size must be a multiple of 64 to use md5_process_block()
+    // below.
+    constexpr std::streamsize block_size = 4096;
+    md5_ctx ctx;
+    char buffer[block_size];
+    std::streamsize read_count;
+
+    // Initialize the computation context.
+    md5_init_ctx(&ctx);
+
+    // Iterate over full file contents.
+    for(;;)
+        {
+        // We read the file in blocks of block_size bytes. One call of the
+        // computation function processes the whole buffer so that with the
+        // next round of the loop another block can be read.
+        is.read(buffer, block_size);
+        read_count = is.gcount();
+
+        // If end of file is reached, end the loop.
+        if (is.eof())
+            {
+            break;
+            }
+
+        if(read_count != block_size || !is)
+            {
+            std::ostringstream oss;
+            oss
+                << "'"
+                << stream_description
+                << "': failed to read data while computing md5sum"
+                ;
+            throw std::runtime_error(oss.str());
+            }
+
+        // Process buffer with block_size bytes. Note that
+        // block_size % 64 == 0
+        md5_process_block(buffer, block_size, &ctx);
+        }
+
+    // Add the last bytes if necessary.
+    if(read_count > 0)
+        {
+        // Note that we have to use md5_process_bytes() and not the faster
+        // md5_process_block() here because the read_count is not necessarily
+        // a multiple of 64 here.
+        md5_process_bytes(buffer, read_count, &ctx);
+        }
+
+    // Construct result in desired memory.
+    md5_finish_ctx(&ctx, md5.data());
+
+    return md5_hex_string(md5);
+}
+
+std::string LMI_SO md5_calculate_file_checksum
+    (fs::path const& filename
+    ,md5_file_mode file_mode
+    )
+{
+    auto const filename_string = filename.string();
+
+    std::vector<unsigned char> md5(md5len);
+
+    std::ios_base::openmode open_mode{std::ios_base::in};
+    switch (file_mode)
+        {
+        case md5_file_mode::binary:
+            open_mode |= std::ios_base::binary;
+            break;
+        case md5_file_mode::text:
+            // Nothing to do.
+            break;
+        }
+
+    std::ifstream is(filename_string, open_mode);
+    if(!is)
+        {
+        std::ostringstream oss;
+        oss << "'" << filename_string << "': no such file or directory";
+        throw std::runtime_error(oss.str());
+        }
+
+    return md5_calculate_stream_checksum(is, filename_string);
+}
+
+std::string md5_hex_string(std::vector<unsigned char> const& vuc)
+{
+    LMI_ASSERT(md5len == vuc.size());
+    std::stringstream oss;
+    oss << std::hex;
+    for(auto const& j : vuc)
+        {
+        oss
+            << std::setw(chars_per_formatted_hex_byte)
+            << std::setfill('0')
+            << static_cast<int>(j)
+            ;
+        }
+    return oss.str();
+}

--- a/md5sum.hpp
+++ b/md5sum.hpp
@@ -1,0 +1,115 @@
+// Compute checksums of files or strings.
+//
+// Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019 Gregory W. Chicares.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//
+// http://savannah.nongnu.org/projects/lmi
+// email: <gchicares@sbcglobal.net>
+// snail: Chicares, 186 Belle Woods Drive, Glastonbury CT 06033, USA
+
+#ifndef md5sum_hpp
+#define md5sum_hpp
+
+#include "config.hpp"
+#include "so_attributes.hpp"
+
+#include <boost/filesystem/path.hpp>
+
+#include <climits>                      // CHAR_BIT
+#include <string>
+#include <vector>
+
+// The gnu libc md5 implementation seems to assume this:
+static_assert(8 == CHAR_BIT || 16 == CHAR_BIT);
+// so md5 output is 128 bits == 16 8-bit bytes or 8 16-bit bytes:
+enum { md5len = 128 / CHAR_BIT };
+
+enum { chars_per_formatted_hex_byte = CHAR_BIT / 4 };
+
+enum class md5_file_mode
+{
+    binary,
+    text
+};
+
+struct md5sum_for_file
+{
+    md5sum_for_file(fs::path&& path, std::string&& sum, md5_file_mode mode)
+        :filename{std::move(path)}
+        ,md5sum{std::move(sum)}
+        ,file_mode{mode}
+    {}
+
+    fs::path      filename;
+    std::string   md5sum;
+    md5_file_mode file_mode{md5_file_mode::binary};
+};
+
+/// Reads the vector of structs with the file name and the md5 sum from the given input
+/// stream.
+///
+/// Throws an std::runtime_error in case of an error.
+///
+/// The input stream must consist of lines with checksum and filename pairs and optional
+/// comments introduced by '#' character at the beginning of the line.
+/// Sample:
+/// 595f44fec1e92a71d3e9e77456ba80d1  filetohashA.txt
+/// 71f920fa275127a7b60fa4d4d41432a3  filetohashB.txt
+/// 43c191bf6d6c3f263a8cd0efd4a058ab  filetohashC.txt
+///
+/// There must be two spaces or a space and an asterisk between each md5sum
+/// value and filename to be compared (the second space indicates text mode,
+/// the asterisk binary mode). Otherwise, a std::runtime_error will be thrown.
+///
+/// The stream_description parameter is only used in exceptions messages.
+
+std::vector<md5sum_for_file> LMI_SO md5_read_checksum_stream
+    (std::istream& is
+    ,std::string const& stream_description
+    );
+
+/// Reads the vector of structs with the file name and the md5 sum from the file.
+///
+/// Throws an std::runtime_error in case of an error.
+///
+/// Uses md5_read_checksum_stream to read the content of the file.
+
+std::vector<md5sum_for_file> LMI_SO md5_read_checksum_file
+    (fs::path const& filename
+    );
+
+/// Reads the content of the input stream and calculates the md5sum from it.
+///
+/// Throws an std::runtime_error in case of an error.
+
+std::string LMI_SO md5_calculate_stream_checksum
+    (std::istream& is
+    ,std::string const& stream_description
+    );
+
+/// Reads the content of the file and calculates the md5sum from it.
+///
+/// Throws an std::runtime_error in case of an error.
+
+std::string LMI_SO md5_calculate_file_checksum
+    (fs::path const& filename
+    ,md5_file_mode file_mode = md5_file_mode::binary
+    );
+
+/// Hex representation of an md5 sum as a string.
+
+std::string LMI_SO md5_hex_string(std::vector<unsigned char> const&);
+
+#endif // md5sum_hpp

--- a/md5sum_cli.cpp
+++ b/md5sum_cli.cpp
@@ -1,0 +1,259 @@
+// Limited functionality variant of GNU `md5sum` program.
+//
+// Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019 Gregory W. Chicares.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; ifnot, write to the Free Software Foundation,
+// Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//
+// http://savannah.nongnu.org/projects/lmi
+// email: <gchicares@sbcglobal.net>
+// snail: Chicares, 186 Belle Woods Drive, Glastonbury CT 06033, USA
+
+#include "pchfile.hpp"
+
+#include "getopt.hpp"
+#include "main_common.hpp"
+#include "md5sum.hpp"
+
+#include <iostream>
+
+int usage(int status)
+{
+    if(status != EXIT_SUCCESS)
+        {
+        std::cerr << "Try 'lmi_md5sum --help' for more information.\n";
+        }
+    else
+        {
+        std::cout
+            <<
+R"(Usage: lmi_md5sum [OPTION]... [FILE]...
+Print or check MD5 (128-bit) checksums.
+
+  -b, --binary   read in binary mode (default)
+  -c, --check    read MD5 sums from the FILEs and check them
+  -t, --text     read in text mode
+
+The following two options are useful only when verifying checksums:
+      --quiet    don't print OK for each successfully verified file
+      --status   don't output anything, status code shows success
+
+      --help     display this help and exit
+      --version  output version information and exit
+
+The sums are computed as described in RFC 1321.  When checking, the input
+should be a former output of this program. The default mode is to print a
+line with checksum, a space, a character indicating input mode ('*' for binary
+' ' for text or where binary is insignificant), and name for each FILE.
+
+This program is a limited functionality variant of GNU 'md5sum' utility
+and is part of the 'Let Me Illustrate' project.
+)"
+        ;
+        }
+    return status;
+}
+
+void version()
+{
+    std::cout
+        <<
+R"(lmi_md5sum 0.9
+
+This program is a limited functionality variant of GNU 'md5sum' utility
+and is part of the 'Let Me Illustrate' project.
+)"
+        ;
+}
+
+// For long options that have no equivalent short option, use a
+// non-character as a pseudo short option, starting with CHAR_MAX + 1.
+enum
+{
+    STATUS_OPTION = CHAR_MAX + 1,
+    QUIET_OPTION,
+    HELP_OPTION,
+    VERSION_OPTION
+};
+
+int try_main(int argc, char* argv[])
+{
+    bool all_ok = true;
+    int c;
+    int option_index = 0;
+    struct Option long_options[] =
+        {
+            {"binary"      ,NO_ARG   ,0 ,'b'            ,0 ,""},
+            {"check"       ,NO_ARG   ,0 ,'c'            ,0 ,""},
+            {"quiet"       ,NO_ARG   ,0 ,QUIET_OPTION   ,0 ,""},
+            {"status"      ,NO_ARG   ,0 ,STATUS_OPTION  ,0 ,""},
+            {"text"        ,NO_ARG   ,0 ,'t'            ,0 ,""},
+            {"help"        ,NO_ARG   ,0 ,HELP_OPTION    ,0 ,""},
+            {"version"     ,NO_ARG   ,0 ,VERSION_OPTION ,0 ,""},
+            {0             ,NO_ARG   ,0 ,0              ,0 ,""}
+        };
+
+    bool show_help = false;
+    bool show_version = false;
+    bool binary = true;
+    bool have_input_mode_option = false;
+    bool do_check = false;
+    bool command_line_syntax_error = false;
+
+    // With --check, don't generate any output.
+    // The exit code indicates success or failure.
+    bool status_only = false;
+
+    // With --check, suppress the "OK" printed for each verified file.
+    bool quiet = false;
+
+    GetOpt getopt_long
+        (argc
+        ,argv
+        ,"chv"
+        ,long_options
+        ,&option_index
+        ,1
+        );
+
+    while(EOF != (c = getopt_long ()))
+        {
+        switch (c)
+            {
+            case 'b':
+                have_input_mode_option = true;
+                break;
+            case 'c':
+                do_check = true;
+                break;
+            case QUIET_OPTION:
+                quiet = true;
+                break;
+            case STATUS_OPTION:
+                status_only = true;
+                break;
+            case 't':
+                binary = false;
+                have_input_mode_option = true;
+                break;
+            case HELP_OPTION:
+                show_help = true;
+                break;
+            case VERSION_OPTION:
+                show_version = true;
+                break;
+            default:
+                // Error message was already given from getopt() code, so no need
+                // to output anything else here, but do flush its output so that it
+                // appears before the usage message.
+                std::fflush(stderr);
+
+                command_line_syntax_error = true;
+            }
+
+        if(command_line_syntax_error)
+            break;
+        }
+
+    if(command_line_syntax_error)
+        {
+        std::cerr << "Try 'lmi_md5sum --help' for more information." << std::endl;
+        return EXIT_FAILURE;
+        }
+    if(have_input_mode_option && do_check)
+        {
+        std::cerr
+            << "The --binary and --text options are meaningless when "
+            << "verifying checksums."
+            << std::endl
+            ;
+        return usage(EXIT_FAILURE);
+        }
+    if(status_only && !do_check)
+        {
+        std::cerr
+            << "The --status option is meaningful only when verifying checksums."
+            << std::endl
+            ;
+        return usage(EXIT_FAILURE);
+        }
+    if(quiet && !do_check)
+        {
+        std::cerr
+            << "The --quiet option is meaningful only when verifying checksums."
+            << std::endl
+            ;
+        return usage(EXIT_FAILURE);
+        }
+    if(show_help)
+        {
+        return usage(EXIT_SUCCESS);
+        }
+
+    if(show_version)
+        {
+        version();
+        return EXIT_SUCCESS;
+        }
+
+    try
+        {
+        for(int i = getopt_long.optind; i < argc; ++i)
+            {
+            char const* filename = argv[i];
+            std::string md5;
+
+            if(do_check)
+                {
+                auto const sums = md5_read_checksum_file(filename);
+
+                for(auto const& s : sums)
+                    {
+                    md5 = md5_calculate_file_checksum(s.filename, s.file_mode);
+
+                    bool const current_ok = md5 == s.md5sum;
+                    if(!status_only)
+                        {
+                        if(!current_ok || !quiet)
+                            {
+                            std::cout
+                                << s.filename.string()
+                                << ": "
+                                << (current_ok ? "OK" : "FAILED")
+                                << std::endl
+                                ;
+                            }
+                        }
+                    all_ok &= current_ok;
+                    }
+                }
+            else
+                {
+                md5 = md5_calculate_file_checksum
+                    (filename
+                    ,binary ? md5_file_mode::binary : md5_file_mode::text
+                    );
+
+                std::cout << md5 << " " << (binary ? "*" : " ") << filename << std::endl;
+                }
+            }
+        }
+    catch(std::runtime_error const& e)
+        {
+        if(!status_only)
+            std::cerr << "lmi_md5sum: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+        }
+
+    return all_ok ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/md5sum_test.cpp
+++ b/md5sum_test.cpp
@@ -1,0 +1,332 @@
+// MD5 sum--unit test.
+//
+// Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019 Gregory W. Chicares.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//
+// http://savannah.nongnu.org/projects/lmi
+// email: <gchicares@sbcglobal.net>
+// snail: Chicares, 186 Belle Woods Drive, Glastonbury CT 06033, USA
+
+#include "pchfile.hpp"
+
+#include "assert_lmi.hpp"
+#include "contains.hpp"
+#include "md5sum.hpp"
+#include "miscellany.hpp"
+#include "system_command.hpp"
+#include "test_tools.hpp"
+
+#include <boost/filesystem/convenience.hpp> // basename()
+#include <boost/filesystem/fstream.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+
+#include <cstdio>
+#include <cstring>                      // memcpy(), strlen()
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+char const* test_filename = "md5_file";
+
+// Use the windows line ending format to test the text mode too.
+std::string const test_text =
+    "The couple bought a lot of vegetables and paid with a cheque. They\r\n"
+    "did some sightseeing, but it was too hot outside. In a park they met\r\n"
+    "a colleague and had a dinner romantically. After the meal they\r\n"
+    "decided to visit the local zoo. A lot of people saw a leopard at the\r\n"
+    "zoo. Near the cage they met the colonel, a well known man doing\r\n"
+    "business. He looked a little bit strange, maybe his ancestors were\r\n"
+    "apache or shoshone indians. They may have travelled from coast to\r\n"
+    "coast and saw interesting places. In the evening every building\r\n"
+    "was lit."
+    ;
+
+char const* test_bin_checksum =  "40e541710871106ebc596595da341dcb";
+
+#if defined LMI_MSW
+char const* test_text_checksum = "e9f0fbd7a758d253ecd48ccded29234c";
+#else
+// Under Linux text and binary modes are the same.
+char const* test_text_checksum = test_bin_checksum;
+#endif // defined LMI_MSW
+
+char const* md5sums_filename = "md5_sums";
+
+// TODO: Ignore asterisk character in strings while processing a code with
+// `test_coding_rules` utility to not generate "should fuse '*' with type"
+// warning.
+// Use the '\x2a' esqape sequence to workaround the issue mentioned above.
+std::string const md5sums_text =
+    "00112233445566778899aabbccddeeff  test.txt\n"
+    "ffeeddccbbaa99887766554433221100 \x2atest.bin\n"
+    ;
+
+}
+
+std::ostream& operator<<(std::ostream& os, std::vector<md5sum_for_file> const& v)
+{
+    for(auto const& s : v)
+        {
+        char delimiter;
+        switch (s.file_mode)
+            {
+            case md5_file_mode::binary:
+                delimiter = '*';
+                break;
+            case md5_file_mode::text:
+                delimiter = ' ';
+                break;
+            default:
+                throw std::runtime_error("Unrecognized file mode value");
+            }
+        os << s.md5sum << ' ' << delimiter << "'" << s.filename.string() << "'\n";
+        }
+    return os;
+}
+
+bool operator==(md5sum_for_file const& l, md5sum_for_file const& r)
+{
+    return
+           l.filename  == r.filename
+        && l.md5sum    == r.md5sum
+        && l.file_mode == r.file_mode
+        ;
+}
+
+/// MD5 sum--unit test.
+///
+/// Public members are declared in invocation order.
+
+class MD5SumTest
+{
+  public:
+    MD5SumTest();
+    ~MD5SumTest();
+
+    void TestMD5Calculation() const;
+    void TestMD5Reading() const;
+    void TestMD5ToHexString() const;
+
+  private:
+    void RemoveTestFilesIfNecessary(char const* file, int line) const;
+    void WriteAndCheckFile
+        (char const* filename
+        ,std::string const& text
+        ,char const* file
+        ,int line
+        ) const;
+
+    void InitializeTestFile() const;
+    void InitializeMD5SumsFile() const;
+};
+
+/// Before writing any test file, remove any old copy that may be left
+/// over from a previous run that failed to complete, because old
+/// copies can cause spurious error reports.
+
+MD5SumTest::MD5SumTest()
+{
+    RemoveTestFilesIfNecessary(__FILE__, __LINE__);
+
+    InitializeTestFile();
+    InitializeMD5SumsFile();
+}
+
+MD5SumTest::~MD5SumTest()
+{
+    RemoveTestFilesIfNecessary(__FILE__, __LINE__);
+}
+
+/// Test md5_read_checksum_stream and md5_read_checksum_file
+/// functions.
+
+void MD5SumTest::TestMD5Calculation() const
+{
+    // Test md5_calculate_stream_checksum function.
+    std::ifstream is_text{test_filename, std::ios_base::in};
+    BOOST_TEST_EQUAL
+        (test_text_checksum
+        ,md5_calculate_stream_checksum(is_text, test_filename)
+        );
+
+    std::ifstream is_bin{test_filename, ios_in_binary()};
+    BOOST_TEST_EQUAL
+        (test_bin_checksum
+        ,md5_calculate_stream_checksum(is_bin, test_filename)
+        );
+
+    std::istringstream is_fail{test_text, std::ios_base::in};
+    is_fail.setstate(std::ios_base::failbit);
+    BOOST_TEST_THROW
+        (md5_calculate_stream_checksum(is_fail, test_filename)
+        ,std::runtime_error
+        ,"'md5_file': failed to read data while computing md5sum"
+        );
+
+    // Test md5_calculate_file_checksum function.
+    BOOST_TEST_EQUAL
+        (test_text_checksum
+        ,md5_calculate_file_checksum(test_filename, md5_file_mode::text)
+        );
+
+    BOOST_TEST_EQUAL
+        (test_bin_checksum
+        ,md5_calculate_file_checksum(test_filename, md5_file_mode::binary)
+        );
+
+    BOOST_TEST_EQUAL
+        (md5_calculate_file_checksum(md5sums_filename, md5_file_mode::text)
+        ,md5_calculate_file_checksum(md5sums_filename, md5_file_mode::binary)
+        );
+
+    BOOST_TEST_THROW
+        (md5_calculate_file_checksum("_ghost_")
+        ,std::runtime_error
+        ,"'_ghost_': no such file or directory"
+        );
+}
+
+/// Test md5_calculate_stream_checksum and md5_calculate_file_checksum
+/// functions.
+
+void MD5SumTest::TestMD5Reading() const
+{
+    std::vector<md5sum_for_file> md5sums
+        {{"test.txt", "00112233445566778899aabbccddeeff", md5_file_mode::text}
+        ,{"test.bin", "ffeeddccbbaa99887766554433221100", md5_file_mode::binary}
+        };
+
+    // Test md5_read_checksum_stream function.
+    std::istringstream is_sums{md5sums_text};
+    BOOST_TEST_EQUAL
+        (md5sums
+        ,md5_read_checksum_stream(is_sums, md5sums_filename)
+        );
+
+    std::istringstream is_throw1{"00112233445566778899aabbccddeeff  \n"};
+    BOOST_TEST_THROW
+        (md5_read_checksum_stream(is_throw1, "test1")
+        ,std::runtime_error
+        ,"'test1': line too short at line 1"
+        );
+
+    std::istringstream is_throw2{"00112233445566778899aabbccddeeff_test\n"};
+    BOOST_TEST_THROW
+        (md5_read_checksum_stream(is_throw2, "test2")
+        ,std::runtime_error
+        ,"'test2': incorrect checksum line format at line 1"
+        );
+
+    std::istringstream is_throw3{"00112233445566778899aabbccddeeff test\n"};
+    BOOST_TEST_THROW
+        (md5_read_checksum_stream(is_throw3, "test3")
+        ,std::runtime_error
+        ,"'test3': incorrect checksum line format at line 1"
+        );
+
+    std::istringstream is_throw4{"00112233445566778899aabbccddee  test\n"};
+    BOOST_TEST_THROW
+        (md5_read_checksum_stream(is_throw4, "test4")
+        ,std::runtime_error
+        ,"'test4': incorrect MD5 sum format at line 1"
+        );
+
+    // Test md5_read_checksum_file function.
+    BOOST_TEST_EQUAL(md5sums, md5_read_checksum_file(md5sums_filename));
+
+    BOOST_TEST_THROW
+        (md5_read_checksum_file("_ghost_")
+        ,std::runtime_error
+        ,"'_ghost_': no such file or directory"
+        );
+}
+
+/// Test md5_hex_string function.
+
+void MD5SumTest::TestMD5ToHexString() const
+{
+    std::vector<unsigned char> v
+        {0x0f, 0x1e, 0x2d, 0x3c, 0x4b, 0x5a, 0x69, 0x78
+        ,0x87, 0x96, 0xa5, 0xb4, 0xc3, 0xd2, 0xe1, 0xf0
+        };
+    BOOST_TEST_EQUAL("0f1e2d3c4b5a69788796a5b4c3d2e1f0", md5_hex_string(v));
+}
+
+void MD5SumTest::RemoveTestFilesIfNecessary(char const* file, int line) const
+{
+    auto const RemoveIfNecessary = [file, line](char const* filename)
+        {
+        if(fs::exists(filename))
+            {
+            INVOKE_BOOST_TEST(std::remove(filename) == 0, file, line);
+            }
+        };
+
+    RemoveIfNecessary(test_filename);
+    RemoveIfNecessary(md5sums_filename);
+}
+
+/// Write the text to the file.
+///
+/// Read the file back after the writing and check the content.
+
+void MD5SumTest::WriteAndCheckFile
+    (char const* filename
+    ,std::string const& text
+    ,char const* file
+    ,int line
+    ) const
+{
+    std::ofstream os{filename, ios_out_trunc_binary()};
+    INVOKE_BOOST_TEST(os.good(), file, line);
+    os << text;
+    os.close();
+
+    // Read the file back.
+    std::ifstream is{filename, ios_in_binary()};
+    INVOKE_BOOST_TEST(is.good(), file, line);
+    std::ostringstream oss;
+    oss << is.rdbuf();
+    is.close();
+
+    INVOKE_BOOST_TEST_EQUAL(text, oss.str(), file, line);
+}
+
+/// Write a text file for testing.
+
+void MD5SumTest::InitializeTestFile() const
+{
+    WriteAndCheckFile(test_filename, test_text, __FILE__, __LINE__);
+}
+
+/// Write the file with the file name and the md5 sum of the test file.
+
+void MD5SumTest::InitializeMD5SumsFile() const
+{
+    WriteAndCheckFile(md5sums_filename, md5sums_text, __FILE__, __LINE__);
+}
+
+int test_main(int, char*[])
+{
+    MD5SumTest tester;
+    tester.TestMD5Calculation();
+    tester.TestMD5Reading();
+    tester.TestMD5ToHexString();
+
+    return EXIT_SUCCESS;
+}

--- a/objects.make
+++ b/objects.make
@@ -1072,6 +1072,14 @@ elapsed_time$(EXEEXT): \
   system_command_non_wx.o \
   timer.o \
 
+lmi_md5sum$(EXEEXT): \
+  $(boost_filesystem_objects) \
+  $(main_auxiliary_common_objects) \
+  getopt.o \
+  md5.o \
+  md5sum.o \
+  md5sum_cli.o \
+
 generate_passkey$(EXEEXT): \
   $(boost_filesystem_objects) \
   $(main_auxiliary_common_objects) \

--- a/objects.make
+++ b/objects.make
@@ -442,6 +442,7 @@ unit_test_targets := \
   materially_equal_test \
   math_functions_test \
   mc_enum_test \
+  md5sum_test \
   miscellany_test \
   mortality_rates_test \
   name_value_pairs_test \
@@ -810,6 +811,13 @@ mc_enum_test$(EXEEXT): \
   miscellany.o \
   null_stream.o \
   path_utility.o \
+
+md5sum_test$(EXEEXT): \
+  $(boost_filesystem_objects) \
+  $(common_test_objects) \
+  md5.o \
+  md5sum.o \
+  md5sum_test.o \
 
 miscellany_test$(EXEEXT): \
   $(common_test_objects) \

--- a/objects.make
+++ b/objects.make
@@ -299,6 +299,7 @@ lmi_common_objects := \
   irc7702_tables.o \
   lmi.o \
   md5.o \
+  md5sum.o \
   mec_input.o \
   mec_server.o \
   mec_state.o \
@@ -534,6 +535,7 @@ authenticity_test$(EXEEXT): \
   calendar_date.o \
   global_settings.o \
   md5.o \
+  md5sum.o \
   miscellany.o \
   null_stream.o \
   path_utility.o \
@@ -1078,6 +1080,7 @@ generate_passkey$(EXEEXT): \
   generate_passkey.o \
   global_settings.o \
   md5.o \
+  md5sum.o \
   miscellany.o \
   null_stream.o \
   path_utility.o \

--- a/set_toolchain.sh
+++ b/set_toolchain.sh
@@ -90,7 +90,7 @@ local   lmi_build_type
 local      prefix="/opt/lmi"
 local localbindir="$prefix/local/${LMI_COMPILER}_${LMI_TRIPLET}/bin"
 local locallibdir="$prefix/local/${LMI_COMPILER}_${LMI_TRIPLET}/lib"
-# $winebindir is where 'install_miscellanea.make' places 'md5sum.exe'.
+# $winebindir is where 'make install' places 'lmi_md5sum.exe'.
 local  winebindir="$prefix"/third_party/bin
 
 # Running a command like this many times:

--- a/system_command_test.cpp
+++ b/system_command_test.cpp
@@ -39,13 +39,13 @@ int test_main(int, char*[])
     os1 << "e87dfb7b7c7f87985d3eff4782c172b8  eraseme\n";
     os1.close();
 
-    system_command("md5sum --check --status eraseme.md5");
+    system_command("lmi_md5sum --check --status eraseme.md5");
 
     BOOST_TEST_THROW
-        (system_command("md5sum --check --status eraseme")
+        (system_command("lmi_md5sum --check --status eraseme")
         ,std::runtime_error
         ,lmi_test::what_regex
-            ("Exit code [0-9]* from command 'md5sum --check --status eraseme'.")
+            ("Exit code [0-9]* from command 'lmi_md5sum --check --status eraseme'.")
         );
 
 #if !defined LMI_MSW

--- a/workhorse.make
+++ b/workhorse.make
@@ -112,6 +112,7 @@ ifeq (,$(USE_SO_ATTRIBUTES))
     bcc_ld$(EXEEXT) \
     bcc_rc$(EXEEXT) \
     elapsed_time$(EXEEXT) \
+    lmi_md5sum$(EXEEXT) \
     generate_passkey$(EXEEXT) \
     ihs_crc_comp$(EXEEXT) \
     rate_table_tool$(EXEEXT) \
@@ -1058,7 +1059,6 @@ installable_binaries := \
   $(default_targets) \
   $(wildcard $(localbindir)/*$(SHREXT)) \
   $(wildcard $(locallibdir)/*$(SHREXT)) \
-  $(wildcard $(prefix)/third_party/bin/*$(EXEEXT)) \
 
 .PHONY: install
 install: $(default_targets)
@@ -1076,6 +1076,7 @@ ifeq (,$(USE_SO_ATTRIBUTES))
 else
 	@$(ECHO) "Can't build product_files$(EXEEXT) with USE_SO_ATTRIBUTES."
 endif
+	@$(CP) --preserve lmi_md5sum$(EXEEXT) $(prefix)/third_party/bin
 
 ################################################################################
 
@@ -1176,11 +1177,11 @@ fardel_files := \
 
 # Sensitive files are authenticated at run time.
 #
-# Binary files other than 'md5sum$(EXEEXT)' are not authenticated
+# Binary files other than 'lmi_md5sum$(EXEEXT)' are not authenticated
 # because they aren't easily forged but are sizable enough to make
 # authentication too slow. An incorrect version of any such file might
 # be distributed by accident, but that problem would not be caught by
-# generating an md5sum for the incorrect file. 'md5sum$(EXEEXT)' is
+# generating an md5sum for the incorrect file. 'lmi_md5sum$(EXEEXT)' is
 # however authenticated because replacing it with a program that
 # always reports success would circumvent authentication.
 #
@@ -1199,7 +1200,7 @@ fardel_checksummed_files = \
   $(extra_fardel_checksummed_files) \
   *.dat *.database *.funds *.ndx *.policy *.rounding *.strata *.xst \
   expiry \
-  md5sum$(EXEEXT) \
+  lmi_md5sum$(EXEEXT) \
 
 .PHONY: fardel
 fardel: install
@@ -1207,15 +1208,14 @@ fardel: install
 	@$(MAKE) --file=$(this_makefile) --directory=$(fardel_dir) wrap_fardel
 	@$(ECHO) "Created '$(fardel_name)' archive in '$(fardel_root)'."
 
-# A native 'md5sum$(EXEEXT)' must be provided because lmi uses it for
-# run-time authentication.
+# A native 'lmi_md5sum$(EXEEXT)' is provided to be used by end users.
 #
 # $(CP) is used without '--update' so that custom extra files can
 # replace defaults regardless of their datestamps.
 
 .PHONY: wrap_fardel
 wrap_fardel:
-	@$(CP) $(prefix)/third_party/bin/md5sum$(EXEEXT) .
+	@$(CP) $(prefix)/third_party/bin/lmi_md5sum$(EXEEXT) .
 	@$(CP) $(datadir)/configurable_settings.xml .
 	@$(CP) $(datadir)/company_logo.png .
 	@$(CP) $(datadir)/group_quote_banner.png .


### PR DESCRIPTION
This PR does 2 related things:

1. Compute the file checksums and compare them with the expected values in lmi code itself, without using any external program at all.
2. Build native (i.e. without Cygwin dependencies) `lmi_md5sum.exe` for inclusion into the fardel distribution and, auxiliary, for the use in the unit tests (we can't use the system `md5sum` in them because this wouldn't work when running tests under Wine).

The third commit (adding the unit tests) could have been part of the first one, please feel free to squash them together if you'd like.

Finally, please note that we still use external md5sum program during lmi build, however this is not a problem, as we can just use the build-environment-native (i.e. Cygwin or Linux) utility in this case (but we can't include this binary in the fardel, which explains why we still need `lmi_md5sum.exe`).