### PR TITLE
Use wxGrid instead of DCV in census_view

### DIFF
--- a/census_document.cpp
+++ b/census_document.cpp
@@ -35,11 +35,11 @@
 
 IMPLEMENT_DYNAMIC_CLASS(CensusDocument, wxDocument)
 
-wxDataViewCtrl& CensusDocument::PredominantViewWindow() const
+wxGrid& CensusDocument::PredominantViewWindow() const
 {
-    return ::PredominantViewWindow<CensusView,wxDataViewCtrl>
+    return ::PredominantViewWindow<CensusView, wxGrid>
         (*this
-        ,&CensusView::list_window_
+        ,&CensusView::grid_window_
         );
 }
 

--- a/census_document.hpp
+++ b/census_document.hpp
@@ -29,7 +29,7 @@
 
 #include <wx/docview.h>
 
-class WXDLLIMPEXP_FWD_ADV wxDataViewCtrl;
+class WXDLLIMPEXP_FWD_ADV wxGrid;
 
 class CensusDocument
     :public wxDocument
@@ -44,7 +44,7 @@ class CensusDocument
     CensusDocument(CensusDocument const&) = delete;
     CensusDocument& operator=(CensusDocument const&) = delete;
 
-    wxDataViewCtrl& PredominantViewWindow() const;
+    wxGrid& PredominantViewWindow() const;
 
     // wxDocument overrides.
     bool OnCreate(wxString const& filename, long int flags) override;

--- a/census_view.hpp
+++ b/census_view.hpp
@@ -31,23 +31,25 @@
 #include "mc_enum_type_enums.hpp"       // enum mcenum_emission
 #include "oecumenic_enumerations.hpp"
 
-#include <wx/object.h>                  // wxObjectDataPtr
+#include <wx/grid.h>
 
 #include <memory>                       // shared_ptr
 #include <string>
 #include <vector>
 
 class CensusDocument;
-class CensusViewDataViewModel;
+class CensusView;
+class CensusViewTable;
 
