### PR TITLE
Census view with DVC and grid

### DIFF
--- a/census_document.cpp
+++ b/census_document.cpp
@@ -34,12 +34,21 @@
 #include <fstream>
 
 IMPLEMENT_DYNAMIC_CLASS(CensusDVCDocument, CensusDocument)
+IMPLEMENT_DYNAMIC_CLASS(CensusGridDocument, CensusDocument)
 
 wxDataViewCtrl& CensusDVCDocument::PredominantViewWindow() const
 {
     return ::PredominantViewWindow<CensusDVCView,wxDataViewCtrl>
         (*this
         ,&CensusDVCView::list_window_
+        );
+}
+
+wxGrid& CensusGridDocument::PredominantViewWindow() const
+{
+    return ::PredominantViewWindow<CensusGridView,wxGrid>
+        (*this
+        ,&CensusGridView::grid_window_
         );
 }
 

--- a/census_document.cpp
+++ b/census_document.cpp
@@ -33,13 +33,13 @@
 
 #include <fstream>
 
-IMPLEMENT_DYNAMIC_CLASS(CensusDocument, wxDocument)
+IMPLEMENT_DYNAMIC_CLASS(CensusDVCDocument, CensusDocument)
 
-wxDataViewCtrl& CensusDocument::PredominantViewWindow() const
+wxDataViewCtrl& CensusDVCDocument::PredominantViewWindow() const
 {
-    return ::PredominantViewWindow<CensusView,wxDataViewCtrl>
+    return ::PredominantViewWindow<CensusDVCView,wxDataViewCtrl>
         (*this
-        ,&CensusView::list_window_
+        ,&CensusDVCView::list_window_
         );
 }
 

--- a/census_document.hpp
+++ b/census_document.hpp
@@ -44,16 +44,28 @@ class CensusDocument
     CensusDocument(CensusDocument const&) = delete;
     CensusDocument& operator=(CensusDocument const&) = delete;
 
-    wxDataViewCtrl& PredominantViewWindow() const;
-
     // wxDocument overrides.
     bool OnCreate(wxString const& filename, long int flags) override;
     bool DoOpenDocument(wxString const& filename) override;
     bool DoSaveDocument(wxString const& filename) override;
 
     multiple_cell_document doc_;
+};
 
-    DECLARE_DYNAMIC_CLASS(CensusDocument)
+class CensusDVCDocument final
+    :public CensusDocument
+{
+  public:
+    CensusDVCDocument() = default;
+    ~CensusDVCDocument() override = default;
+
+  private:
+    CensusDVCDocument(CensusDVCDocument const&) = delete;
+    CensusDVCDocument& operator=(CensusDVCDocument const&) = delete;
+
+    wxDataViewCtrl& PredominantViewWindow() const;
+
+    DECLARE_DYNAMIC_CLASS(CensusDVCDocument)
 };
 
 #endif // census_document_hpp

--- a/census_document.hpp
+++ b/census_document.hpp
@@ -30,6 +30,7 @@
 #include <wx/docview.h>
 
 class WXDLLIMPEXP_FWD_ADV wxDataViewCtrl;
+class WXDLLIMPEXP_FWD_ADV wxGrid;
 
 class CensusDocument
     :public wxDocument
@@ -66,6 +67,22 @@ class CensusDVCDocument final
     wxDataViewCtrl& PredominantViewWindow() const;
 
     DECLARE_DYNAMIC_CLASS(CensusDVCDocument)
+};
+
+class CensusGridDocument final
+    :public CensusDocument
+{
+  public:
+    CensusGridDocument() = default;
+    ~CensusGridDocument() override = default;
+
+  private:
+    CensusGridDocument(CensusGridDocument const&) = delete;
+    CensusGridDocument& operator=(CensusGridDocument const&) = delete;
+
+    wxGrid& PredominantViewWindow() const;
+
+    DECLARE_DYNAMIC_CLASS(CensusGridDocument)
 };
 
 #endif // census_document_hpp

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1970,7 +1970,6 @@ wxWindow* CensusGridView::CreateChildWindow()
     grid_window_->SetColLabelAlignment(wxALIGN_LEFT, wxALIGN_CENTRE);
     grid_window_->SetDefaultCellAlignment(wxALIGN_LEFT, wxALIGN_CENTRE);
     grid_window_->SetDefaultCellFitMode(wxGridFitMode::Ellipsize(wxELLIPSIZE_MIDDLE));
-    grid_window_->SetGridLineColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
 
     // Grid must be already created when we create the table because we use
     // the default cell background color to determine the alternating color.

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1234,7 +1234,7 @@ class table_type_converter
 
     virtual void register_data_type(wxGrid* grid) const = 0;
 
-    static std::map<std::string, table_type_converter const*>& get_all();
+    static std::map<std::string, table_type_converter const*> const& get_all();
     static table_type_converter const& get_by_value(any_member<Input> const& value);
 
   private:
@@ -1441,10 +1441,10 @@ class table_string_converter : public table_standard_type_converter
     }
 };
 
-std::map<std::string, table_type_converter const*>&
+std::map<std::string, table_type_converter const*> const&
 table_type_converter::get_all()
 {
-    static std::map<std::string, table_type_converter const*> all
+    static std::map<std::string, table_type_converter const*> const all
         {{ get_impl<table_bool_converter>().type()
          ,&get_impl<table_bool_converter>()
          }

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1502,6 +1502,8 @@ class CensusViewGridTable
 
     wxString GetColLabelValue(int col) override;
 
+    bool CanMeasureColUsingSameAttr(int col) const override;
+
     std::string const& col_name(int col) const;
 
     Input& row_at(int row);
@@ -1609,6 +1611,15 @@ wxString CensusViewGridTable::GetColLabelValue(int col)
 
     auto const& header = all_headers()[visible_columns_[col - 1]];
     return insert_spaces_between_words(header);
+}
+
+bool CensusViewGridTable::CanMeasureColUsingSameAttr(int) const
+{
+    // All our columns use the same type and practically the same attribute:
+    // only its background colour varies, but the colour doesn't matter for
+    // measuring, so we can always return true from here and allow wxGrid to
+    // reuse the same attribute for the entire column.
+    return true;
 }
 
 bool CensusViewGridTable::AppendRows(size_t numRows)

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1177,7 +1177,7 @@ class table_type_converter
 
     virtual void register_data_type(wxGrid* grid) const = 0;
 
-    static std::map<std::string, table_type_converter const*> const& get_all();
+    static void register_all(wxGrid* grid);
     static table_type_converter const& get_by_value(any_member<Input> const& value);
 
   private:
@@ -1185,8 +1185,7 @@ class table_type_converter
     static table_type_converter const& get_impl();
 };
 
-// The base class for custom table type convertors which uses an own renderer
-// and an editor.
+// The base class for table type converters using custom renderer and editor.
 
 class table_custom_type_converter : public table_type_converter
 {
@@ -1384,33 +1383,12 @@ class table_string_converter : public table_standard_type_converter
     }
 };
 
-std::map<std::string, table_type_converter const*> const&
-table_type_converter::get_all()
+void
+table_type_converter::register_all(wxGrid* grid)
 {
-    static std::map<std::string, table_type_converter const*> const all
-        {{ get_impl<table_bool_converter>().type()
-         ,&get_impl<table_bool_converter>()
-         }
-        ,{ get_impl<table_string_converter>().type()
-         ,&get_impl<table_string_converter>()
-         }
-        ,{ get_impl<table_sequence_converter>().type()
-         ,&get_impl<table_sequence_converter>()
-         }
-        ,{ get_impl<table_enum_converter>().type()
-         ,&get_impl<table_enum_converter>()
-         }
-        ,{ get_impl<table_int_range_converter>().type()
-         ,&get_impl<table_int_range_converter>()
-         }
-        ,{ get_impl<table_double_range_converter>().type()
-         ,&get_impl<table_double_range_converter>()
-         }
-        ,{ get_impl<table_date_converter>().type()
-         ,&get_impl<table_date_converter>()
-         }
-        };
-    return all;
+    get_impl<table_sequence_converter>().register_data_type(grid);
+    get_impl<table_double_range_converter>().register_data_type(grid);
+    get_impl<table_date_converter>().register_data_type(grid);
 }
 
 table_type_converter const&
@@ -2043,10 +2021,7 @@ wxWindow* CensusGridView::CreateChildWindow()
     grid_window_->DisableDragRowSize();
     grid_window_->SelectRow(0);
 
-    for(auto const& it : table_type_converter::get_all())
-        {
-        it.second->register_data_type(grid_window_);
-        }
+    table_type_converter::register_all(grid_window_);
 
     // Show headers.
     document().Modify(false);

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1793,7 +1793,11 @@ BEGIN_EVENT_TABLE(CensusView, ViewEx)
     EVT_MENU(XRCID("delete_cells"              ),CensusView::UponDeleteCells            )
     EVT_MENU(XRCID("column_width_varying"      ),CensusView::UponColumnWidthVarying     )
     EVT_MENU(XRCID("column_width_fixed"        ),CensusView::UponColumnWidthFixed       )
+    EVT_UPDATE_UI(XRCID("edit_cell"            ),CensusView::UponUpdateSingleSelection  )
+    EVT_UPDATE_UI(XRCID("edit_class"           ),CensusView::UponUpdateSingleSelection  )
     EVT_UPDATE_UI(XRCID("edit_case"            ),CensusView::UponUpdateAlwaysEnabled    )
+    EVT_UPDATE_UI(XRCID("run_cell"             ),CensusView::UponUpdateSingleSelection  )
+    EVT_UPDATE_UI(XRCID("run_class"            ),CensusView::UponUpdateSingleSelection  )
     EVT_UPDATE_UI(XRCID("run_case"             ),CensusView::UponUpdateAlwaysEnabled    )
     EVT_UPDATE_UI(XRCID("print_case"           ),CensusView::UponUpdateAlwaysEnabled    )
     EVT_UPDATE_UI(XRCID("print_case_to_disk"   ),CensusView::UponUpdateAlwaysEnabled    )
