### PR TITLE
Always assume two's complement representation

### DIFF
--- a/bourn_cast.hpp
+++ b/bourn_cast.hpp
@@ -176,15 +176,13 @@ constexpr inline To bourn_cast(From from, std::true_type, std::false_type)
 
     From const limit = std::ldexp(From(1), to_traits::digits);
 
-    constexpr bool is_twos_complement(~To(0) == -To(1));
-
     if(std::isnan(from))
         throw std::runtime_error("Cannot cast NaN to integral.");
     if(std::isinf(from))
         throw std::runtime_error("Cannot cast infinite to integral.");
     if(!to_traits::is_signed && from < 0)
         throw std::runtime_error("Cannot cast negative to unsigned.");
-    if(from < -limit || from == -limit && !is_twos_complement)
+    if(from < -limit)
         throw std::runtime_error("Cast would transgress lower limit.");
     if(limit <= from)
         throw std::runtime_error("Cast would transgress upper limit.");

--- a/bourn_cast_test.cpp
+++ b/bourn_cast_test.cpp
@@ -81,10 +81,6 @@ void test_same(char const* file, int line)
     // an 80-bit long double type whose 64-bit mantissa suffices to
     // test the limits of every integral type up to 64 digits exactly
     // because it can distinguish +/-(2^64) from +/-(2^64 - 1).
-    //
-    // The signed minimum given here assumes two's complement; it
-    // would be -(x - 1) for a ones' complement or sign-and-magnitude
-    // representation.
     if(traits::is_integer)
         {
         long double const x = std::scalbln(1.0l, traits::digits);

--- a/bourn_cast_test.cpp
+++ b/bourn_cast_test.cpp
@@ -463,11 +463,18 @@ void test_m64_neighborhood()
     // unsigned integer is UB.
 
     unsigned long long int const ull_max = ull_traits::max();
+#if defined __clang__
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"
+#endif // defined __clang__
 #if defined __GNUC__
 #   pragma GCC diagnostic push
 #   pragma GCC diagnostic ignored "-Wfloat-conversion"
 #endif // defined __GNUC__
     float const f_ull_max = ull_max;
+#if defined __clang__
+#   pragma clang diagnostic pop
+#endif // defined __clang__
 #if defined __GNUC__
 #   pragma GCC diagnostic pop
 #endif // defined __GNUC__


### PR DESCRIPTION
This fixes a problem in clang build by avoiding errors such as
```
bourn_cast.hpp:179:39: error: bitwise negation of a boolean expression; did you mean logical negation? [-Werror,-Wbool-operation]
    constexpr bool is_twos_complement(~To(0) == -To(1));
                                      ^~~~~~
                                      !
bourn_cast.hpp:314:12: note: in instantiation of function template specialization 'bourn_cast<bool, double>' requested here
    return bourn_cast<To,From>
           ^
database.hpp:125:16: note: in instantiation of function template specialization 'bourn_cast<bool, double>' requested here
        return bourn_cast<T>(d);
               ^
gpt_server.cpp:270:20: note: in instantiation of function template specialization 'product_database::query<bool>' requested here
          database.query<bool>(DB_TgtPremFixedAtIssue)
                   ^
```
and simplifies the code a little bit.