### PR TITLE
Fix trailing whitespace detection in stream_cast()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1134,7 +1134,9 @@ test_stratified_algorithms_CXXFLAGS = $(AM_CXXFLAGS)
 
 test_stream_cast_SOURCES = \
   $(common_test_objects) \
+  calendar_date.cpp \
   facets.cpp \
+  null_stream.cpp \
   stream_cast_test.cpp \
   timer.cpp
 test_stream_cast_CXXFLAGS = $(AM_CXXFLAGS)

--- a/objects.make
+++ b/objects.make
@@ -1001,7 +1001,9 @@ stratified_algorithms_test$(EXEEXT): \
 
 stream_cast_test$(EXEEXT): \
   $(common_test_objects) \
+  calendar_date.o \
   facets.o \
+  null_stream.o \
   stream_cast_test.o \
   timer.o \
 

--- a/stream_cast.hpp
+++ b/stream_cast.hpp
@@ -122,13 +122,16 @@ To stream_cast(From from, To = To())
         {
         err << "Output failed ";
         }
-    else if(!(interpreter >> std::ws))
-        {
-        err << "Trailing whitespace remains ";
-        }
     else if(!interpreter.eof())
         {
-        err << "Unconverted data remains ";
+        if(interpreter >> std::ws)
+            {
+            err << "Trailing whitespace remains ";
+            }
+        else
+            {
+            err << "Unconverted data remains ";
+            }
         }
     else
         {

--- a/stream_cast_test.cpp
+++ b/stream_cast_test.cpp
@@ -23,6 +23,7 @@
 
 #include "stream_cast.hpp"
 
+#include "calendar_date.hpp"
 #include "test_tools.hpp"
 #include "timer.hpp"
 
@@ -137,6 +138,16 @@ int test_main(int, char*[])
         (stream_cast<std::string>((char const*)nullptr)
         ,std::runtime_error
         ,"Cannot convert (char const*)(0) to std::string."
+        );
+
+    calendar_date d;
+    d = stream_cast("2454687", d);
+    BOOST_TEST_EQUAL(2454687, d.julian_day_number());
+
+    BOOST_TEST_THROW
+        (stream_cast("2454687 ", d)
+        ,std::runtime_error
+        ,lmi_test::what_regex("^Trailing whitespace remains converting '2454687 '")
         );
 
     assay_speed();


### PR DESCRIPTION
Make it work both for libstdc++, which currently suffers from this bug:

	https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88034

and other, correct, standard library implementations by avoiding calls
to ws() when the input stream is already at EOF.

Extend the unit tests to check both for the correct handling of the
strings without trailing whitespace (which would previously fail with
clang or msvc standard library implementations) and for the correct
error message being given for the strings with trailing whitespace
(which would previously fail even when using gcc with libstdc++).