@@ -1818,10 +1822,6 @@ IMPLEMENT_DYNAMIC_CLASS(CensusDVCView, CensusView)
 BEGIN_EVENT_TABLE(CensusDVCView, CensusView)
     EVT_DATAVIEW_ITEM_CONTEXT_MENU (wxID_ANY    ,CensusDVCView::UponRightClick             )
     EVT_DATAVIEW_ITEM_VALUE_CHANGED(wxID_ANY    ,CensusDVCView::UponValueChanged           )
-    EVT_UPDATE_UI(XRCID("edit_cell"            ),CensusDVCView::UponUpdateSingleSelection  )
-    EVT_UPDATE_UI(XRCID("edit_class"           ),CensusDVCView::UponUpdateSingleSelection  )
-    EVT_UPDATE_UI(XRCID("run_cell"             ),CensusDVCView::UponUpdateSingleSelection  )
-    EVT_UPDATE_UI(XRCID("run_class"            ),CensusDVCView::UponUpdateSingleSelection  )
     EVT_UPDATE_UI(XRCID("delete_cells"         ),CensusDVCView::UponUpdateNonemptySelection)
 END_EVENT_TABLE()
 
@@ -1831,10 +1831,6 @@ BEGIN_EVENT_TABLE(CensusGridView, CensusView)
     EVT_GRID_CELL_RIGHT_CLICK(                   CensusGridView::UponRightClick         )
     EVT_GRID_CELL_CHANGED(                       CensusGridView::UponValueChanged       )
     EVT_GRID_COL_AUTO_SIZE(                      CensusGridView::UponColumnAutoSize     )
-    EVT_UPDATE_UI(XRCID("edit_cell"            ),CensusGridView::UponUpdateAlwaysEnabled)
-    EVT_UPDATE_UI(XRCID("edit_class"           ),CensusGridView::UponUpdateAlwaysEnabled)
-    EVT_UPDATE_UI(XRCID("run_cell"             ),CensusGridView::UponUpdateAlwaysEnabled)
-    EVT_UPDATE_UI(XRCID("run_class"            ),CensusGridView::UponUpdateAlwaysEnabled)
     EVT_UPDATE_UI(XRCID("delete_cells"         ),CensusGridView::UponUpdateAlwaysEnabled)
 END_EVENT_TABLE()
 
@@ -2455,6 +2451,21 @@ void CensusView::UponUpdateAlwaysEnabled(wxUpdateUIEvent& e)
 void CensusDVCView::UponUpdateSingleSelection(wxUpdateUIEvent& e)
 {
     bool const is_single_sel = list_window_->GetSelection().IsOk();
+    e.Enable(is_single_sel);
+}
+
+void CensusGridView::UponUpdateSingleSelection(wxUpdateUIEvent& e)
+{
+    // We consider that in absence of any selected rows, the current row is the
+    // selected/active one, so what we actually check for here is that we do
+    // not have more than a single row selected.
+    auto const sel_blocks = grid_window_->GetSelectedRowBlocks();
+    bool const is_single_sel
+        =  sel_blocks.empty()
+        || (sel_blocks.size() == 1
+            && sel_blocks[0].GetTopRow() == sel_blocks[0].GetBottomRow())
+        ;
+
     e.Enable(is_single_sel);
 }
 

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -2469,13 +2469,20 @@ void CensusGridView::UponUpdateSingleSelection(wxUpdateUIEvent& e)
 {
     // We consider that in absence of any selected rows, the current row is the
     // selected/active one, so what we actually check for here is that we do
-    // not have more than a single row selected.
-    auto const sel_blocks = grid_window_->GetSelectedRowBlocks();
-    bool const is_single_sel
-        =  sel_blocks.empty()
-        || (sel_blocks.size() == 1
-            && sel_blocks[0].GetTopRow() == sel_blocks[0].GetBottomRow())
-        ;
+    // not have any rows other than, possibly, the current one, selected.
+    bool is_single_sel = true;
+    for(auto const& sel_block: grid_window_->GetSelectedRowBlocks())
+        {
+            auto const cursor_row = grid_window_->GetGridCursorRow();
+            if
+                (  sel_block.GetTopRow()    != cursor_row
+                || sel_block.GetBottomRow() != cursor_row
+                )
+                {
+                is_single_sel = false;
+                break;
+                }
+        }
 
     e.Enable(is_single_sel);
 }

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1009,9 +1009,7 @@ class DatumSequenceEditorEvtHandler
     :public wxEvtHandler
 {
   public:
-    // wxIMPLEMENT_DYNAMIC_CLASS requires the default constructor
-    // so add the default value for the entry parameter.
-    explicit DatumSequenceEditorEvtHandler(InputSequenceEntry* entry = nullptr)
+    explicit DatumSequenceEditorEvtHandler(InputSequenceEntry* entry)
         :entry_(entry)
     {
     }
@@ -1064,11 +1062,8 @@ class DatumSequenceEditorEvtHandler
     InputSequenceEntry* entry_{};
 
     DECLARE_EVENT_TABLE()
-    DECLARE_DYNAMIC_CLASS(DatumSequenceEditorEvtHandler)
     DECLARE_NO_COPY_CLASS(DatumSequenceEditorEvtHandler)
 };
-
-IMPLEMENT_DYNAMIC_CLASS(DatumSequenceEditorEvtHandler, wxEvtHandler)
 
 BEGIN_EVENT_TABLE(DatumSequenceEditorEvtHandler, wxEvtHandler)
     EVT_CHAR(DatumSequenceEditorEvtHandler::UponChar)

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -2100,11 +2100,7 @@ wxWindow* CensusGridView::CreateChildWindow()
     // Grid must be already created when we create the table because we use
     // the default cell background color to determine the alternating color.
     grid_table_ = new(wx) CensusViewGridTable(*this);
-    grid_window_->SetTable
-        (grid_table_
-        ,true // Take ownership of the table.
-        ,wxGrid::wxGridSelectRows
-        );
+    grid_window_->AssignTable(grid_table_, wxGrid::wxGridSelectRows);
 
     grid_window_->UseNativeColHeader();
     grid_window_->DisableHidingColumns();

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1062,27 +1062,23 @@ void DatumSequenceEditor::Create
         evtHandler = m_control;
         }
 
+    // Use a special handler to open the editor window when Alt-Enter is
+    // pressed instead of just closing the editor, as would be done by default.
     evtHandler->Bind
         (wxEVT_KEY_DOWN
         ,[entry](wxKeyEvent& event)
         {
-            switch(event.GetKeyCode())
+            auto const code = event.GetKeyCode();
+            if
+                (  (code == WXK_RETURN || code == WXK_NUMPAD_ENTER)
+                && wxGetKeyState(WXK_ALT)
+                )
                 {
-                case WXK_RETURN:
-                case WXK_NUMPAD_ENTER:
-                    if(!wxGetKeyState(WXK_ALT))
-                        {
-                        event.Skip();
-                        return;
-                        }
-
-                    // Open the editor window when Alt-Enter is pressed instead of
-                    // just closing the editor, as would be done by default.
-                    entry->open_editor();
-                    break;
-                default:
-                    event.Skip();
-                    break;
+                entry->open_editor();
+                }
+            else
+                {
+                event.Skip();
                 }
         });
 }

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1700,7 +1700,7 @@ void CensusViewGridTable::SetValue(int row, int col, wxString const& value)
 
     cell = new_val;
 
-    Input& model = view_.cell_parms()[row];
+    Input& model = view_.cell_parms().at(row);
     model.Reconcile();
 
     view_.document().Modify(true);
@@ -1842,17 +1842,17 @@ inline std::string const& CensusViewGridTable::col_name(int col) const
 {
     LMI_ASSERT(0 < col);
     // "- 1" because first column is cell serial number.
-    return all_headers()[visible_columns_[col - 1]];
+    return all_headers().at(visible_columns_.at(col - 1));
 }
 
 inline Input& CensusViewGridTable::row_at(int row)
 {
-    return view_.cell_parms()[row];
+    return view_.cell_parms().at(row);
 }
 
 inline Input const& CensusViewGridTable::row_at(int row) const
 {
-    return view_.cell_parms()[row];
+    return view_.cell_parms().at(row);
 }
 
 inline any_member<Input>& CensusViewGridTable::cell_at(int row, int col)
@@ -1877,7 +1877,7 @@ inline any_member<Input> const& CensusViewGridTable::cell_at(int row, std::strin
 
 inline std::vector<std::string> const& CensusViewGridTable::all_headers() const
 {
-    return view_.case_parms()[0].member_names();
+    return view_.case_parms().at(0).member_names();
 }
 
 namespace

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1178,7 +1178,7 @@ class table_type_converter
     virtual void register_data_type(wxGrid* grid) const = 0;
 
     static void register_all(wxGrid* grid);
-    static table_type_converter const& get_by_value(any_member<Input> const& value);
+    static table_type_converter const& get(any_member<Input> const& value);
 
   private:
     template<typename T>
@@ -1392,7 +1392,7 @@ table_type_converter::register_all(wxGrid* grid)
 }
 
 table_type_converter const&
-table_type_converter::get_by_value(any_member<Input> const& value)
+table_type_converter::get(any_member<Input> const& value)
 {
     if(exact_cast<mce_yes_or_no>(value))
         {
@@ -1594,7 +1594,7 @@ wxString CensusViewGridTable::GetValue(int row, int col)
         }
 
     auto const& cell = cell_at(row, col);
-    auto const& conv = table_type_converter::get_by_value(cell);
+    auto const& conv = table_type_converter::get(cell);
     return conv.to_renderer_value(cell.str());
 }
 