-class WXDLLIMPEXP_FWD_ADV wxDataViewEvent;
-class WXDLLIMPEXP_FWD_ADV wxDataViewCtrl;
+class WXDLLIMPEXP_FWD_ADV wxGrid;
+class WXDLLIMPEXP_FWD_ADV wxGridEvent;
 
 class CensusView final
     :public ViewEx
 {
     friend class CensusDocument;
-    friend class CensusViewDataViewModel;
+    friend class CensusViewTable;
+    friend class CensusViewGrid;
 
   public:
     CensusView();
@@ -66,8 +68,8 @@ class CensusView final
     char const* menubar_xrc_resource() const override;
 
     // Event handlers, in event-table order (reflecting GUI order)
-    void UponRightClick             (wxDataViewEvent&);
-    void UponValueChanged           (wxDataViewEvent&);
+    void UponRightClick             (wxGridEvent&);
+    void UponValueChanged           (wxGridEvent&);
     void UponEditCell               (wxCommandEvent&);
     void UponEditClass              (wxCommandEvent&);
     void UponEditCase               (wxCommandEvent&);
@@ -127,12 +129,13 @@ class CensusView final
 
     void DoCopyCensus() const;
 
-    bool autosize_columns_;
+    bool             autosize_columns_;
+    std::vector<int> visible_columns_;
 
     std::shared_ptr<Ledger const> composite_ledger_;
 
-    wxDataViewCtrl* list_window_;
-    wxObjectDataPtr<CensusViewDataViewModel> list_model_;
+    wxGrid*          grid_window_;
+    CensusViewTable* grid_table_;
 
     DECLARE_DYNAMIC_CLASS(CensusView)
     DECLARE_EVENT_TABLE()

--- a/wx_test_paste_census.cpp
+++ b/wx_test_paste_census.cpp
@@ -25,14 +25,15 @@
 #include "bourn_cast.hpp"
 #include "data_directory.hpp"
 #include "mvc_controller.hpp"
+#include "ssize_lmi.hpp"
 #include "wx_test_case.hpp"
 #include "wx_test_new.hpp"
 #include "wx_test_output.hpp"
 #include "wx_utility.hpp"
 
 #include <wx/app.h>
-#include <wx/dataview.h>
 #include <wx/dialog.h>
+#include <wx/grid.h>
 #include <wx/mdi.h>
 #include <wx/radiobox.h>
 #include <wx/testing.h>
@@ -47,10 +48,10 @@
 namespace
 {
 
-// Helper function to find the wxDataViewCtrl used for the census display.
+// Helper function to find the wxGrid used for the census display.
 //
 // Precondition: the currently active window must be a CensusView.
-wxDataViewCtrl* find_census_list_window()
+wxGrid* find_census_grid_window()
 {
     wxWindow* const top_window = wxTheApp->GetTopWindow();
     LMI_ASSERT(top_window);
@@ -66,28 +67,24 @@ wxDataViewCtrl* find_census_list_window()
     wxWindowList::const_iterator z = census_children.begin();
     LMI_ASSERT(z != census_children.end());
 
-    wxDataViewCtrl* const dvc = dynamic_cast<wxDataViewCtrl*>(*z);
-    LMI_ASSERT(dvc);
+    wxGrid* const grid = dynamic_cast<wxGrid*>(*z);
+    LMI_ASSERT(grid);
 
-    return dvc;
+    return grid;
 }
 
-// Retrieve the list model from list window.
+// Retrieve the table from grid window.
 //
-// Precondition: this wxDataViewCtrl must actually use a list model.
-wxDataViewListModel* get_census_list_model(wxDataViewCtrl* dvc)
+// Precondition: this wxGrid must actually use a list model.
+wxGridTableBase* get_census_table(wxGrid* grid)
 {
-    wxDataViewModel* const model = dvc->GetModel();
-    LMI_ASSERT(model);
+    wxGridTableBase* const table = grid->GetTable();
+    LMI_ASSERT(table);
 
-    wxDataViewListModel* const
-        list_model = dynamic_cast<wxDataViewListModel*>(model);
-    LMI_ASSERT(list_model);
-
-    return list_model;
+    return table;
 }
 
-// Helper for building the diagnostic message in check_list_columns().
+// Helper for building the diagnostic message in check_grid_columns().
 std::string build_not_found_message(std::set<std::string> const& remaining)
 {
     std::ostringstream message;
@@ -116,8 +113,8 @@ std::string build_not_found_message(std::set<std::string> const& remaining)
 //
 // The 'when' parameter is used solely for the diagnostic messages in case of
 // the check failure.
-void check_list_columns
-    (wxDataViewCtrl* dvc
+void check_grid_columns
+    (wxGrid* grid
     ,char const* when
     ,std::set<std::string> const& expected
     ,std::string const& unexpected = std::string()
@@ -125,9 +122,9 @@ void check_list_columns
 {
     std::set<std::string> remaining(expected.begin(), expected.end());
 
-    for(int n = 0; n < bourn_cast<int>(dvc->GetColumnCount()); ++n)
+    for(int n = 0; n < bourn_cast<int>(grid->GetNumberCols()); ++n)
         {
-        std::string const title = dvc->GetColumn(n)->GetTitle().ToStdString();
+        std::string const title = grid->GetColLabelValue(n).ToStdString();
         LMI_ASSERT_WITH_MSG
             (title != unexpected
             ,"column '" << title << "' unexpectedly found " << when
@@ -147,17 +144,16 @@ void check_list_columns
 // Find the index of the column with the given title.
 //
 // Throws an exception if the column is not found.
-int find_model_column_by_title
-    (wxDataViewCtrl* dvc
+int find_table_column_by_title
+    (wxGrid* grid
     ,std::string const& title
     )
 {
-    for(int n = 0; n < bourn_cast<int>(dvc->GetColumnCount()); ++n)
+    for(int n = 0; n < bourn_cast<int>(grid->GetNumberCols()); ++n)
         {
-        wxDataViewColumn const* column = dvc->GetColumn(n);
-        if(column->GetTitle().ToStdString() == title)
+        if(grid->GetColLabelValue(n).ToStdString() == title)
             {
-            return column->GetModelColumn();
+            return n;
             }
         }
 
@@ -252,12 +248,12 @@ LMI_WX_TEST_CASE(paste_census)
 
     // Find the model containing the cells and check that it was filled in
     // correctly.
-    wxDataViewCtrl* const list_window = find_census_list_window();
-    wxDataViewListModel* const list_model = get_census_list_model(list_window);
-    LMI_ASSERT_EQUAL(bourn_cast<int>(list_model->GetCount()), number_of_rows);
+    wxGrid* const grid_window = find_census_grid_window();
+    wxGridTableBase* const table = get_census_table(grid_window);
+    LMI_ASSERT_EQUAL(table->GetNumberRows(), number_of_rows);
 
-    check_list_columns
-        (list_window
+    check_grid_columns
+        (grid_window
         ,"after pasting initial census data"
         ,column_titles
         );
@@ -265,17 +261,17 @@ LMI_WX_TEST_CASE(paste_census)
     // Change class defaults: this requires a selection, so ensure we have one
     // by clicking somewhere inside the control.
     ui.MouseMove
-        (list_window->ClientToScreen
+        (grid_window->ClientToScreen
             (wxPoint
-                (10 * list_window->GetCharWidth()
-                , 3 * list_window->GetCharHeight()
+                (10 * grid_window->GetCharWidth()
+                , 3 * grid_window->GetCharHeight()
                 )
             )
         );
     ui.MouseClick();
     wxYield();
 
-    LMI_ASSERT_EQUAL(list_window->GetSelectedItemsCount(), 1);
+    LMI_ASSERT_EQUAL(lmi::ssize(grid_window->GetSelectedRows()), 1);
 
     ui.Char('e', wxMOD_CONTROL | wxMOD_ALT); // "Census|Edit class defaults"
 
@@ -330,22 +326,20 @@ LMI_WX_TEST_CASE(paste_census)
         );
 
     // Check that all columns, including the "Gender" one, are still shown.
-    check_list_columns
-        (list_window
+    check_grid_columns
+        (grid_window
         ,"after changing gender in class defaults"
         ,column_titles
         );
 
     // Verify that the "Gender" column value is "Unisex" in every row now.
-    int const gender_column = find_model_column_by_title(list_window, "Gender");
-    LMI_ASSERT_EQUAL(bourn_cast<int>(list_model->GetCount()), number_of_rows);
+    int const gender_column = find_table_column_by_title(grid_window, "Gender");
+    LMI_ASSERT_EQUAL(table->GetNumberRows(), number_of_rows);
     // Only the first two rows are affected, because only they belong
     // to the first employee class.
     for(int row = 0; row < 2; ++row)
         {
-        wxVariant value;
-        list_model->GetValueByRow(value, row, gender_column);
-        LMI_ASSERT_EQUAL(value.GetString(), "Unisex");
+        LMI_ASSERT_EQUAL(table->GetValue(row, gender_column), "Unisex");
         }
 
     // Change the case defaults to get rid of the underwriting class.
@@ -399,11 +393,11 @@ LMI_WX_TEST_CASE(paste_census)
 
     // Check that we still have the same cells but that now the underwriting
     // class column has disappeared as its value has been fixed.
-    LMI_ASSERT_EQUAL(bourn_cast<int>(list_model->GetCount()), number_of_rows);
+    LMI_ASSERT_EQUAL(table->GetNumberRows(), number_of_rows);
 
     column_titles.erase("Underwriting Class");
-    check_list_columns
-        (list_window
+    check_grid_columns
+        (grid_window
         ,"after changing class in case defaults"
         ,column_titles
         ,"Underwriting Class"


### PR DESCRIPTION
Replace wxDataViewCtrl with wxGrid in the CensusView class.

Implement the own grid and the table classes. Also implement editors
for custom cell types.

Also fix the gui test `wx_test_paste_census`.