### PR TITLE
Stop using std::bind{1st,2nd}() removed from C++17

### DIFF
--- a/ihs_irc7702.cpp
+++ b/ihs_irc7702.cpp
@@ -485,7 +485,7 @@ void Irc7702::InitCorridor()
         (denominator.begin()
         ,denominator.end()
         ,denominator.begin()
-        ,std::bind1st(std::plus<double>(), DEndt[Opt1Int4Pct])
+        ,[this](double x) { return DEndt[Opt1Int4Pct] + x; }
         );
     std::transform
         (CommFns[Opt1Int4Pct]->aD().begin()
@@ -625,7 +625,7 @@ void Irc7702::InitPvVectors(EIOBasis const& a_EIOBasis)
     npf_sgl_tgt = LoadTgt;
     LMI_ASSERT(Length == lmi::ssize(npf_sgl_tgt));
     std::transform(npf_sgl_tgt.begin(), npf_sgl_tgt.end(), npf_sgl_tgt.begin()
-        ,std::bind1st(std::minus<double>(), 1.0)
+        ,[](double x) { return 1.0 - x; }
         );
     LMI_ASSERT(Length == lmi::ssize(npf_sgl_tgt));
     LMI_ASSERT(Length == lmi::ssize(comm_fns.aD()));
@@ -652,7 +652,7 @@ void Irc7702::InitPvVectors(EIOBasis const& a_EIOBasis)
     npf_sgl_exc = LoadExc;
     LMI_ASSERT(Length == lmi::ssize(npf_sgl_exc));
     std::transform(npf_sgl_exc.begin(), npf_sgl_exc.end(), npf_sgl_exc.begin()
-        ,std::bind1st(std::minus<double>(), 1.0)
+        ,[](double x) { return 1.0 - x; }
         );
     LMI_ASSERT(Length == lmi::ssize(npf_sgl_tgt)); // TAXATION !! Shouldn't this be npf_sgl_exc?
     LMI_ASSERT(Length == lmi::ssize(comm_fns.aD()));

--- a/interest_rates.cpp
+++ b/interest_rates.cpp
@@ -461,7 +461,7 @@ void InterestRates::InitializeGeneralAccountRates()
             (spread[mce_gen_curr].begin()
             ,spread[mce_gen_curr].end()
             ,spread[mce_gen_curr].begin()
-            ,std::bind2nd(std::minus<double>(), spread[mce_gen_curr].front())
+            ,[&spread](double x) { return x - spread[mce_gen_curr].front(); }
             );
         // ET !! spread[mce_gen_mdpt] = 0.5 * spread[mce_gen_curr];
         // ...but writing it that way makes it look wrong.
@@ -469,7 +469,7 @@ void InterestRates::InitializeGeneralAccountRates()
             (spread[mce_gen_curr].begin()
             ,spread[mce_gen_curr].end()
             ,spread[mce_gen_mdpt].begin()
-            ,std::bind1st(std::multiplies<double>(), 0.5)
+            ,[](double x) { return 0.5*x; }
             );
         }
     else
@@ -571,7 +571,7 @@ void InterestRates::InitializeSeparateAccountRates()
                 (total_charges[j].begin()
                 ,total_charges[j].end()
                 ,total_charges[j].begin()
-                ,std::bind2nd(std::minus<double>(), total_charges[j].front())
+                ,[&total_charges, j](double x) { return x - total_charges[j].front(); }
                 );
             }
         fee = 0.0;
@@ -587,7 +587,7 @@ void InterestRates::InitializeSeparateAccountRates()
         (SepAcctGrossRate_[mce_sep_full].begin()
         ,SepAcctGrossRate_[mce_sep_full].end()
         ,std::back_inserter(SepAcctGrossRate_[mce_sep_half])
-        ,std::bind1st(std::multiplies<double>(), 0.5)
+        ,[](double x) { return 0.5*x; }
         );
 
     for(int j = mce_gen_curr; j < mc_n_gen_bases; ++j)
@@ -1021,7 +1021,12 @@ void InterestRates::Initialize7702Rates()
 
     MlyGlpRate_.resize(Length_);
     // ET !! MlyGlpRate_ = max(0.04, annual_guar_rate);
-    std::transform(annual_guar_rate.begin(), annual_guar_rate.end(), MlyGlpRate_.begin(), std::bind1st(greater_of<double>(), 0.04));
+    std::transform
+        (annual_guar_rate.begin()
+        ,annual_guar_rate.end()
+        ,MlyGlpRate_.begin()
+        ,[](double x) { return std::max(0.04, x); }
+        );
     // ET !! This ought to be implicit, at least in some 'safe' mode:
     LMI_ASSERT(MlyGlpRate_.size() == SpreadFor7702_.size());
     // ET !! MlyGlpRate_ = i_upper_12_over_12_from_i(MlyGlpRate_ - SpreadFor7702_);


### PR DESCRIPTION
These functions were deprecated in C++11 and formally removed in C++17
and are not available in clang 10 standard library (libc++) any longer.

Simply replace them with the lambda functions performing the same
functions.