@@ -1603,7 +1603,7 @@ void CensusViewGridTable::SetValue(int row, int col, wxString const& value)
     LMI_ASSERT(col != Col_CellNum);
 
     auto& cell = cell_at(row, col);
-    auto const& conv = table_type_converter::get_by_value(cell);
+    auto const& conv = table_type_converter::get(cell);
     auto const& prev_val = cell.str();
     auto const& new_val = conv.from_editor_value(value);
 
@@ -1628,7 +1628,7 @@ wxString CensusViewGridTable::GetTypeName(int row, int col)
         }
 
     auto const& value = cell_at(row, col);
-    auto const& conv = table_type_converter::get_by_value(value);
+    auto const& conv = table_type_converter::get(value);
 
     return conv.grid_value_type(value);
 }

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1028,8 +1028,9 @@ class DatumSequenceEditorEvtHandler
                     return;
                     }
 
-                // Just handle the event to not allow other handlers
-                // process it. The editor window opened in OnKeyDown.
+                // Just handle, i.e. don't skip, the event to not let any other
+                // handlers process it. The editor window was already opened in
+                // UponKeyDown() handler.
                 break;
             default:
                 event.Skip();
@@ -1049,9 +1050,8 @@ class DatumSequenceEditorEvtHandler
                     return;
                     }
 
-                // We should handle the event in DatumSequenceEditorEvtHandler
-                // because otherwise the grid cell editor event handler will
-                // handle Enter.
+                // Open the editor window when Alt-Enter is pressed instead of
+                // just closing the editor, as would be done by default.
                 entry_->open_editor();
                 break;
             default:

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1979,7 +1979,6 @@ wxWindow* CensusGridView::CreateChildWindow()
     grid_window_->UseNativeColHeader();
     grid_window_->DisableHidingColumns();
     grid_window_->DisableDragRowSize();
-    grid_window_->SelectRow(0);
 
     // We could implement some kind of automatic registration, but it doesn't
     // seem to be worth it for now, as we only have a few custom converters,

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -938,8 +938,13 @@ inline std::vector<std::string> const& CensusViewDataViewModel::all_headers() co
 namespace
 {
 
-// Declare the functions here, but implement after the CensusViewGridTable
-// declaration to avoid the "use of undefined type" error.
+// Declare free functions corresponding to their namesakes in CensusViewGridTable
+// that can be used in the implementation of the custom editors below, which
+// are defined before CensusViewGridTable is declared.
+//
+// This seems preferable to intermixing the declarations and definitions, as it
+// allows to declare (and define) all the classes in consistent bottom-to-top
+// order -- but at a price of having these not really indispensable wrappers.
 
 // Get the cell value from the table.
 

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -2274,15 +2274,6 @@ void CensusGridView::update_visible_columns()
             grid_table_->AppendCols(new_columns_count - old_columns_count);
             }
 
-        // Recompute the best fitting sizes if the columns have changed.
-        // Ideally, we would only do it for the new columns, but this would be
-        // more complicated, and for now we prefer to keep the things simple.
-        if(autosize_columns_)
-            {
-            // Pass false to avoid setting min size to the best size.
-            grid_window_->AutoSizeColumns(false);
-            }
-
         grid_window_->SetGridCursor
             (cursor_row
             ,std::min(cursor_col, new_columns_count - 1)

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1009,12 +1009,6 @@ class DatumSequenceEditor
   public:
     DatumSequenceEditor() = default;
 
-    // We don't define a copy ctor because wxGridCellEditor doesn't provide one
-    // and its derived classes are supposed to override Clone() to support
-    // polymorphic copying, instead of using the copy ctor.
-    DatumSequenceEditor(DatumSequenceEditor const&) = delete;
-    DatumSequenceEditor& operator=(DatumSequenceEditor const&) = delete;
-
     void Create(wxWindow* parent, wxWindowID id, wxEvtHandler* evtHandler) override;
 
     void BeginEdit(int row, int col, wxGrid* grid) override;

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1566,22 +1566,23 @@ class CensusViewGridCellAttrProvider
         ,wxGridCellAttr::wxAttrKind kind
         ) const override
     {
-        wxGridCellAttr* attr = wxGridCellAttrProvider::GetAttr(row, col, kind);
+        wxGridCellAttrPtr attr{wxGridCellAttrProvider::GetAttr(row, col, kind)};
 
         if(row % 2)
             {
-            if(attr == nullptr)
+            if(!attr)
                 {
-                attr = attrForOddRows_.get();
-                attr->IncRef();
+                attr = attrForOddRows_;
                 }
             else
                 {
                 if(!attr->HasBackgroundColour())
                     {
-                    wxGridCellAttr* attrNew = attr->Clone();
-                    attr->DecRef();
-                    attr = attrNew;
+                    // Note that we can't modify attr itself, as it can be used
+                    // for other cells and changing its background would change
+                    // their appearance, so allocate a new attribute for this
+                    // cell only.
+                    attr = attr->Clone();
                     attr->SetBackgroundColour
                         (attrForOddRows_->GetBackgroundColour()
                         );
@@ -1589,11 +1590,11 @@ class CensusViewGridCellAttrProvider
                 }
             }
 
-        return attr;
+        return attr.release();
     }
 
   private:
-    wxObjectDataPtr<wxGridCellAttr> attrForOddRows_;
+    wxGridCellAttrPtr attrForOddRows_;
 };
 
 /// Interface to the data for wxGrid.

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1556,9 +1556,8 @@ class CensusViewGridCellAttrProvider
         // Depending on the background, alternate row color
         // will be 3% more dark or 50% brighter.
         int const alpha = bgColor.GetRGB() > 0x808080 ? 97 : 150;
-        altColor_ = bgColor.ChangeLightness(alpha);
 
-        attrForOddRows_->SetBackgroundColour(altColor_);
+        attrForOddRows_->SetBackgroundColour(bgColor.ChangeLightness(alpha));
     }
 
     wxGridCellAttr* GetAttr
@@ -1583,7 +1582,9 @@ class CensusViewGridCellAttrProvider
                     wxGridCellAttr* attrNew = attr->Clone();
                     attr->DecRef();
                     attr = attrNew;
-                    attr->SetBackgroundColour(altColor_);
+                    attr->SetBackgroundColour
+                        (attrForOddRows_->GetBackgroundColour()
+                        );
                     }
                 }
             }
@@ -1592,7 +1593,6 @@ class CensusViewGridCellAttrProvider
     }
 
   private:
-    wxColor                         altColor_;
     wxObjectDataPtr<wxGridCellAttr> attrForOddRows_;
 };
 

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1378,6 +1378,10 @@ class table_string_converter : public table_type_converter
 void
 table_custom_type_converter::register_all(wxGrid* grid)
 {
+    // We could implement some kind of automatic registration, but it doesn't
+    // seem to be worth it for now, as we only have a few custom converters,
+    // all of which defined in this single file, so it's simpler to just list
+    // them explicitly here.
     table_sequence_converter{}.register_data_type(grid);
     table_double_range_converter{}.register_data_type(grid);
     table_date_converter{}.register_data_type(grid);

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -2371,7 +2371,6 @@ void CensusGridView::UponColumnWidthVarying(wxCommandEvent&)
 
     // Pass false to avoid setting min size to the best size.
     grid_window_->AutoSizeColumns(false);
-    Update();
 }
 
 /// Shrink all nonfrozen columns to default width.
@@ -2397,7 +2396,6 @@ void CensusGridView::UponColumnWidthFixed(wxCommandEvent&)
         {
         grid_window_->SetColSize(j, WXGRID_DEFAULT_COL_WIDTH);
         }
-    Update();
 }
 
 void CensusGridView::UponRightClick(wxGridEvent&)

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1803,7 +1803,6 @@ BEGIN_EVENT_TABLE(CensusView, ViewEx)
     EVT_UPDATE_UI(XRCID("copy_census"          ),CensusView::UponUpdateColumnValuesVary )
     EVT_UPDATE_UI(XRCID("paste_census"         ),CensusView::UponUpdateAlwaysEnabled    )
     EVT_UPDATE_UI(XRCID("add_cell"             ),CensusView::UponUpdateAlwaysEnabled    )
-    EVT_UPDATE_UI(XRCID("delete_cells"         ),CensusView::UponUpdateAlwaysEnabled    )
     EVT_UPDATE_UI(XRCID("column_width_varying" ),CensusView::UponUpdateAlwaysEnabled    )
     EVT_UPDATE_UI(XRCID("column_width_fixed"   ),CensusView::UponUpdateAlwaysEnabled    )
     // Disable these printing commands on the "File" menu: specialized
@@ -1817,12 +1816,13 @@ END_EVENT_TABLE()
 IMPLEMENT_DYNAMIC_CLASS(CensusDVCView, CensusView)
 
 BEGIN_EVENT_TABLE(CensusDVCView, CensusView)
-    EVT_DATAVIEW_ITEM_CONTEXT_MENU (wxID_ANY    ,CensusDVCView::UponRightClick           )
-    EVT_DATAVIEW_ITEM_VALUE_CHANGED(wxID_ANY    ,CensusDVCView::UponValueChanged         )
-    EVT_UPDATE_UI(XRCID("edit_cell"            ),CensusDVCView::UponUpdateSingleSelection)
-    EVT_UPDATE_UI(XRCID("edit_class"           ),CensusDVCView::UponUpdateSingleSelection)
-    EVT_UPDATE_UI(XRCID("run_cell"             ),CensusDVCView::UponUpdateSingleSelection)
-    EVT_UPDATE_UI(XRCID("run_class"            ),CensusDVCView::UponUpdateSingleSelection)
+    EVT_DATAVIEW_ITEM_CONTEXT_MENU (wxID_ANY    ,CensusDVCView::UponRightClick             )
+    EVT_DATAVIEW_ITEM_VALUE_CHANGED(wxID_ANY    ,CensusDVCView::UponValueChanged           )
+    EVT_UPDATE_UI(XRCID("edit_cell"            ),CensusDVCView::UponUpdateSingleSelection  )
+    EVT_UPDATE_UI(XRCID("edit_class"           ),CensusDVCView::UponUpdateSingleSelection  )
+    EVT_UPDATE_UI(XRCID("run_cell"             ),CensusDVCView::UponUpdateSingleSelection  )
+    EVT_UPDATE_UI(XRCID("run_class"            ),CensusDVCView::UponUpdateSingleSelection  )
+    EVT_UPDATE_UI(XRCID("delete_cells"         ),CensusDVCView::UponUpdateNonemptySelection)
 END_EVENT_TABLE()
 
 IMPLEMENT_DYNAMIC_CLASS(CensusGridView, CensusView)
@@ -1835,6 +1835,7 @@ BEGIN_EVENT_TABLE(CensusGridView, CensusView)
     EVT_UPDATE_UI(XRCID("edit_class"           ),CensusGridView::UponUpdateAlwaysEnabled)
     EVT_UPDATE_UI(XRCID("run_cell"             ),CensusGridView::UponUpdateAlwaysEnabled)
     EVT_UPDATE_UI(XRCID("run_class"            ),CensusGridView::UponUpdateAlwaysEnabled)
+    EVT_UPDATE_UI(XRCID("delete_cells"         ),CensusGridView::UponUpdateAlwaysEnabled)
 END_EVENT_TABLE()
 
 CensusView::CensusView()
@@ -2465,12 +2466,6 @@ void CensusDVCView::UponUpdateNonemptySelection(wxUpdateUIEvent& e)
 {
     wxDataViewItemArray selection;
     e.Enable(0 < list_window_->GetSelections(selection));
-}
-
-void CensusGridView::UponUpdateNonemptySelection(wxUpdateUIEvent& e)
-{
-    auto const& selected_rows = grid_window_->GetSelectedRows();
-    e.Enable(!selected_rows.empty());
 }
 
 /// Conditionally enable copying.

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -2274,18 +2274,19 @@ void CensusGridView::update_visible_columns()
             grid_table_->AppendCols(new_columns_count - old_columns_count);
             }
 
+        // Recompute the best fitting sizes if the columns have changed.
+        // Ideally, we would only do it for the new columns, but this would be
+        // more complicated, and for now we prefer to keep the things simple.
+        if(autosize_columns_)
+            {
+            // Pass false to avoid setting min size to the best size.
+            grid_window_->AutoSizeColumns(false);
+            }
+
         grid_window_->SetGridCursor
             (cursor_row
             ,std::min(cursor_col, new_columns_count - 1)
             );
-        }
-
-    // Even if the visible columns are the same as before, their contents could
-    // have changed, so always auto-size them if we're configured to do so.
-    if(autosize_columns_)
-        {
-        // Pass false to avoid setting min size to the best size.
-        grid_window_->AutoSizeColumns(false);
         }
 }
 

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1012,6 +1012,8 @@ class DatumSequenceEditorEvtHandler
     explicit DatumSequenceEditorEvtHandler(InputSequenceEntry* entry)
         :entry_(entry)
     {
+        Bind(wxEVT_CHAR, &DatumSequenceEditorEvtHandler::UponChar, this);
+        Bind(wxEVT_KEY_DOWN, &DatumSequenceEditorEvtHandler::UponKeyDown, this);
     }
 
     void UponChar(wxKeyEvent& event)
@@ -1061,14 +1063,8 @@ class DatumSequenceEditorEvtHandler
   private:
     InputSequenceEntry* entry_{};
 
-    DECLARE_EVENT_TABLE()
     DECLARE_NO_COPY_CLASS(DatumSequenceEditorEvtHandler)
 };
-
-BEGIN_EVENT_TABLE(DatumSequenceEditorEvtHandler, wxEvtHandler)
-    EVT_CHAR(DatumSequenceEditorEvtHandler::UponChar)
-    EVT_KEY_DOWN(DatumSequenceEditorEvtHandler::UponKeyDown)
-END_EVENT_TABLE()
 
 class DatumSequenceEditor
     :public wxGridCellEditor

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -2257,11 +2257,18 @@ void CensusGridView::update_visible_columns()
 
         grid_table_->set_visible_columns(std::move(new_visible_columns));
 
-        if(old_columns_count != new_columns_count)
+        // Bring the number of columns actually shown in the grid in sync with
+        // the number of columns in the table if necessary.
+        if(new_columns_count < old_columns_count)
             {
-            grid_window_->DeleteCols(0, old_columns_count);
-            grid_window_->AppendCols(new_columns_count);
-            grid_table_->make_cell_number_column_read_only();
+            grid_table_->DeleteCols
+                (new_columns_count
+                ,old_columns_count - new_columns_count
+                );
+            }
+        else if(old_columns_count < new_columns_count)
+            {
+            grid_table_->AppendCols(new_columns_count - old_columns_count);
             }
 
         grid_window_->SetGridCursor

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1012,30 +1012,7 @@ class DatumSequenceEditorEvtHandler
     explicit DatumSequenceEditorEvtHandler(InputSequenceEntry* entry)
         :entry_(entry)
     {
-        Bind(wxEVT_CHAR, &DatumSequenceEditorEvtHandler::UponChar, this);
         Bind(wxEVT_KEY_DOWN, &DatumSequenceEditorEvtHandler::UponKeyDown, this);
-    }
-
-    void UponChar(wxKeyEvent& event)
-    {
-        switch(event.GetKeyCode())
-            {
-            case WXK_RETURN:
-            case WXK_NUMPAD_ENTER:
-                if(!wxGetKeyState(WXK_ALT))
-                    {
-                    event.Skip();
-                    return;
-                    }
-
-                // Just handle, i.e. don't skip, the event to not let any other
-                // handlers process it. The editor window was already opened in
-                // UponKeyDown() handler.
-                break;
-            default:
-                event.Skip();
-                break;
-            }
     }
 
     void UponKeyDown(wxKeyEvent& event)

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1447,7 +1447,7 @@ table_type_converter::get_by_value(any_member<Input> const& value)
 template<typename T>
 table_type_converter const& table_type_converter::get_impl()
 {
-    static T singleton;
+    static T const singleton;
     return singleton;
 }
 

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1445,35 +1445,27 @@ std::map<std::string, table_type_converter const*>&
 table_type_converter::get_all()
 {
     static std::map<std::string, table_type_converter const*> all
-        {
-            { get_impl<table_bool_converter>().type()
-            ,&get_impl<table_bool_converter>()
-            }
-        ,
-            { get_impl<table_string_converter>().type()
-            ,&get_impl<table_string_converter>()
-            }
-        ,
-            { get_impl<table_sequence_converter>().type()
-            ,&get_impl<table_sequence_converter>()
-            }
-        ,
-            { get_impl<table_enum_converter>().type()
-            ,&get_impl<table_enum_converter>()
-            }
-        ,
-            { get_impl<table_int_range_converter>().type()
-            ,&get_impl<table_int_range_converter>()
-            }
-        ,
-            { get_impl<table_double_range_converter>().type()
-            ,&get_impl<table_double_range_converter>()
-            }
-        ,
-            { get_impl<table_date_converter>().type()
-            ,&get_impl<table_date_converter>()
-            }
-        ,
+        {{ get_impl<table_bool_converter>().type()
+         ,&get_impl<table_bool_converter>()
+         }
+        ,{ get_impl<table_string_converter>().type()
+         ,&get_impl<table_string_converter>()
+         }
+        ,{ get_impl<table_sequence_converter>().type()
+         ,&get_impl<table_sequence_converter>()
+         }
+        ,{ get_impl<table_enum_converter>().type()
+         ,&get_impl<table_enum_converter>()
+         }
+        ,{ get_impl<table_int_range_converter>().type()
+         ,&get_impl<table_int_range_converter>()
+         }
+        ,{ get_impl<table_double_range_converter>().type()
+         ,&get_impl<table_double_range_converter>()
+         }
+        ,{ get_impl<table_date_converter>().type()
+         ,&get_impl<table_date_converter>()
+         }
         };
     return all;
 }

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1965,20 +1965,27 @@ wxWindow* CensusDVCView::CreateChildWindow()
 
 wxWindow* CensusGridView::CreateChildWindow()
 {
+    // Create and customize the grid window: we want to hide its row labels
+    // because we show our own row number column, tweak its alignment slightly
+    // and, importantly, use ellipsis in the overlong cell values rather than
+    // silently truncating them. We also prefer to use the native column header
+    // for a better appearance under MSW and disable the operations which are
+    // either not supported or are not useful.
     grid_window_ = new(wx) wxGrid(GetFrame(), wxID_ANY);
     grid_window_->HideRowLabels();
     grid_window_->SetColLabelAlignment(wxALIGN_LEFT, wxALIGN_CENTRE);
     grid_window_->SetDefaultCellAlignment(wxALIGN_LEFT, wxALIGN_CENTRE);
     grid_window_->SetDefaultCellFitMode(wxGridFitMode::Ellipsize(wxELLIPSIZE_MIDDLE));
-
-    // Grid must be already created when we create the table because we use
-    // the default cell background color to determine the alternating color.
-    grid_table_ = new(wx) CensusViewGridTable(*this);
-    grid_window_->AssignTable(grid_table_, wxGrid::wxGridSelectRows);
-
     grid_window_->UseNativeColHeader();
     grid_window_->DisableHidingColumns();
     grid_window_->DisableDragRowSize();
+
+    // Create the table, providing the grid window with its data, now: notice
+    // that it must be done after creating the grid, as the table attribute
+    // provider uses the default grid cell background color to determine the
+    // alternating rows color.
+    grid_table_ = new(wx) CensusViewGridTable(*this);
+    grid_window_->AssignTable(grid_table_, wxGrid::wxGridSelectRows);
 
     // We could implement some kind of automatic registration, but it doesn't
     // seem to be worth it for now, as we only have a few custom converters,

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -2264,15 +2264,17 @@ void CensusGridView::update_visible_columns()
             grid_table_->make_cell_number_column_read_only();
             }
 
-        if(autosize_columns_)
-            {
-            grid_window_->AutoSize();
-            }
-
         grid_window_->SetGridCursor
             (cursor_row
             ,std::min(cursor_col, new_columns_count - 1)
             );
+        }
+
+    // Even if the visible columns are the same as before, their contents could
+    // have changed, so always auto-size them if we're configured to do so.
+    if(autosize_columns_)
+        {
+        grid_window_->AutoSize();
         }
 }
 

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1536,6 +1536,7 @@ CensusViewGridTable::CensusViewGridTable(CensusGridView& view)
     wxGrid const* grid = view.grid_window_;
     SetAttrProvider(new(wx) CensusViewGridCellAttrProvider(grid));
 
+    // The first, special, column shows the cell row number and can't be edited.
     auto attr = new(wx) wxGridCellAttr();
     attr->SetReadOnly();
     SetColAttr(attr, 0);

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -2253,10 +2253,7 @@ void CensusGridView::update_visible_columns()
 
         wxGridUpdateLocker grid_update_locker(grid_window_);
 
-        if(grid_window_->IsCellEditControlEnabled())
-            {
-            grid_window_->DisableCellEditControl();
-            }
+        grid_window_->DisableCellEditControl();
 
         grid_table_->set_visible_columns(std::move(new_visible_columns));
 
@@ -3194,11 +3191,7 @@ void CensusGridView::UponPasteCensus(wxCommandEvent&)
 
     wxGridUpdateLocker grid_update_locker(grid_window_);
     grid_window_->ClearSelection();
-
-    if(grid_window_->IsCellEditControlEnabled())
-        {
-        grid_window_->DisableCellEditControl();
-        }
+    grid_window_->DisableCellEditControl();
 
     if(old_rows != new_rows || old_cols != new_cols)
         {

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1648,7 +1648,7 @@ class CensusViewGridTable
 
     void set_visible_columns(std::vector<int>&& new_visible_columns)
     {
-        std::swap(new_visible_columns, visible_columns_);
+        visible_columns_ = std::move(new_visible_columns);
     }
 
   private:

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -2284,7 +2284,8 @@ void CensusGridView::update_visible_columns()
     // have changed, so always auto-size them if we're configured to do so.
     if(autosize_columns_)
         {
-        grid_window_->AutoSize();
+        // Pass false to avoid setting min size to the best size.
+        grid_window_->AutoSizeColumns(false);
         }
 }
 

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1061,7 +1061,7 @@ class DatumSequenceEditorEvtHandler
     }
 
   private:
-    InputSequenceEntry* entry_{};
+    InputSequenceEntry* const entry_{};
 
     DECLARE_NO_COPY_CLASS(DatumSequenceEditorEvtHandler)
 };

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -2246,7 +2246,7 @@ void CensusGridView::update_visible_columns()
         auto const cursor_row = grid_window_->GetGridCursorRow();
         auto const cursor_col = grid_window_->GetGridCursorCol();
 
-        auto const columns_count     =
+        auto const old_columns_count =
             lmi::ssize(grid_table_->get_visible_columns()) + 1;
         auto const new_columns_count =
             lmi::ssize(new_visible_columns)                + 1;
@@ -2257,9 +2257,9 @@ void CensusGridView::update_visible_columns()
 
         grid_table_->set_visible_columns(std::move(new_visible_columns));
 
-        if(columns_count != new_columns_count)
+        if(old_columns_count != new_columns_count)
             {
-            grid_window_->DeleteCols(0, columns_count);
+            grid_window_->DeleteCols(0, old_columns_count);
             grid_window_->AppendCols(new_columns_count);
             grid_table_->make_cell_number_column_read_only();
             }

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1482,13 +1482,7 @@ class CensusViewGridTable
     // Cell serial number: always shown in the first column.
     static int const Col_CellNum = 0;
 
-    explicit CensusViewGridTable(CensusGridView& view)
-        :view_ {view}
-    {
-        wxGrid const* grid = view.grid_window_;
-        SetAttrProvider(new(wx) CensusViewGridCellAttrProvider(grid));
-        make_cell_number_column_read_only();
-    }
+    explicit CensusViewGridTable(CensusGridView& view);
 
     // return the number of rows and columns in this table.
     int GetNumberRows() override;
@@ -1507,8 +1501,6 @@ class CensusViewGridTable
     bool DeleteCols(size_t pos, size_t numCols) override;
 
     wxString GetColLabelValue(int col) override;
-
-    void make_cell_number_column_read_only();
 
     std::string const& col_name(int col) const;
 
@@ -1537,6 +1529,17 @@ class CensusViewGridTable
 
     std::vector<int> visible_columns_;
 };
+
+CensusViewGridTable::CensusViewGridTable(CensusGridView& view)
+    :view_ {view}
+{
+    wxGrid const* grid = view.grid_window_;
+    SetAttrProvider(new(wx) CensusViewGridCellAttrProvider(grid));
+
+    auto attr = new(wx) wxGridCellAttr();
+    attr->SetReadOnly();
+    SetColAttr(attr, 0);
+}
 
 int CensusViewGridTable::GetNumberRows()
 {
@@ -1706,13 +1709,6 @@ bool CensusViewGridTable::DeleteCols(size_t pos, size_t num_cols)
     grid->ProcessTableMessage(msg);
 
     return true;
-}
-
-void CensusViewGridTable::make_cell_number_column_read_only()
-{
-    auto attr = new(wx) wxGridCellAttr();
-    attr->SetReadOnly();
-    SetColAttr(attr, 0);
 }
 
 inline std::string const& CensusViewGridTable::col_name(int col) const

--- a/census_view.hpp
+++ b/census_view.hpp
@@ -85,7 +85,6 @@ class CensusView
     virtual void UponColumnWidthFixed       (wxCommandEvent&) = 0;
     void         UponUpdateAlwaysDisabled   (wxUpdateUIEvent&);
     void         UponUpdateAlwaysEnabled    (wxUpdateUIEvent&);
-    virtual void UponUpdateNonemptySelection(wxUpdateUIEvent&) = 0;
     virtual void UponUpdateColumnValuesVary (wxUpdateUIEvent&) = 0;
 
     bool DoAllCells(mcenum_emission);
@@ -159,7 +158,7 @@ class CensusDVCView final
     void UponColumnWidthVarying     (wxCommandEvent&) override;
     void UponColumnWidthFixed       (wxCommandEvent&) override;
     void UponUpdateSingleSelection  (wxUpdateUIEvent&);
-    void UponUpdateNonemptySelection(wxUpdateUIEvent&) override;
+    void UponUpdateNonemptySelection(wxUpdateUIEvent&);
     void UponUpdateColumnValuesVary (wxUpdateUIEvent&) override;
 
     void Update() override;
@@ -200,7 +199,6 @@ class CensusGridView final
     void UponDeleteCells            (wxCommandEvent&) override;
     void UponColumnWidthVarying     (wxCommandEvent&) override;
     void UponColumnWidthFixed       (wxCommandEvent&) override;
-    void UponUpdateNonemptySelection(wxUpdateUIEvent&) override;
     void UponUpdateColumnValuesVary (wxUpdateUIEvent&) override;
 
     void Update() override;

--- a/census_view.hpp
+++ b/census_view.hpp
@@ -85,6 +85,7 @@ class CensusView
     virtual void UponColumnWidthFixed       (wxCommandEvent&) = 0;
     void         UponUpdateAlwaysDisabled   (wxUpdateUIEvent&);
     void         UponUpdateAlwaysEnabled    (wxUpdateUIEvent&);
+    virtual void UponUpdateSingleSelection  (wxUpdateUIEvent&) = 0;
     virtual void UponUpdateColumnValuesVary (wxUpdateUIEvent&) = 0;
 
     bool DoAllCells(mcenum_emission);
@@ -157,7 +158,7 @@ class CensusDVCView final
     void UponDeleteCells            (wxCommandEvent&) override;
     void UponColumnWidthVarying     (wxCommandEvent&) override;
     void UponColumnWidthFixed       (wxCommandEvent&) override;
-    void UponUpdateSingleSelection  (wxUpdateUIEvent&);
+    void UponUpdateSingleSelection  (wxUpdateUIEvent&) override;
     void UponUpdateNonemptySelection(wxUpdateUIEvent&);
     void UponUpdateColumnValuesVary (wxUpdateUIEvent&) override;
 
@@ -199,6 +200,7 @@ class CensusGridView final
     void UponDeleteCells            (wxCommandEvent&) override;
     void UponColumnWidthVarying     (wxCommandEvent&) override;
     void UponColumnWidthFixed       (wxCommandEvent&) override;
+    void UponUpdateSingleSelection  (wxUpdateUIEvent&) override;
     void UponUpdateColumnValuesVary (wxUpdateUIEvent&) override;
 
     void Update() override;

--- a/census_view.hpp
+++ b/census_view.hpp
@@ -47,7 +47,6 @@ class WXDLLIMPEXP_FWD_ADV wxGrid;
 class WXDLLIMPEXP_FWD_ADV wxGridEvent;
 class WXDLLIMPEXP_FWD_ADV wxGridSizeEvent;
 
-
 class CensusView
     :public ViewEx
 {

--- a/census_view.hpp
+++ b/census_view.hpp
@@ -38,6 +38,15 @@
 #include <vector>
 
 class CensusDocument;
+class CensusViewDataViewModel;
+class CensusViewGridTable;
+
+class WXDLLIMPEXP_FWD_ADV wxDataViewEvent;
+class WXDLLIMPEXP_FWD_ADV wxDataViewCtrl;
+class WXDLLIMPEXP_FWD_ADV wxGrid;
+class WXDLLIMPEXP_FWD_ADV wxGridEvent;
+class WXDLLIMPEXP_FWD_ADV wxGridSizeEvent;
+
 
 class CensusView
     :public ViewEx
@@ -49,9 +58,9 @@ class CensusView
     CensusView(CensusView const&) = delete;
     CensusView& operator=(CensusView const&) = delete;
 
-  protected:
     virtual void update_visible_columns() = 0;
 
+  protected:
     CensusDocument& document() const;
 
     // ViewEx required implementation.
@@ -111,7 +120,7 @@ class CensusView
         ,std::string const& title
         );
 
-    virtual int selected_row() = 0;
+    virtual int current_row() = 0;
 
     void update_class_names();
 
@@ -123,12 +132,6 @@ class CensusView
 
     DECLARE_EVENT_TABLE()
 };
-
-class CensusDVCDocument;
-class CensusViewDataViewModel;
-
-class WXDLLIMPEXP_FWD_ADV wxDataViewEvent;
-class WXDLLIMPEXP_FWD_ADV wxDataViewCtrl;
 
 class CensusDVCView final
     :public CensusView
@@ -149,7 +152,6 @@ class CensusDVCView final
     wxWindow* CreateChildWindow() override;
 
     // Event handlers, in event-table order (reflecting GUI order)
-
     void UponRightClick             (wxDataViewEvent&);
     void UponValueChanged           (wxDataViewEvent&);
     void UponPasteCensus            (wxCommandEvent&) override;
@@ -163,12 +165,53 @@ class CensusDVCView final
 
     void Update() override;
 
-    int selected_row() override;
+    int current_row() override;
 
-    wxDataViewCtrl* list_window_ {nullptr};
+    wxDataViewCtrl* list_window_;
     wxObjectDataPtr<CensusViewDataViewModel> list_model_;
 
     DECLARE_DYNAMIC_CLASS(CensusDVCView)
+    DECLARE_EVENT_TABLE()
+};
+
+class CensusGridView final
+    :public CensusView
+{
+    friend class CensusGridDocument;
+    friend class CensusViewGridTable;
+
+  public:
+    CensusGridView() = default;
+
+  private:
+    CensusGridView(CensusGridView const&) = delete;
+    CensusGridView& operator=(CensusGridView const&) = delete;
+
+    void update_visible_columns() override;
+
+    // ViewEx required implementation.
+    wxWindow* CreateChildWindow() override;
+
+    // Event handlers, in event-table order (reflecting GUI order)
+    void UponRightClick             (wxGridEvent&);
+    void UponValueChanged           (wxGridEvent&);
+    void UponColumnAutoSize         (wxGridSizeEvent&);
+    void UponPasteCensus            (wxCommandEvent&) override;
+    void UponAddCell                (wxCommandEvent&) override;
+    void UponDeleteCells            (wxCommandEvent&) override;
+    void UponColumnWidthVarying     (wxCommandEvent&) override;
+    void UponColumnWidthFixed       (wxCommandEvent&) override;
+    void UponUpdateNonemptySelection(wxUpdateUIEvent&) override;
+    void UponUpdateColumnValuesVary (wxUpdateUIEvent&) override;
+
+    void Update() override;
+
+    int current_row() override;
+
+    wxGrid*              grid_window_ {nullptr};
+    CensusViewGridTable* grid_table_  {nullptr};
+
+    DECLARE_DYNAMIC_CLASS(CensusGridView)
     DECLARE_EVENT_TABLE()
 };
 

--- a/census_view.hpp
+++ b/census_view.hpp
@@ -38,17 +38,10 @@
 #include <vector>
 
 class CensusDocument;
-class CensusViewDataViewModel;
 
-class WXDLLIMPEXP_FWD_ADV wxDataViewEvent;
-class WXDLLIMPEXP_FWD_ADV wxDataViewCtrl;
-
-class CensusView final
+class CensusView
     :public ViewEx
 {
-    friend class CensusDocument;
-    friend class CensusViewDataViewModel;
-
   public:
     CensusView();
 
@@ -56,43 +49,40 @@ class CensusView final
     CensusView(CensusView const&) = delete;
     CensusView& operator=(CensusView const&) = delete;
 
-    void update_visible_columns();
+  protected:
+    virtual void update_visible_columns() = 0;
 
     CensusDocument& document() const;
 
     // ViewEx required implementation.
-    wxWindow* CreateChildWindow() override;
     char const* icon_xrc_resource   () const override;
     char const* menubar_xrc_resource() const override;
 
     // Event handlers, in event-table order (reflecting GUI order)
-    void UponRightClick             (wxDataViewEvent&);
-    void UponValueChanged           (wxDataViewEvent&);
-    void UponEditCell               (wxCommandEvent&);
-    void UponEditClass              (wxCommandEvent&);
-    void UponEditCase               (wxCommandEvent&);
-    void UponRunCell                (wxCommandEvent&);
-    void UponRunCase                (wxCommandEvent&);
-    void UponPrintCase              (wxCommandEvent&);
-    void UponPrintCaseToDisk        (wxCommandEvent&);
-    void UponRunCaseToSpreadsheet   (wxCommandEvent&);
-    void UponRunCaseToGroupRoster   (wxCommandEvent&);
-    void UponRunCaseToGroupQuote    (wxCommandEvent&);
-    void UponCopyCensus             (wxCommandEvent&);
-    void UponPasteCensus            (wxCommandEvent&);
-    void UponAddCell                (wxCommandEvent&);
-    void UponDeleteCells            (wxCommandEvent&);
-    void UponColumnWidthVarying     (wxCommandEvent&);
-    void UponColumnWidthFixed       (wxCommandEvent&);
-    void UponUpdateAlwaysDisabled   (wxUpdateUIEvent&);
-    void UponUpdateAlwaysEnabled    (wxUpdateUIEvent&);
-    void UponUpdateSingleSelection  (wxUpdateUIEvent&);
-    void UponUpdateNonemptySelection(wxUpdateUIEvent&);
-    void UponUpdateColumnValuesVary (wxUpdateUIEvent&);
+    void         UponEditCell               (wxCommandEvent&);
+    void         UponEditClass              (wxCommandEvent&);
+    void         UponEditCase               (wxCommandEvent&);
+    void         UponRunCell                (wxCommandEvent&);
+    void         UponRunCase                (wxCommandEvent&);
+    void         UponPrintCase              (wxCommandEvent&);
+    void         UponPrintCaseToDisk        (wxCommandEvent&);
+    void         UponRunCaseToSpreadsheet   (wxCommandEvent&);
+    void         UponRunCaseToGroupRoster   (wxCommandEvent&);
+    void         UponRunCaseToGroupQuote    (wxCommandEvent&);
+    void         UponCopyCensus             (wxCommandEvent&);
+    virtual void UponPasteCensus            (wxCommandEvent&) = 0;
+    virtual void UponAddCell                (wxCommandEvent&) = 0;
+    virtual void UponDeleteCells            (wxCommandEvent&) = 0;
+    virtual void UponColumnWidthVarying     (wxCommandEvent&) = 0;
+    virtual void UponColumnWidthFixed       (wxCommandEvent&) = 0;
+    void         UponUpdateAlwaysDisabled   (wxUpdateUIEvent&);
+    void         UponUpdateAlwaysEnabled    (wxUpdateUIEvent&);
+    virtual void UponUpdateNonemptySelection(wxUpdateUIEvent&) = 0;
+    virtual void UponUpdateColumnValuesVary (wxUpdateUIEvent&) = 0;
 
     bool DoAllCells(mcenum_emission);
 
-    void Update();
+    virtual void Update() = 0;
     void ViewOneCell(int);
     void ViewComposite();
 
@@ -121,7 +111,7 @@ class CensusView final
         ,std::string const& title
         );
 
-    int selected_row();
+    virtual int selected_row() = 0;
 
     void update_class_names();
 
@@ -131,10 +121,54 @@ class CensusView final
 
     std::shared_ptr<Ledger const> composite_ledger_;
 
-    wxDataViewCtrl* list_window_;
+    DECLARE_EVENT_TABLE()
+};
+
+class CensusDVCDocument;
+class CensusViewDataViewModel;
+
+class WXDLLIMPEXP_FWD_ADV wxDataViewEvent;
+class WXDLLIMPEXP_FWD_ADV wxDataViewCtrl;
+
+class CensusDVCView final
+    :public CensusView
+{
+    friend class CensusDVCDocument;
+    friend class CensusViewDataViewModel;
+
+  public:
+    CensusDVCView();
+
+  private:
+    CensusDVCView(CensusDVCView const&) = delete;
+    CensusDVCView& operator=(CensusDVCView const&) = delete;
+
+    void update_visible_columns() override;
+
+    // ViewEx required implementation.
+    wxWindow* CreateChildWindow() override;
+
+    // Event handlers, in event-table order (reflecting GUI order)
+
+    void UponRightClick             (wxDataViewEvent&);
+    void UponValueChanged           (wxDataViewEvent&);
+    void UponPasteCensus            (wxCommandEvent&) override;
+    void UponAddCell                (wxCommandEvent&) override;
+    void UponDeleteCells            (wxCommandEvent&) override;
+    void UponColumnWidthVarying     (wxCommandEvent&) override;
+    void UponColumnWidthFixed       (wxCommandEvent&) override;
+    void UponUpdateSingleSelection  (wxUpdateUIEvent&);
+    void UponUpdateNonemptySelection(wxUpdateUIEvent&) override;
+    void UponUpdateColumnValuesVary (wxUpdateUIEvent&) override;
+
+    void Update() override;
+
+    int selected_row() override;
+
+    wxDataViewCtrl* list_window_ {nullptr};
     wxObjectDataPtr<CensusViewDataViewModel> list_model_;
 
-    DECLARE_DYNAMIC_CLASS(CensusView)
+    DECLARE_DYNAMIC_CLASS(CensusDVCView)
     DECLARE_EVENT_TABLE()
 };
 

--- a/input_sequence_entry.cpp
+++ b/input_sequence_entry.cpp
@@ -1346,6 +1346,7 @@ class InputSequenceTextCtrl
 
   private:
     void UponChar(wxKeyEvent& event);
+    void UponKeyDown(wxKeyEvent& event);
 };
 
 InputSequenceTextCtrl::InputSequenceTextCtrl(wxWindow* parent, wxWindowID id)
@@ -1363,11 +1364,22 @@ InputSequenceTextCtrl::InputSequenceTextCtrl(wxWindow* parent, wxWindowID id)
             ,wxEVT_CHAR
             ,&InputSequenceTextCtrl::UponChar
             );
+    ::Connect
+            (this
+            ,wxEVT_KEY_DOWN
+            ,&InputSequenceTextCtrl::UponKeyDown
+            );
 }
 
 void InputSequenceTextCtrl::UponChar(wxKeyEvent& event)
 {
     if(!GetParent()->ProcessWindowEvent(event))
+        event.Skip();
+}
+
+void InputSequenceTextCtrl::UponKeyDown(wxKeyEvent& event)
+{
+    if (!GetParent()->ProcessWindowEvent(event))
         event.Skip();
 }
 
@@ -1446,6 +1458,15 @@ bool InputSequenceEntry::Create
         );
 
     return true;
+}
+
+void InputSequenceEntry::open_editor()
+{
+    DoOpenEditor();
+
+    // Put focus back on the control itself as normal focus restoring logic
+    // doesn't work as we block some of the events in UponChildKillFocus().
+    text_->SetFocus();
 }
 
 void InputSequenceEntry::input(Input const& input)
@@ -1534,11 +1555,7 @@ void InputSequenceEntry::UponEnter(wxCommandEvent& event)
         return;
         }
 
-    DoOpenEditor();
-
-    // Put focus back on the control itself as normal focus restoring logic
-    // doesn't work as we block some of the events in UponChildKillFocus().
-    text_->SetFocus();
+    open_editor();
 }
 
 void InputSequenceEntry::UponOpenEditor(wxCommandEvent&)

--- a/input_sequence_entry.hpp
+++ b/input_sequence_entry.hpp
@@ -55,6 +55,8 @@ class InputSequenceEntry final
 
     void set_popup_title(wxString const& title) {title_ = title;}
 
+    void open_editor();
+
   private:
     void UponChildKillFocus(wxFocusEvent&);
     void UponEnter(wxCommandEvent&);

--- a/install_wx.sh
+++ b/install_wx.sh
@@ -33,7 +33,7 @@ set -vxe
 
 remote_host_url=${remote_host_url:-"https://github.com/wxWidgets/wxWidgets.git"}
 
-wx_commit_sha=${wx_commit_sha:-"f741031e69de73d5816cc56e99c9beba3ac820de"}
+wx_commit_sha=${wx_commit_sha:-"a03e2b8b4fe747559d7b963f3bc20e4ae23aada5"}
 
 wx_skip_clean=${wx_skip_clean:-"0"}
 

--- a/install_wx.sh
+++ b/install_wx.sh
@@ -33,7 +33,7 @@ set -vxe
 
 remote_host_url=${remote_host_url:-"https://github.com/wxWidgets/wxWidgets.git"}
 
-wx_commit_sha=${wx_commit_sha:-"a03e2b8b4fe747559d7b963f3bc20e4ae23aada5"}
+wx_commit_sha=${wx_commit_sha:-"789c7cec7b7020053461f45572e93b6f30cc9b9d"}
 
 wx_skip_clean=${wx_skip_clean:-"0"}
 

--- a/install_wxpdfdoc.sh
+++ b/install_wxpdfdoc.sh
@@ -33,7 +33,7 @@ set -vxe
 
 remote_host_url=${remote_host_url:-"https://github.com/vadz/wxpdfdoc.git"}
 
-wxpdfdoc_commit_sha=${wxpdfdoc_commit_sha:-"55366f01eed8549ca704f9d9825127868858aafb"}
+wxpdfdoc_commit_sha=${wxpdfdoc_commit_sha:-"6bc5794ba0c7461225ec976c7d9130871bd6ce5a"}
 
 wxpdfdoc_skip_clean=${wxpdfdoc_skip_clean:-"0"}
 

--- a/install_wxpdfdoc.sh
+++ b/install_wxpdfdoc.sh
@@ -33,7 +33,7 @@ set -vxe
 
 remote_host_url=${remote_host_url:-"https://github.com/vadz/wxpdfdoc.git"}
 
-wxpdfdoc_commit_sha=${wxpdfdoc_commit_sha:-"6bc5794ba0c7461225ec976c7d9130871bd6ce5a"}
+wxpdfdoc_commit_sha=${wxpdfdoc_commit_sha:-"acbd019d18e991cca46a80e1be58e637774d5d3b"}
 
 wxpdfdoc_skip_clean=${wxpdfdoc_skip_clean:-"0"}
 

--- a/skeleton.cpp
+++ b/skeleton.cpp
@@ -297,6 +297,8 @@ void Skeleton::InitDocManager()
     doc_manager_ = CreateDocManager();
     doc_manager_->FileHistoryLoad(*config_);
 
+    auto const use_grid =
+        contains(global_settings::instance().pyx(), "use_census_grid");
     new(wx) wxDocTemplate
         (doc_manager_
         ,"Census"
@@ -305,8 +307,8 @@ void Skeleton::InitDocManager()
         ,"cns"
         ,"Census document"
         ,"Census view"
-        ,CLASSINFO(CensusDVCDocument)
-        ,CLASSINFO(CensusDVCView)
+        ,use_grid ? CLASSINFO(CensusGridDocument) : CLASSINFO(CensusDVCDocument)
+        ,use_grid ? CLASSINFO(CensusGridView)     : CLASSINFO(CensusDVCView)
         );
 
     new(wx) wxDocTemplate

--- a/skeleton.cpp
+++ b/skeleton.cpp
@@ -305,8 +305,8 @@ void Skeleton::InitDocManager()
         ,"cns"
         ,"Census document"
         ,"Census view"
-        ,CLASSINFO(CensusDocument)
-        ,CLASSINFO(CensusView)
+        ,CLASSINFO(CensusDVCDocument)
+        ,CLASSINFO(CensusDVCView)
         );
 
     new(wx) wxDocTemplate

--- a/wx_test_paste_census.cpp
+++ b/wx_test_paste_census.cpp
@@ -23,8 +23,11 @@
 
 #include "assert_lmi.hpp"
 #include "bourn_cast.hpp"
+#include "contains.hpp"
 #include "data_directory.hpp"
+#include "global_settings.hpp"
 #include "mvc_controller.hpp"
+#include "ssize_lmi.hpp"
 #include "wx_test_case.hpp"
 #include "wx_test_new.hpp"
 #include "wx_test_output.hpp"
@@ -33,6 +36,7 @@
 #include <wx/app.h>
 #include <wx/dataview.h>
 #include <wx/dialog.h>
+#include <wx/grid.h>
 #include <wx/mdi.h>
 #include <wx/radiobox.h>
 #include <wx/testing.h>
@@ -46,6 +50,8 @@
 
 namespace
 {
+
+// wxDataViewCtrl functions.
 
 // Helper function to find the wxDataViewCtrl used for the census display.
 //
@@ -87,7 +93,7 @@ wxDataViewListModel* get_census_list_model(wxDataViewCtrl* dvc)
     return list_model;
 }
 
-// Helper for building the diagnostic message in check_list_columns().
+// Helper for building the diagnostic message.
 std::string build_not_found_message(std::set<std::string> const& remaining)
 {
     std::ostringstream message;
@@ -158,6 +164,85 @@ int find_model_column_by_title
         if(column->GetTitle().ToStdString() == title)
             {
             return column->GetModelColumn();
+            }
+        }
+
+    throw std::runtime_error("column " + title + " not found");
+}
+
+// wxGrid functions.
+
+// Helper function to find the wxGrid used for the census display.
+//
+// Precondition: the currently active window must be a CensusView.
+wxGrid* find_census_grid_window()
+{
+    wxWindow* const top_window = wxTheApp->GetTopWindow();
+    LMI_ASSERT(top_window);
+
+    wxMDIParentFrame* const
+        parent_frame = dynamic_cast<wxMDIParentFrame*>(top_window);
+    LMI_ASSERT(parent_frame);
+
+    wxMDIChildFrame* const child_frame = parent_frame->GetActiveChild();
+    LMI_ASSERT(child_frame);
+
+    wxWindowList const& census_children = child_frame->GetChildren();
+    wxWindowList::const_iterator z = census_children.begin();
+    LMI_ASSERT(z != census_children.end());
+
+    wxGrid* const grid = dynamic_cast<wxGrid*>(*z);
+    LMI_ASSERT(grid);
+
+    return grid;
+}
+
+// Check for the presence of all columns with the given name and, if specified,
+// for the absence of the given one.
+//
+// The 'when' parameter is used solely for the diagnostic messages in case of
+// the check failure.
+void check_grid_columns
+    (wxGrid* grid
+    ,char const* when
+    ,std::set<std::string> const& expected
+    ,std::string const& unexpected = std::string()
+    )
+{
+    std::set<std::string> remaining(expected.begin(), expected.end());
+
+    for(int n = 0; n < grid->GetNumberCols(); ++n)
+        {
+        std::string const title = grid->GetColLabelValue(n).ToStdString();
+        LMI_ASSERT_WITH_MSG
+            (title != unexpected
+            ,"column '" << title << "' unexpectedly found " << when
+            );
+
+        // Notice that it is not an error if the column is not in the expected
+        // columns set, it is not exhaustive.
+        remaining.erase(title);
+        }
+
+    LMI_ASSERT_WITH_MSG
+        (remaining.empty()
+        ,build_not_found_message(remaining) << when
+        );
+}
+
+// Find the index of the column with the given title.
+//
+// Throws an exception if the column is not found.
+int find_table_column_by_title
+    (wxGrid* grid
+    ,std::string const& title
+    )
+{
+    for(int n = 0; n < grid->GetNumberCols(); ++n)
+        {
+        if(grid->GetColLabelValue(n).ToStdString() == title)
+            {
+            return n;
             }
         }
 
@@ -242,6 +327,9 @@ LMI_WX_TEST_CASE(paste_census)
     // Put the data to paste on clipboard.
     ClipboardEx::SetText(census_data);
 
+    auto const use_grid =
+        contains(global_settings::instance().pyx(), "use_census_grid");
+
     // Create a new census.
     wx_test_new_census census;
 
@@ -250,32 +338,70 @@ LMI_WX_TEST_CASE(paste_census)
     ui.Char('s', wxMOD_CONTROL | wxMOD_SHIFT); // "Census | Paste census"
     wxYield();
 
-    // Find the model containing the cells and check that it was filled in
-    // correctly.
-    wxDataViewCtrl* const list_window = find_census_list_window();
-    wxDataViewListModel* const list_model = get_census_list_model(list_window);
-    LMI_ASSERT_EQUAL(bourn_cast<int>(list_model->GetCount()), number_of_rows);
+    wxGrid* grid_window = nullptr;
+    wxGridTableBase* table = nullptr;
+    wxDataViewCtrl* list_window = nullptr;
+    wxDataViewListModel* list_model = nullptr;
 
-    check_list_columns
-        (list_window
-        ,"after pasting initial census data"
-        ,column_titles
-        );
+    if (use_grid)
+        {
+        // Find the model containing the cells and check that it was filled in
+        // correctly.
+        grid_window = find_census_grid_window();
+        table = grid_window->GetTable();
+        LMI_ASSERT(table);
+        LMI_ASSERT_EQUAL(table->GetNumberRows(), number_of_rows);
 
-    // Change class defaults: this requires a selection, so ensure we have one
-    // by clicking somewhere inside the control.
-    ui.MouseMove
-        (list_window->ClientToScreen
-            (wxPoint
-                (10 * list_window->GetCharWidth()
-                , 3 * list_window->GetCharHeight()
+        check_grid_columns
+            (grid_window
+            ,"after pasting initial census data"
+            ,column_titles
+            );
+
+        // Change class defaults: this requires a selection, so ensure we have one
+        // by clicking somewhere inside the control.
+        ui.MouseMove
+            (grid_window->ClientToScreen
+                (wxPoint
+                    (10 * grid_window->GetCharWidth()
+                    , 3 * grid_window->GetCharHeight()
+                    )
                 )
-            )
-        );
-    ui.MouseClick();
-    wxYield();
+            );
+        ui.MouseClick();
+        wxYield();
 
-    LMI_ASSERT_EQUAL(list_window->GetSelectedItemsCount(), 1);
+        LMI_ASSERT_EQUAL(lmi::ssize(grid_window->GetSelectedRows()), 1);
+        }
+    else
+        {
+        // Find the model containing the cells and check that it was filled in
+        // correctly.
+        list_window = find_census_list_window();
+        list_model = get_census_list_model(list_window);
+        LMI_ASSERT_EQUAL(bourn_cast<int>(list_model->GetCount()), number_of_rows);
+
+        check_list_columns
+            (list_window
+            ,"after pasting initial census data"
+            ,column_titles
+            );
+
+        // Change class defaults: this requires a selection, so ensure we have one
+        // by clicking somewhere inside the control.
+        ui.MouseMove
+            (list_window->ClientToScreen
+                (wxPoint
+                    (10 * list_window->GetCharWidth()
+                    , 3 * list_window->GetCharHeight()
+                    )
+                )
+            );
+        ui.MouseClick();
+        wxYield();
+
+        LMI_ASSERT_EQUAL(list_window->GetSelectedItemsCount(), 1);
+        }
 
     ui.Char('e', wxMOD_CONTROL | wxMOD_ALT); // "Census|Edit class defaults"
 
@@ -329,23 +455,45 @@ LMI_WX_TEST_CASE(paste_census)
             Describe("message box asking whether to apply gender changes to all")
         );
 
-    // Check that all columns, including the "Gender" one, are still shown.
-    check_list_columns
-        (list_window
-        ,"after changing gender in class defaults"
-        ,column_titles
-        );
-
-    // Verify that the "Gender" column value is "Unisex" in every row now.
-    int const gender_column = find_model_column_by_title(list_window, "Gender");
-    LMI_ASSERT_EQUAL(bourn_cast<int>(list_model->GetCount()), number_of_rows);
-    // Only the first two rows are affected, because only they belong
-    // to the first employee class.
-    for(int row = 0; row < 2; ++row)
+    if (use_grid)
         {
-        wxVariant value;
-        list_model->GetValueByRow(value, row, gender_column);
-        LMI_ASSERT_EQUAL(value.GetString(), "Unisex");
+        // Check that all columns, including the "Gender" one, are still shown.
+        check_grid_columns
+            (grid_window
+            ,"after changing gender in class defaults"
+            ,column_titles
+            );
+
+        // Verify that the "Gender" column value is "Unisex" in every row now.
+        int const gender_column = find_table_column_by_title(grid_window, "Gender");
+        LMI_ASSERT_EQUAL(table->GetNumberRows(), number_of_rows);
+        // Only the first two rows are affected, because only they belong
+        // to the first employee class.
+        for(int row = 0; row < 2; ++row)
+            {
+            LMI_ASSERT_EQUAL(table->GetValue(row, gender_column), "Unisex");
+            }
+        }
+    else
+        {
+        // Check that all columns, including the "Gender" one, are still shown.
+        check_list_columns
+            (list_window
+            ,"after changing gender in class defaults"
+            ,column_titles
+            );
+
+        // Verify that the "Gender" column value is "Unisex" in every row now.
+        int const gender_column = find_model_column_by_title(list_window, "Gender");
+        LMI_ASSERT_EQUAL(bourn_cast<int>(list_model->GetCount()), number_of_rows);
+        // Only the first two rows are affected, because only they belong
+        // to the first employee class.
+        for(int row = 0; row < 2; ++row)
+            {
+            wxVariant value;
+            list_model->GetValueByRow(value, row, gender_column);
+            LMI_ASSERT_EQUAL(value.GetString(), "Unisex");
+            }
         }
 
     // Change the case defaults to get rid of the underwriting class.
@@ -397,17 +545,34 @@ LMI_WX_TEST_CASE(paste_census)
             Describe("message box asking whether to apply class changes to all")
         );
 
-    // Check that we still have the same cells but that now the underwriting
-    // class column has disappeared as its value has been fixed.
-    LMI_ASSERT_EQUAL(bourn_cast<int>(list_model->GetCount()), number_of_rows);
+    if (use_grid)
+        {
+        // Check that we still have the same cells but that now the underwriting
+        // class column has disappeared as its value has been fixed.
+        LMI_ASSERT_EQUAL(table->GetNumberRows(), number_of_rows);
 
-    column_titles.erase("Underwriting Class");
-    check_list_columns
-        (list_window
-        ,"after changing class in case defaults"
-        ,column_titles
-        ,"Underwriting Class"
-        );
+        column_titles.erase("Underwriting Class");
+        check_grid_columns
+            (grid_window
+            ,"after changing class in case defaults"
+            ,column_titles
+            ,"Underwriting Class"
+            );
+        }
+    else
+        {
+        // Check that we still have the same cells but that now the underwriting
+        // class column has disappeared as its value has been fixed.
+        LMI_ASSERT_EQUAL(bourn_cast<int>(list_model->GetCount()), number_of_rows);
+
+        column_titles.erase("Underwriting Class");
+        check_list_columns
+            (list_window
+            ,"after changing class in case defaults"
+            ,column_titles
+            ,"Underwriting Class"
+            );
+        }
 
     // Finally save the census with the pasted data for later inspection.
     std::string const census_file_name = get_test_file_path_for("PasteCensus.cns");

--- a/wx_test_validate_output.cpp
+++ b/wx_test_validate_output.cpp
@@ -23,6 +23,7 @@
 
 #include "assert_lmi.hpp"
 #include "configurable_settings.hpp"
+#include "contains.hpp"
 #include "mvc_controller.hpp"
 #include "path_utility.hpp"
 #include "wx_test_case.hpp"
@@ -344,8 +345,21 @@ void validate_run_cell_and_copy_output
 
     wxUIActionSimulator ui;
 
-    ui.Char(WXK_HOME);           // Select the first cell.
-    ui.Char('r', wxMOD_CONTROL); // "Census|Run cell"
+    auto const use_grid =
+        contains(global_settings::instance().pyx(), "use_census_grid");
+
+    if(use_grid)
+        {
+        ui.Char(WXK_UP);                  // Clear the current selection if any.
+        ui.Char(WXK_HOME, wxMOD_CONTROL); // Go to the left top cell.
+        ui.Char(WXK_RIGHT, wxMOD_SHIFT);  // Select the first row.
+        }
+    else
+        {
+        ui.Char(WXK_HOME);               // Select the first cell.
+        }
+
+    ui.Char('r', wxMOD_CONTROL);         // "Census|Run cell"
     wxYield();
 
     LMI_ASSERT_WITH_MSG


### PR DESCRIPTION
The command line argument to use a grid as a view control: `--pyx=use_census_grid`.