### PR TITLE
Leave only wxGrid-based census view implementation

### DIFF
--- a/census_document.cpp
+++ b/census_document.cpp
@@ -35,11 +35,11 @@
 
 IMPLEMENT_DYNAMIC_CLASS(CensusDocument, wxDocument)
 
-wxDataViewCtrl& CensusDocument::PredominantViewWindow() const
+wxGrid& CensusDocument::PredominantViewWindow() const
 {
-    return ::PredominantViewWindow<CensusView,wxDataViewCtrl>
+    return ::PredominantViewWindow<CensusView,wxGrid>
         (*this
-        ,&CensusView::list_window_
+        ,&CensusView::grid_window_
         );
 }
 

--- a/census_document.hpp
+++ b/census_document.hpp
@@ -29,7 +29,7 @@
 
 #include <wx/docview.h>
 
-class WXDLLIMPEXP_FWD_ADV wxDataViewCtrl;
+class WXDLLIMPEXP_FWD_ADV wxGrid;
 
 class CensusDocument
     :public wxDocument
@@ -44,7 +44,7 @@ class CensusDocument
     CensusDocument(CensusDocument const&) = delete;
     CensusDocument& operator=(CensusDocument const&) = delete;
 
-    wxDataViewCtrl& PredominantViewWindow() const;
+    wxGrid& PredominantViewWindow() const;
 
     // wxDocument overrides.
     bool OnCreate(wxString const& filename, long int flags) override;

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -52,12 +52,14 @@
 
 #include <boost/filesystem/convenience.hpp> // basename()
 
-#include <wx/dataview.h>
 #include <wx/datectrl.h>
+#include <wx/grid.h>
+#include <wx/headercol.h>               // wxCOL_WIDTH_DEFAULT
 #include <wx/menu.h>
 #include <wx/msgdlg.h>
 #include <wx/settings.h>
 #include <wx/spinctrl.h>
+#include <wx/textctrl.h>
 #include <wx/utils.h>                   // wxBusyCursor
 #include <wx/valnum.h>
 #include <wx/wupdlock.h>                // wxWindowUpdateLocker
@@ -87,700 +89,455 @@ std::string insert_spaces_between_words(std::string const& s)
     return r;
 }
 
-/// Data needed to create UI for tn_range<> types.
+// Declare free functions corresponding to their namesakes in CensusViewGridTable
+// that can be used in the implementation of the custom editors below, which
+// are defined before CensusViewGridTable is declared.
+//
+// This seems preferable to intermixing the declarations and definitions, as it
+// allows to declare (and define) all the classes in consistent bottom-to-top
+// order -- but at a price of having these not really indispensable wrappers.
 
-struct tn_range_variant_data
-    :public wxVariantData
-{
-    tn_range_variant_data(std::string const& a_value, double a_min, double a_max)
-        :value {a_value}
-        ,min   {a_min}
-        ,max   {a_max}
-    {
-    }
+// Get the cell value from the table.
 
-    tn_range_variant_data(tn_range_base const& r)
-        :value {r.str()}
-        ,min   {r.universal_minimum()}
-        ,max   {r.universal_maximum()}
-    {
-    }
+any_member<Input> const& cell_at(wxGridTableBase const& table, int row, int col);
 
-    bool Eq(wxVariantData& data) const override
-    {
-        tn_range_variant_data* d = dynamic_cast<tn_range_variant_data*>(&data);
-        if(!d)
-            return false;
-        return value == d->value && min == d->min && max == d->max;
-    }
+// Get the raw value from the table.
 
-    wxString GetType() const override { return typeid(tn_range_variant_data).name(); }
+Input const& row_at(wxGridTableBase const& table, int row);
 
-    wxVariantData* Clone() const override
-    {
-        return new(wx) tn_range_variant_data(value, min, max);
-    }
+// Get the column name from the table.
 
-    std::string value;
-    double min, max;
-};
+std::string const& col_name(wxGridTableBase const& table, int col);
 
-// class RangeTypeRenderer
+// class RangeDoubleEditor
 
-class RangeTypeRenderer
-    :public wxDataViewCustomRenderer
-{
-  protected:
-    RangeTypeRenderer();
-
-  public:
-    bool HasEditorCtrl() const override { return true; }
-    wxWindow* CreateEditorCtrl
-        (wxWindow*        parent
-        ,wxRect           label_rect
-        ,wxVariant const& value
-        ) override;
-    bool GetValueFromEditorCtrl(wxWindow* editor, wxVariant& value) override;
-    bool Render(wxRect rect, wxDC* dc, int state) override;
-    wxSize GetSize() const override;
-    bool SetValue(wxVariant const& value) override;
-    bool GetValue(wxVariant& value) const override;
-
-  protected:
-    virtual wxWindow* DoCreateEditor
-        (wxWindow*                    parent
-        ,wxRect                const& rect
-        ,tn_range_variant_data const& data
-        ) = 0;
-    virtual std::string DoGetValueFromEditor(wxWindow* editor) = 0;
-
-    std::string value_;
-    double      min_;
-    double      max_;
-};
-
-RangeTypeRenderer::RangeTypeRenderer()
-    :wxDataViewCustomRenderer
-    (typeid(tn_range_variant_data).name()
-    ,wxDATAVIEW_CELL_EDITABLE
-    ,wxDVR_DEFAULT_ALIGNMENT
-    )
-{
-}
-
-wxWindow* RangeTypeRenderer::CreateEditorCtrl
-    (wxWindow*        parent
-    ,wxRect           label_rect
-    ,wxVariant const& value
-    )
-{
-    tn_range_variant_data const* data = dynamic_cast<tn_range_variant_data*>(value.GetData());
-    LMI_ASSERT(data);
-
-    // Always use default height for editor controls
-    wxRect rect(label_rect);
-    rect.height = -1;
-
-    return DoCreateEditor(parent, rect, *data);
-}
-
-bool RangeTypeRenderer::GetValueFromEditorCtrl(wxWindow* editor, wxVariant& value)
-{
-    std::string const val = DoGetValueFromEditor(editor);
-    value = new(wx) tn_range_variant_data(val, min_, max_);
-    return true;
-}
-
-bool RangeTypeRenderer::Render(wxRect rect, wxDC* dc, int state)
-{
-    RenderText(value_, 0, rect, dc, state);
-    return true;
-}
-
-wxSize RangeTypeRenderer::GetSize() const
-{
-    wxSize sz = GetTextExtent(value_);
-
-    // Allow some space for the spin button, which is approximately the size of
-    // a scrollbar (and getting pixel-exact value would be complicated). Also
-    // add some whitespace between the text and the button:
-    sz.x += wxSystemSettings::GetMetric(wxSYS_VSCROLL_X);
-    sz.x += GetTextExtent("M").x;
-
-    return sz;
-}
-
-bool RangeTypeRenderer::SetValue(wxVariant const& value)
-{
-    tn_range_variant_data const* data = dynamic_cast<tn_range_variant_data*>(value.GetData());
-    LMI_ASSERT(data);
-
-    value_ = data->value;
-    min_   = data->min;
-    max_   = data->max;
-    return true;
-}
-
-bool RangeTypeRenderer::GetValue(wxVariant& value) const
-{
-    value = new(wx) tn_range_variant_data(value_, min_, max_);
-    return true;
-}
-
-// class IntSpinRenderer
-
-class IntSpinRenderer
-    :public RangeTypeRenderer
+class RangeDoubleEditor
+    :public wxGridCellTextEditor
 {
   public:
-    IntSpinRenderer() : RangeTypeRenderer() {}
+    RangeDoubleEditor() = default;
 
-  protected:
-    wxWindow* DoCreateEditor
-        (wxWindow*                    parent
-        ,wxRect                const& rect
-        ,tn_range_variant_data const& data
-        ) override;
-    std::string DoGetValueFromEditor(wxWindow* editor) override;
+    void BeginEdit(int row, int col, wxGrid* grid) override
+    {
+        auto const& value = cell_at(*grid->GetTable(), row, col);
+        auto const* as_range = member_cast<tn_range_base>(value);
+        LMI_ASSERT(typeid(double) == as_range->value_type());
+
+        wxFloatingPointValidator<double> val;
+        val.SetRange(as_range->universal_minimum(), as_range->universal_maximum());
+        SetValidator(val);
+
+        wxGridCellTextEditor::BeginEdit(row, col, grid);
+    }
 };
 
-wxWindow* IntSpinRenderer::DoCreateEditor
-    (wxWindow*                    parent
-    ,wxRect                const& rect
-    ,tn_range_variant_data const& data
-    )
-{
-    return new(wx) wxSpinCtrl
-        (parent
-        ,wxID_ANY
-        ,data.value
-        ,rect.GetTopLeft()
-        ,rect.GetSize()
-        ,wxSP_ARROW_KEYS | wxTE_PROCESS_ENTER
-        ,bourn_cast<int>(data.min)
-        ,bourn_cast<int>(data.max)
-        ,value_cast<int>(data.value)
-        );
-}
+// class RangeDateEditor
 
-std::string IntSpinRenderer::DoGetValueFromEditor(wxWindow* editor)
-{
-    wxSpinCtrl* spin = dynamic_cast<wxSpinCtrl*>(editor);
-    LMI_ASSERT(spin);
-
-    return value_cast<std::string>(spin->GetValue());
-}
-
-// class DoubleRangeRenderer
-
-class DoubleRangeRenderer
-    :public RangeTypeRenderer
+class RangeDateEditor
+    :public wxGridCellDateEditor
 {
   public:
-    DoubleRangeRenderer() : RangeTypeRenderer() {}
+    RangeDateEditor() = default;
 
-  protected:
-    wxWindow* DoCreateEditor
-        (wxWindow*                    parent
-        ,wxRect                const& rect
-        ,tn_range_variant_data const& data
-        ) override;
-    std::string DoGetValueFromEditor(wxWindow* editor) override;
+    void BeginEdit(int row, int col, wxGrid* grid) override
+    {
+        auto const& value = cell_at(*grid->GetTable(), row, col);
+        auto const* as_range = member_cast<tn_range_base>(value);
+        LMI_ASSERT(typeid(calendar_date) == as_range->value_type());
+
+        DatePicker()->SetValue(ConvertDateToWx(value_cast<calendar_date>(value)));
+
+        auto const min_value = as_range->universal_minimum();
+        auto const max_value = as_range->universal_maximum();
+
+        DatePicker()->SetRange
+            (ConvertDateToWx(jdn_t(bourn_cast<int>(min_value)))
+            ,ConvertDateToWx(jdn_t(bourn_cast<int>(max_value)))
+            );
+
+        DatePicker()->SetFocus();
+    }
 };
 
-wxWindow* DoubleRangeRenderer::DoCreateEditor
-    (wxWindow*                    parent
-    ,wxRect                const& rect
-    ,tn_range_variant_data const& data
-    )
-{
-    wxFloatingPointValidator<double> val;
-    val.SetRange(data.min, data.max);
-
-    wxTextCtrl* ctrl = new(wx) wxTextCtrl
-        (parent
-        ,wxID_ANY
-        ,data.value
-        ,rect.GetTopLeft()
-        ,rect.GetSize()
-        ,wxTE_PROCESS_ENTER
-        ,val);
-
-    // select the text in the control an place the cursor at the end
-    // (same as wxDataViewTextRenderer)
-    ctrl->SetInsertionPointEnd();
-    ctrl->SelectAll();
-
-    return ctrl;
-}
-
-std::string DoubleRangeRenderer::DoGetValueFromEditor(wxWindow* editor)
-{
-    wxTextCtrl* ctrl = dynamic_cast<wxTextCtrl*>(editor);
-    LMI_ASSERT(ctrl);
-
-    return ctrl->GetValue().ToStdString();
-}
-
-// class DateRenderer
-
-class DateRenderer
-    :public RangeTypeRenderer
+class DatumSequenceEditor
+    :public wxGridCellEditor
 {
   public:
-    DateRenderer() : RangeTypeRenderer() {}
-    bool Render(wxRect rect, wxDC* dc, int state) override;
+    DatumSequenceEditor() = default;
 
-  protected:
-    wxWindow* DoCreateEditor
-        (wxWindow*                    parent
-        ,wxRect                const& rect
-        ,tn_range_variant_data const& data
+    void Create(wxWindow* parent, wxWindowID id, wxEvtHandler* evtHandler) override;
+
+    void BeginEdit(int row, int col, wxGrid* grid) override;
+    bool EndEdit
+        (int row
+        ,int col
+        ,wxGrid const* grid
+        ,wxString const& oldval
+        ,wxString* newval
         ) override;
-    std::string DoGetValueFromEditor(wxWindow* editor) override;
-};
+    void ApplyEdit(int row, int col, wxGrid* grid) override;
 
-wxWindow* DateRenderer::DoCreateEditor
-    (wxWindow*                    parent
-    ,wxRect                const& rect
-    ,tn_range_variant_data const& data
-    )
-{
-    // Always use default height for editor controls
-    wxRect r(rect);
-    r.height = -1;
+    void Reset() override;
 
-    wxDatePickerCtrl* ctrl = new(wx) wxDatePickerCtrl
-        (parent
-        ,wxID_ANY
-        ,ConvertDateToWx(value_cast<calendar_date>(data.value))
-        ,r.GetTopLeft()
-        ,r.GetSize());
+    wxGridCellEditor* Clone() const override;
 
-    ctrl->SetRange
-        (ConvertDateToWx(jdn_t(static_cast<int>(data.min)))
-        ,ConvertDateToWx(jdn_t(static_cast<int>(data.max)))
-        );
+    wxString GetValue() const override;
 
-    return ctrl;
-}
+  private:
+    InputSequenceEntry* Entry() const;
 
-bool DateRenderer::Render(wxRect rect, wxDC* dc, int state)
-{
-    // Use wx for date formatting so that it is identical to the way wxDatePickerCtrl does it.
-    wxDateTime const date = ConvertDateToWx(value_cast<calendar_date>(value_));
-    RenderText(date.FormatDate(), 0, rect, dc, state);
-    return true;
-}
-
-std::string DateRenderer::DoGetValueFromEditor(wxWindow* editor)
-{
-    wxDatePickerCtrl* ctrl = dynamic_cast<wxDatePickerCtrl*>(editor);
-    LMI_ASSERT(ctrl);
-
-    return value_cast<std::string>(ConvertDateFromWx(ctrl->GetValue()));
-}
-
-/// Data needed to create UI for input sequences.
-
-struct input_sequence_variant_data
-    :public wxVariantData
-{
-    input_sequence_variant_data
-        (std::string const& a_value
-        ,Input       const* a_input
-        ,std::string const& a_field
-        )
-        :value {a_value}
-        ,input {a_input}
-        ,field {a_field}
-    {
-    }
-
-    input_sequence_variant_data(input_sequence_variant_data const&) = delete;
-    input_sequence_variant_data& operator=(input_sequence_variant_data const&) = delete;
-
-    bool Eq(wxVariantData& data) const override
-    {
-        input_sequence_variant_data* d = dynamic_cast<input_sequence_variant_data*>(&data);
-        if(!d)
-            return false;
-        return value == d->value;
-    }
-
-    wxString GetType() const override { return typeid(input_sequence_variant_data).name(); }
-
-    wxVariantData* Clone() const override
-    {
-        return new(wx) input_sequence_variant_data(value, input, field);
-    }
-
-    std::string value;
-    Input const* input;
-    std::string field;
-};
-
-class DatumSequenceRenderer
-    :public wxDataViewCustomRenderer
-{
-  public:
-    DatumSequenceRenderer();
-    DatumSequenceRenderer(DatumSequenceRenderer const&) = delete;
-    DatumSequenceRenderer& operator=(DatumSequenceRenderer const&) = delete;
-    bool HasEditorCtrl() const override { return true; }
-    wxWindow* CreateEditorCtrl
-        (wxWindow*        parent
-        ,wxRect           label_rect
-        ,wxVariant const& value
-        ) override;
-    bool GetValueFromEditorCtrl(wxWindow* editor, wxVariant& value) override;
-    bool Render(wxRect rect, wxDC* dc, int state) override;
-    wxSize GetSize() const override;
-    bool SetValue(wxVariant const& value) override;
-    bool GetValue(wxVariant& value) const override;
-
-    std::string  value_;
-    Input const* input_;
+    wxString     value_;
+    Input const* input_ {nullptr};
     std::string  field_;
 };
 
-DatumSequenceRenderer::DatumSequenceRenderer()
-    :wxDataViewCustomRenderer
-        (typeid(input_sequence_variant_data).name()
-        ,wxDATAVIEW_CELL_EDITABLE
-        ,wxDVR_DEFAULT_ALIGNMENT
-        )
-    ,input_(nullptr)
-{
-}
-
-wxWindow* DatumSequenceRenderer::CreateEditorCtrl
-    (wxWindow*        parent
-    ,wxRect           label_rect
-    ,wxVariant const& value
+void DatumSequenceEditor::Create
+    (wxWindow*     parent
+    ,wxWindowID    id
+    ,wxEvtHandler* evtHandler
     )
 {
-    input_sequence_variant_data const* data = dynamic_cast<input_sequence_variant_data*>(value.GetData());
-    LMI_ASSERT(data);
-    LMI_ASSERT(data->input);
+    auto* const entry = new(wx) InputSequenceEntry(parent, id, "sequence_editor");
+    m_control = entry;
 
-    InputSequenceEntry* ctrl = new(wx) InputSequenceEntry(parent, wxID_ANY, "sequence_editor");
+    wxGridCellEditor::Create(parent, id, evtHandler);
 
-    ctrl->text_ctrl().SetValue(data->value.c_str());
-    ctrl->input(*data->input);
-    ctrl->field_name(data->field);
+    // When an event handler is specified, it will get all the keys first and
+    // so we need to bind our wxEVT_KEY_DOWN handler to it, as we want to
+    // override the default keyboard handling. And currently it is always
+    // specified, but fall back to the control itself just in case this changes
+    // in the future.
+    if(!evtHandler)
+        {
+        evtHandler = m_control;
+        }
 
-    ctrl->SetSize(label_rect);
-
-    return ctrl;
+    // Use a special handler to open the editor window when Alt-Enter is
+    // pressed instead of just closing the editor, as would be done by default.
+    evtHandler->Bind
+        (wxEVT_KEY_DOWN
+        ,[entry](wxKeyEvent& event)
+        {
+            auto const code = event.GetKeyCode();
+            if
+                (  (code == WXK_RETURN || code == WXK_NUMPAD_ENTER)
+                && wxGetKeyState(WXK_ALT)
+                )
+                {
+                entry->open_editor();
+                }
+            else
+                {
+                event.Skip();
+                }
+        });
 }
 
-bool DatumSequenceRenderer::GetValueFromEditorCtrl(wxWindow* editor, wxVariant& value)
+void DatumSequenceEditor::BeginEdit(int row, int col, wxGrid* grid)
 {
-    InputSequenceEntry* ctrl = dynamic_cast<InputSequenceEntry*>(editor);
-    LMI_ASSERT(ctrl);
+    auto table = grid->GetTable();
+    value_ = table->GetValue(row, col);
+    input_ = &row_at(*table, row);
+    field_ = col_name(*table, col);
 
-    value = new(wx) input_sequence_variant_data
-        (ctrl->text_ctrl().GetValue().ToStdString()
-        ,&ctrl->input()
-        ,ctrl->field_name());
+    auto entry = Entry();
+
+    entry->text_ctrl().SetValue(value_);
+    entry->input(*input_);
+    entry->field_name(field_);
+
+    entry->text_ctrl().SelectAll();
+    entry->text_ctrl().SetFocus();
+}
+
+bool DatumSequenceEditor::EndEdit
+    (int
+    ,int
+    ,wxGrid const*
+    ,wxString const&
+    ,wxString*       newval
+    )
+{
+    auto value = Entry()->text_ctrl().GetValue();
+
+    if(value == value_)
+        {
+        return false;
+        }
+
+    value_ = value;
+
+    *newval = GetValue();
+
     return true;
 }
 
-bool DatumSequenceRenderer::Render(wxRect rect, wxDC* dc, int state)
+void DatumSequenceEditor::ApplyEdit(int row, int col, wxGrid* grid)
 {
-    RenderText(value_, 0, rect, dc, state);
-    return true;
+    grid->GetTable()->SetValue(row, col, value_);
 }
 
-wxSize DatumSequenceRenderer::GetSize() const
+void DatumSequenceEditor::Reset()
 {
-    wxSize sz = GetTextExtent(value_);
-
-    // Add size of the "..." button. We assume it will use the same font that this renderer
-    // uses and add some extra whitespace in addition to InputSequenceButton's 8px padding.
-    sz.x += 16 + GetTextExtent("...").x;
-
-    return sz;
+    Entry()->text_ctrl().SetValue(value_);
 }
 
-bool DatumSequenceRenderer::SetValue(wxVariant const& value)
+wxGridCellEditor* DatumSequenceEditor::Clone() const
 {
-    input_sequence_variant_data const* data = dynamic_cast<input_sequence_variant_data*>(value.GetData());
-    LMI_ASSERT(data);
+    auto editor = new(wx) DatumSequenceEditor();
+    editor->value_ = value_;
+    editor->input_ = input_;
+    editor->field_ = field_;
 
-    value_ = data->value;
-    input_ = data->input;
-    field_ = data->field;
-    return true;
+    return editor;
 }
 
-bool DatumSequenceRenderer::GetValue(wxVariant& value) const
+wxString DatumSequenceEditor::GetValue() const
 {
-    value = new(wx) input_sequence_variant_data(value_, input_, field_);
-    return true;
+    return Entry()->text_ctrl().GetValue();
 }
 
-// This class is used to implement conversion to and from wxVariant for use by
-// wxDVC renderers in a single place.
+InputSequenceEntry* DatumSequenceEditor::Entry() const
+{
+    auto entry = dynamic_cast<InputSequenceEntry*>(m_control);
+    LMI_ASSERT(entry);
+    return entry;
+}
 
-class renderer_type_converter
+// This class is used to implement conversion to and from strings shown in the
+// grid cells by CensusViewGridTable in a single place.
+
+class table_type_converter
 {
   public:
-    virtual ~renderer_type_converter() = default;
-    virtual wxVariant to_variant
-        (any_member<Input> const& x
-        ,Input             const& row
-        ,std::string       const& col
-        ) const = 0;
-    virtual std::string from_variant(wxVariant const& x) const = 0;
-    virtual char const* variant_type() const = 0;
-    virtual wxDataViewRenderer* create_renderer(any_member<Input> const& exemplar) const = 0;
+    virtual ~table_type_converter() = default;
 
-    static renderer_type_converter const& get(any_member<Input> const& value);
+    virtual wxString to_renderer_value(std::string const& value) const
+    {
+        return wxString::FromUTF8(value);
+    }
+
+    virtual std::string from_editor_value(wxString const& value) const
+    {
+        return value.ToStdString(wxConvUTF8);
+    }
+
+    // Returns the grid value type, used by wxGridTypeRegistry.
+    virtual wxString grid_value_type(any_member<Input> const& value) const = 0;
+
+    static table_type_converter const& get(any_member<Input> const& value);
 
   private:
     template<typename T>
-    static renderer_type_converter const& get_impl();
+    static table_type_converter const& get_impl();
 };
 
-// class renderer_bool_converter
+// The base class for table type converters using custom renderer and editor.
+// It uses CRTP pattern, i.e. the derived class should pass itself as the
+// template parameter to this one.
 
-class renderer_bool_converter : public renderer_type_converter
+template<typename T>
+class table_custom_type_converter : public table_type_converter
 {
-    wxVariant to_variant
-        (any_member<Input> const& x
-        ,Input             const&
-        ,std::string       const&
-        ) const override
+  public:
+    wxString grid_value_type(any_member<Input> const&) const override
     {
-        std::string const s(x.str());
-        return
-              "Yes" == s ? true
-            : "No"  == s ? false
-            : throw "Invalid boolean value."
-            ;
+        return grid_type();
     }
 
-    std::string from_variant(wxVariant const& x) const override
+    void register_data_type(wxGrid* grid) const
     {
-        return x.GetBool() ? "Yes" : "No";
+        grid->RegisterDataType
+            (grid_type()
+            ,create_renderer()
+            ,create_editor()
+            );
     }
 
-    char const* variant_type() const override
+  private:
+    // Currently the grid data type used for custom converters doesn't depend
+    // on the concrete value, which allows us to define this function and use
+    // it in both grid_value_type() and register_data_type().
+    wxString grid_type() const
     {
-        return "bool";
+        return typeid(T).name();
     }
 
-    wxDataViewRenderer* create_renderer(any_member<Input> const&) const override
+    virtual wxGridCellRenderer* create_renderer() const = 0;
+    virtual wxGridCellEditor* create_editor() const = 0;
+
+};
+
+// class table_bool_converter
+
+class table_bool_converter : public table_type_converter
+{
+  public:
+    table_bool_converter()
     {
-        return new(wx) wxDataViewToggleRenderer
-            ("bool"
-            ,wxDATAVIEW_CELL_ACTIVATABLE
-            ,wxALIGN_CENTER
+        wxGridCellBoolEditor::UseStringValues("Yes", "No");
+    }
+
+    wxString grid_value_type(any_member<Input> const&) const override
+    {
+        return wxGRID_VALUE_BOOL;
+    }
+};
+
+// class table_enum_converter
+
+class table_enum_converter : public table_type_converter
+{
+  public:
+    wxString grid_value_type(any_member<Input> const& value) const override
+    {
+        wxString type = wxGRID_VALUE_CHOICE;
+        auto const* as_enum = member_cast<mc_enum_base>(value);
+        auto const& all_strings = as_enum->all_strings();
+
+        bool first = true;
+        for(auto const& s : all_strings)
+            {
+            type.append(first ? ':' : ',');
+            type.append(s);
+            first = false;
+            }
+
+        return type;
+    }
+};
+
+// class table_sequence_converter
+
+class table_sequence_converter
+    :public table_custom_type_converter<table_sequence_converter>
+{
+  private:
+    wxGridCellRenderer* create_renderer() const override
+    {
+        return new(wx) wxGridCellStringRenderer();
+    }
+
+    wxGridCellEditor* create_editor() const override
+    {
+        return new(wx) DatumSequenceEditor();
+    }
+};
+
+// class table_int_range_converter
+
+class table_int_range_converter : public table_type_converter
+{
+  public:
+    wxString grid_value_type(any_member<Input> const& value) const override
+    {
+        auto const* as_range = member_cast<tn_range_base>(value);
+
+        return wxString::Format
+            ("%s:%d,%d"
+            ,wxGRID_VALUE_NUMBER
+            ,bourn_cast<int>(as_range->universal_minimum())
+            ,bourn_cast<int>(as_range->universal_maximum())
             );
     }
 };
 
-// class renderer_enum_converter
+// class table_double_range_converter
 
-class renderer_enum_converter : public renderer_type_converter
+class table_double_range_converter
+    :public table_custom_type_converter<table_double_range_converter>
 {
-    wxVariant to_variant
-        (any_member<Input> const& x
-        ,Input             const&
-        ,std::string       const&
-        ) const override
+  private:
+    wxGridCellRenderer* create_renderer() const override
     {
-        return wxString(x.str());
+        // Use wxGridCellStringRenderer instead of wxGridCellFloatRenderer to
+        // keep the number format as is.
+        return new(wx) wxGridCellStringRenderer();
     }
 
-    std::string from_variant(wxVariant const& x) const override
+    wxGridCellEditor* create_editor() const override
     {
-        return x.GetString().ToStdString();
-    }
-
-    char const* variant_type() const override
-    {
-        return "string";
-    }
-
-    wxDataViewRenderer* create_renderer(any_member<Input> const& exemplar) const override
-    {
-        mc_enum_base const* as_enum = member_cast<mc_enum_base>(exemplar);
-
-        std::vector<std::string> const& all_strings = as_enum->all_strings();
-        wxArrayString choices;
-        choices.assign(all_strings.begin(), all_strings.end());
-        return new(wx) wxDataViewChoiceRenderer(choices, wxDATAVIEW_CELL_EDITABLE);
+        return new(wx) RangeDoubleEditor();
     }
 };
 
-// class renderer_sequence_converter
+// class table_date_converter
 
-class renderer_sequence_converter : public renderer_type_converter
+class table_date_converter
+    :public table_custom_type_converter<table_date_converter>
 {
   public:
-    wxVariant to_variant
-        (any_member<Input> const& x
-        ,Input             const& row
-        ,std::string       const& col
-        ) const override
+    wxString to_renderer_value(std::string const& value) const override
     {
-        return new(wx) input_sequence_variant_data(x.str(), &row, col);
+        auto const date = ConvertDateToWx(value_cast<calendar_date>(value));
+        return date.FormatDate();
     }
 
-    std::string from_variant(wxVariant const& x) const override
+    std::string from_editor_value(wxString const& value) const override
     {
-        input_sequence_variant_data const* data = dynamic_cast<input_sequence_variant_data*>(x.GetData());
-        LMI_ASSERT(data);
-        return data->value;
-    }
+        wxDateTime date;
+        auto date_parse_ok = date.ParseISODate(value);
+        LMI_ASSERT(date_parse_ok);
 
-    char const* variant_type() const override
-    {
-        return typeid(input_sequence_variant_data).name();
-    }
-
-    wxDataViewRenderer* create_renderer(any_member<Input> const&) const override
-    {
-        return new(wx) DatumSequenceRenderer();
-    }
-};
-
-// class renderer_range_converter
-
-class renderer_range_converter : public renderer_type_converter
-{
-  public:
-    wxVariant to_variant
-        (any_member<Input> const& x
-        ,Input             const&
-        ,std::string       const&
-        ) const override
-    {
-        tn_range_base const* as_range = member_cast<tn_range_base>(x);
-        LMI_ASSERT(as_range);
-        return new(wx) tn_range_variant_data(*as_range);
-    }
-
-    std::string from_variant(wxVariant const& x) const override
-    {
-        tn_range_variant_data const* data = dynamic_cast<tn_range_variant_data*>(x.GetData());
-        LMI_ASSERT(data);
-        return data->value;
-    }
-
-    char const* variant_type() const override
-    {
-        return typeid(tn_range_variant_data).name();
-    }
-};
-
-class renderer_int_range_converter : public renderer_range_converter
-{
-  public:
-    wxDataViewRenderer* create_renderer(any_member<Input> const&) const override
-    {
-        return new(wx) IntSpinRenderer();
-    }
-};
-
-class renderer_double_range_converter : public renderer_range_converter
-{
-  public:
-    wxDataViewRenderer* create_renderer(any_member<Input> const&) const override
-    {
-        return new(wx) DoubleRangeRenderer();
-    }
-};
-
-class renderer_date_converter : public renderer_range_converter
-{
-  public:
-    wxDataViewRenderer* create_renderer(any_member<Input> const&) const override
-    {
-        return new(wx) DateRenderer();
-    }
-};
-
-// class renderer_fallback_converter
-
-class renderer_fallback_converter : public renderer_type_converter
-{
-  public:
-    wxVariant to_variant
-        (any_member<Input> const& x
-        ,Input             const&
-        ,std::string       const&
-        ) const override
-    {
-        // Strings containing new line characters are currently not displayed
-        // correctly by wxDataViewCtrl, so display the value on a single line
-        // after converting any optional new lines to the Unicode character
-        // representing them.
-        wxString s(x.str());
-        s.Replace("\n", RETURN_SYMBOL, true);
-        return s;
-    }
-
-    std::string from_variant(wxVariant const& x) const override
-    {
-        // Undo the replacement done above. Notice that this will (wrongly)
-        // translate any RETURN_SYMBOL characters entered by the user into the
-        // string to new lines, but this character is not supposed to be used
-        // in any of the cells values, so just ignore this problem for now.
-        wxString s = x.GetString();
-        s.Replace(RETURN_SYMBOL, "\n", true);
-        return s.ToStdString();
-    }
-
-    char const* variant_type() const override
-    {
-        return "string";
-    }
-
-    wxDataViewRenderer* create_renderer(any_member<Input> const&) const override
-    {
-        return new(wx) wxDataViewTextRenderer("string", wxDATAVIEW_CELL_EDITABLE);
+        return value_cast<std::string>(ConvertDateFromWx(date));
     }
 
   private:
-    static const wchar_t RETURN_SYMBOL = 0x23ce;
+    wxGridCellRenderer* create_renderer() const override
+    {
+        return new(wx) wxGridCellDateRenderer();
+    }
+
+    wxGridCellEditor* create_editor() const override
+    {
+        return new(wx) RangeDateEditor();
+    }
 };
 
-renderer_type_converter const& renderer_type_converter::get(any_member<Input> const& value)
+// class table_string_converter
+
+class table_string_converter : public table_type_converter
+{
+  public:
+    wxString grid_value_type(any_member<Input> const&) const override
+    {
+        return wxGRID_VALUE_STRING;
+    }
+};
+
+table_type_converter const&
+table_type_converter::get(any_member<Input> const& value)
 {
     if(exact_cast<mce_yes_or_no>(value))
         {
-        return get_impl<renderer_bool_converter>();
+        return get_impl<table_bool_converter>();
         }
     else if(exact_cast<datum_string>(value))
         {
-        return get_impl<renderer_fallback_converter>();
+        return get_impl<table_string_converter>();
         }
     else if(is_reconstitutable_as<datum_sequence>(value))
         {
-        return get_impl<renderer_sequence_converter>();
+        return get_impl<table_sequence_converter>();
         }
     else if(is_reconstitutable_as<mc_enum_base  >(value))
         {
-        return get_impl<renderer_enum_converter>();
+        return get_impl<table_enum_converter>();
         }
     else if(is_reconstitutable_as<tn_range_base >(value))
         {
         tn_range_base const* as_range = member_cast<tn_range_base>(value);
         if(typeid(int) == as_range->value_type())
             {
-            return get_impl<renderer_int_range_converter>();
+            return get_impl<table_int_range_converter>();
             }
         else if(typeid(double) == as_range->value_type())
             {
-            return get_impl<renderer_double_range_converter>();
+            return get_impl<table_double_range_converter>();
             }
         else if(typeid(calendar_date) == as_range->value_type())
             {
-            return get_impl<renderer_date_converter>();
+            return get_impl<table_date_converter>();
             }
         else
             {
@@ -798,138 +555,383 @@ renderer_type_converter const& renderer_type_converter::get(any_member<Input> co
         // Fall through to treat datum as string.
         }
 
-    return get_impl<renderer_fallback_converter>();
+    return get_impl<table_string_converter>();
 }
 
 template<typename T>
-renderer_type_converter const& renderer_type_converter::get_impl()
+table_type_converter const& table_type_converter::get_impl()
 {
-    static T singleton;
+    static T const singleton;
     return singleton;
 }
 
 } // Unnamed namespace.
 
-/// Interface to the data for wxDataViewCtrl.
+/// The attribute provider to make all odd rows appear grey.
 
-class CensusViewDataViewModel : public wxDataViewIndexListModel
+class CensusViewGridCellAttrProvider
+    :public wxGridCellAttrProvider
 {
   public:
-    // Cell serial number: always shown in first column.
-    static int const Col_CellNum = 0;
-
-    CensusViewDataViewModel(CensusView& view)
-        :view_ {view}
+    explicit CensusViewGridCellAttrProvider(wxGrid const* grid)
+        :attrForOddRows_{new wxGridCellAttr()}
     {
+        // Determine the alternate rows colour automatically from the
+        // background colour.
+        wxColour const bgColor = grid->GetDefaultCellBackgroundColour();
+
+        // Depending on the background, alternate row color
+        // will be 3% more dark or 50% brighter.
+        int const alpha = bgColor.GetRGB() > 0x808080 ? 97 : 150;
+
+        attrForOddRows_->SetBackgroundColour(bgColor.ChangeLightness(alpha));
     }
 
-    void GetValueByRow(wxVariant& variant, unsigned int row, unsigned int col) const override;
-    bool SetValueByRow(wxVariant const&, unsigned int, unsigned int) override;
+    wxGridCellAttr* GetAttr
+        (int row
+        ,int col
+        ,wxGridCellAttr::wxAttrKind kind
+        ) const override
+    {
+        wxGridCellAttrPtr attr{wxGridCellAttrProvider::GetAttr(row, col, kind)};
 
-    unsigned int GetColumnCount() const override;
+        if(row % 2)
+            {
+            if(!attr)
+                {
+                attr = attrForOddRows_;
+                }
+            else
+                {
+                if(!attr->HasBackgroundColour())
+                    {
+                    // Note that we can't modify attr itself, as it can be used
+                    // for other cells and changing its background would change
+                    // their appearance, so allocate a new attribute for this
+                    // cell only.
+                    attr = attr->Clone();
+                    attr->SetBackgroundColour
+                        (attrForOddRows_->GetBackgroundColour()
+                        );
+                    }
+                }
+            }
 
-    wxString GetColumnType(unsigned int col) const override;
+        return attr.release();
+    }
+
+  private:
+    wxGridCellAttrPtr attrForOddRows_;
+};
+
+/// Interface to the data for wxGrid.
+
+class CensusViewGridTable
+    :public wxGridTableBase
+{
+  public:
+    // Cell serial number: always shown in the first column.
+    static int const Col_CellNum = 0;
+
+    explicit CensusViewGridTable(CensusView& view);
+
+    // return the number of rows and columns in this table.
+    int GetNumberRows() override;
+    int GetNumberCols() override;
+
+    wxString GetValue(int row, int col) override;
+    void SetValue(int row, int col, wxString const& value) override;
+
+    // Data type determination.
+    wxString GetTypeName(int row, int col) override;
+
+    // Override only used rows/cols handling functions.
+    bool AppendRows(size_t numRows) override;
+    bool DeleteRows(size_t pos, size_t numRows) override;
+    bool AppendCols(size_t numCols) override;
+    bool DeleteCols(size_t pos, size_t numCols) override;
+
+    wxString GetColLabelValue(int col) override;
+
+    bool CanMeasureColUsingSameAttr(int col) const override;
 
     std::string const& col_name(int col) const;
+
+    Input& row_at(int row);
+    Input const& row_at(int row) const;
+
     any_member<Input>& cell_at(int row, int col);
     any_member<Input> const& cell_at(int row, int col) const;
 
+    std::vector<int> const& get_visible_columns() const
+    {
+        return visible_columns_;
+    }
+
+    void set_visible_columns(std::vector<int>&& new_visible_columns)
+    {
+        visible_columns_ = std::move(new_visible_columns);
+    }
+
   private:
+    any_member<Input>& cell_at(int row, std::string const& col);
+    any_member<Input> const& cell_at(int row, std::string const& col) const;
     std::vector<std::string> const& all_headers() const;
 
-    CensusView& view_;
+    CensusView&      view_;
+
+    std::vector<int> visible_columns_;
 };
 
-void CensusViewDataViewModel::GetValueByRow
-    (wxVariant&   variant
-    ,unsigned int row
-    ,unsigned int col
-    ) const
+CensusViewGridTable::CensusViewGridTable(CensusView& view)
+    :view_ {view}
+{
+    wxGrid const* grid = view.grid_window_;
+    SetAttrProvider(new(wx) CensusViewGridCellAttrProvider(grid));
+
+    // The first, special, column shows the cell row number and can't be edited.
+    auto attr = new(wx) wxGridCellAttr();
+    attr->SetReadOnly();
+    SetColAttr(attr, 0);
+}
+
+int CensusViewGridTable::GetNumberRows()
+{
+    return lmi::ssize(view_.cell_parms());
+}
+
+int CensusViewGridTable::GetNumberCols()
+{
+    // "+ 1" for cell serial number in first column.
+    return lmi::ssize(visible_columns_) + 1;
+}
+
+wxString CensusViewGridTable::GetValue(int row, int col)
 {
     if(col == Col_CellNum)
         {
-        // WX !! wxVariant::operator=() is overloaded for numerous
-        // types, including 'long int' but excluding 'int'.
-        variant = static_cast<long int>(bourn_cast<int>(1 + row));
+        return value_cast<std::string>(1 + row);
         }
-    else
-        {
-        any_member<Input> const& cell = cell_at(row, col);
-        renderer_type_converter const& conv = renderer_type_converter::get(cell);
-        Input const& row_data = view_.cell_parms()[row];
 
-        variant = conv.to_variant(cell, row_data, col_name(col));
-        }
+    auto const& cell = cell_at(row, col);
+    auto const& conv = table_type_converter::get(cell);
+    return conv.to_renderer_value(cell.str());
 }
 
-bool CensusViewDataViewModel::SetValueByRow
-    (wxVariant const& variant
-    ,unsigned int     row
-    ,unsigned int     col
-    )
+void CensusViewGridTable::SetValue(int row, int col, wxString const& value)
 {
     LMI_ASSERT(col != Col_CellNum);
 
-    any_member<Input>& cell = cell_at(row, col);
-    renderer_type_converter const& conv = renderer_type_converter::get(cell);
-
-    std::string const prev_val = cell.str();
-    std::string new_val = conv.from_variant(variant);
+    auto& cell = cell_at(row, col);
+    auto const& conv = table_type_converter::get(cell);
+    auto const& prev_val = cell.str();
+    auto const& new_val = conv.from_editor_value(value);
 
     if(prev_val == new_val)
-        return false;
+        {
+        return;
+        }
 
     cell = new_val;
 
-    Input& model = view_.cell_parms()[row];
+    Input& model = view_.cell_parms().at(row);
     model.Reconcile();
 
     view_.document().Modify(true);
+}
+
+wxString CensusViewGridTable::GetTypeName(int row, int col)
+{
+    if(col == Col_CellNum)
+        {
+        return wxGRID_VALUE_NUMBER;
+        }
+
+    auto const& value = cell_at(row, col);
+    auto const& conv = table_type_converter::get(value);
+
+    return conv.grid_value_type(value);
+}
+
+wxString CensusViewGridTable::GetColLabelValue(int col)
+{
+    if(col == Col_CellNum)
+        {
+        return "Cell";
+        }
+
+    auto const& header = all_headers()[visible_columns_[col - 1]];
+    return insert_spaces_between_words(header);
+}
+
+bool CensusViewGridTable::CanMeasureColUsingSameAttr(int) const
+{
+    // All our columns use the same type and practically the same attribute:
+    // only its background colour varies, but the colour doesn't matter for
+    // measuring, so we can always return true from here and allow wxGrid to
+    // reuse the same attribute for the entire column.
+    return true;
+}
+
+bool CensusViewGridTable::AppendRows(size_t numRows)
+{
+    auto grid = GetView();
+    LMI_ASSERT(grid != nullptr);
+
+    wxGridTableMessage msg
+        (this
+        ,wxGRIDTABLE_NOTIFY_ROWS_APPENDED
+        ,bourn_cast<int>(numRows)
+        );
+    grid->ProcessTableMessage(msg);
 
     return true;
 }
 
-// Avoid using unsigned types in an interface.
-unsigned int CensusViewDataViewModel::GetColumnCount() const
+bool CensusViewGridTable::DeleteRows(size_t pos, size_t num_rows)
 {
-    // "+ 1" for cell serial number in first column.
-    return bourn_cast<unsigned int>(lmi::ssize(all_headers()) + 1);
+    auto grid = GetView();
+    LMI_ASSERT(grid != nullptr);
+
+    auto const ipos = bourn_cast<int>(pos);
+    auto inum_rows = bourn_cast<int>(num_rows);
+    auto const cur_num_rows = GetView()->GetNumberRows();
+    LMI_ASSERT_WITH_MSG
+        (ipos < cur_num_rows
+        ,wxString::Format
+            ("Called CensusViewGridTable::DeleteRows(pos=%d, N=%d)\n"
+             "Pos value is invalid for present table with %d rows"
+            ,ipos
+            ,inum_rows
+            ,cur_num_rows
+            )
+        );
+
+    if(inum_rows > cur_num_rows - ipos)
+        {
+        inum_rows = cur_num_rows - ipos;
+        }
+
+    wxGridTableMessage msg
+        (this
+        ,wxGRIDTABLE_NOTIFY_ROWS_DELETED
+        ,ipos
+        ,inum_rows
+        );
+    grid->ProcessTableMessage(msg);
+
+    return true;
 }
 
-wxString CensusViewDataViewModel::GetColumnType(unsigned int col) const
+bool CensusViewGridTable::AppendCols(size_t numCols)
 {
-    if(col == Col_CellNum)
-        {
-        return "long";
-        }
-    else
-        {
-        any_member<Input> const& exemplar = cell_at(0, col);
-        renderer_type_converter const& conv = renderer_type_converter::get(exemplar);
-        return conv.variant_type();
-        }
+    auto grid = GetView();
+    LMI_ASSERT(grid != nullptr);
+
+    wxGridTableMessage msg
+        (this
+        ,wxGRIDTABLE_NOTIFY_COLS_APPENDED
+        ,bourn_cast<int>(numCols)
+        );
+    grid->ProcessTableMessage(msg);
+
+    return true;
 }
 
-std::string const& CensusViewDataViewModel::col_name(int col) const
+bool CensusViewGridTable::DeleteCols(size_t pos, size_t num_cols)
+{
+    auto grid = GetView();
+    LMI_ASSERT(grid != nullptr);
+
+    auto const ipos = bourn_cast<int>(pos);
+    auto inum_cols = bourn_cast<int>(num_cols);
+    auto const cur_num_cols = GetView()->GetNumberCols();
+
+    LMI_ASSERT_WITH_MSG
+        (ipos < cur_num_cols
+        ,wxString::Format
+            ("Called CensusViewGridTable::DeleteCols(pos=%d, N=%d)\n"
+             "Pos value is invalid for present table with %d cols"
+            ,ipos
+            ,inum_cols
+            ,cur_num_cols
+            )
+        );
+
+    if(inum_cols > cur_num_cols - ipos)
+        {
+        inum_cols = cur_num_cols - ipos;
+        }
+
+    wxGridTableMessage msg
+        (this
+        ,wxGRIDTABLE_NOTIFY_COLS_DELETED
+        ,ipos
+        ,inum_cols
+        );
+    grid->ProcessTableMessage(msg);
+
+    return true;
+}
+
+inline std::string const& CensusViewGridTable::col_name(int col) const
 {
     LMI_ASSERT(0 < col);
     // "- 1" because first column is cell serial number.
-    return all_headers()[col - 1];
+    return all_headers().at(visible_columns_.at(col - 1));
 }
 
-inline any_member<Input>& CensusViewDataViewModel::cell_at(int row, int col)
+inline Input& CensusViewGridTable::row_at(int row)
 {
-    return view_.cell_parms()[row][col_name(col)];
+    return view_.cell_parms().at(row);
 }
 
-inline any_member<Input> const& CensusViewDataViewModel::cell_at(int row, int col) const
+inline Input const& CensusViewGridTable::row_at(int row) const
 {
-    return view_.cell_parms()[row][col_name(col)];
+    return view_.cell_parms().at(row);
 }
 
-inline std::vector<std::string> const& CensusViewDataViewModel::all_headers() const
+inline any_member<Input>& CensusViewGridTable::cell_at(int row, int col)
 {
-    return view_.case_parms()[0].member_names();
+    return cell_at(row, col_name(col));
+}
+
+inline any_member<Input> const& CensusViewGridTable::cell_at(int row, int col) const
+{
+    return cell_at(row, col_name(col));
+}
+
+inline any_member<Input>& CensusViewGridTable::cell_at(int row, std::string const& col)
+{
+    return row_at(row)[col];
+}
+
+inline any_member<Input> const& CensusViewGridTable::cell_at(int row, std::string const& col) const
+{
+    return row_at(row)[col];
+}
+
+inline std::vector<std::string> const& CensusViewGridTable::all_headers() const
+{
+    return view_.case_parms().at(0).member_names();
+}
+
+namespace
+{
+any_member<Input> const& cell_at(wxGridTableBase const& table, int row, int col)
+{
+    return dynamic_cast<CensusViewGridTable const&>(table).cell_at(row, col);
+}
+
+Input const& row_at(wxGridTableBase const& table, int row)
+{
+    return dynamic_cast<CensusViewGridTable const&>(table).row_at(row);
+}
+
+std::string const& col_name(wxGridTableBase const& table, int col)
+{
+    return dynamic_cast<CensusViewGridTable const&>(table).col_name(col);
+}
 }
 
 // class CensusView
@@ -937,8 +939,9 @@ inline std::vector<std::string> const& CensusViewDataViewModel::all_headers() co
 IMPLEMENT_DYNAMIC_CLASS(CensusView, ViewEx)
 
 BEGIN_EVENT_TABLE(CensusView, ViewEx)
-    EVT_DATAVIEW_ITEM_CONTEXT_MENU (wxID_ANY    ,CensusView::UponRightClick             )
-    EVT_DATAVIEW_ITEM_VALUE_CHANGED(wxID_ANY    ,CensusView::UponValueChanged           )
+    EVT_GRID_CELL_RIGHT_CLICK(                   CensusView::UponRightClick             )
+    EVT_GRID_CELL_CHANGED(                       CensusView::UponValueChanged           )
+    EVT_GRID_COL_AUTO_SIZE(                      CensusView::UponColumnAutoSize         )
     EVT_MENU(XRCID("edit_cell"                 ),CensusView::UponEditCell               )
     EVT_MENU(XRCID("edit_class"                ),CensusView::UponEditClass              )
     EVT_MENU(XRCID("edit_case"                 ),CensusView::UponEditCase               )
@@ -971,7 +974,7 @@ BEGIN_EVENT_TABLE(CensusView, ViewEx)
     EVT_UPDATE_UI(XRCID("copy_census"          ),CensusView::UponUpdateColumnValuesVary )
     EVT_UPDATE_UI(XRCID("paste_census"         ),CensusView::UponUpdateAlwaysEnabled    )
     EVT_UPDATE_UI(XRCID("add_cell"             ),CensusView::UponUpdateAlwaysEnabled    )
-    EVT_UPDATE_UI(XRCID("delete_cells"         ),CensusView::UponUpdateNonemptySelection)
+    EVT_UPDATE_UI(XRCID("delete_cells"         ),CensusView::UponUpdateAlwaysEnabled    )
     EVT_UPDATE_UI(XRCID("column_width_varying" ),CensusView::UponUpdateAlwaysEnabled    )
     EVT_UPDATE_UI(XRCID("column_width_fixed"   ),CensusView::UponUpdateAlwaysEnabled    )
     // Disable these printing commands on the "File" menu: specialized
@@ -985,8 +988,6 @@ END_EVENT_TABLE()
 CensusView::CensusView()
     :ViewEx            {}
     ,autosize_columns_ {false}
-    ,list_window_      {nullptr}
-    ,list_model_       {new(wx) CensusViewDataViewModel(*this)}
 {
 }
 
@@ -1082,24 +1083,41 @@ bool CensusView::column_value_varies_across_cells(std::string const& header) con
 
 wxWindow* CensusView::CreateChildWindow()
 {
-    list_window_ = new(wx) wxDataViewCtrl
-        (GetFrame()
-        ,wxID_ANY
-        ,wxDefaultPosition
-        ,wxDefaultSize
-        ,wxDV_ROW_LINES | wxDV_MULTIPLE
-        );
+    // Create and customize the grid window: we want to hide its row labels
+    // because we show our own row number column, tweak its alignment slightly
+    // and, importantly, use ellipsis in the overlong cell values rather than
+    // silently truncating them. We also prefer to use the native column header
+    // for a better appearance under MSW and disable the operations which are
+    // either not supported or are not useful.
+    grid_window_ = new(wx) wxGrid(GetFrame(), wxID_ANY);
+    grid_window_->HideRowLabels();
+    grid_window_->SetColLabelAlignment(wxALIGN_LEFT, wxALIGN_CENTRE);
+    grid_window_->SetDefaultCellAlignment(wxALIGN_LEFT, wxALIGN_CENTRE);
+    grid_window_->SetDefaultCellFitMode(wxGridFitMode::Ellipsize(wxELLIPSIZE_MIDDLE));
+    grid_window_->UseNativeColHeader();
+    grid_window_->DisableHidingColumns();
+    grid_window_->DisableDragRowSize();
 
-    list_window_->AssociateModel(list_model_.get());
+    // Create the table, providing the grid window with its data, now: notice
+    // that it must be done after creating the grid, as the table attribute
+    // provider uses the default grid cell background color to determine the
+    // alternating rows color.
+    grid_table_ = new(wx) CensusViewGridTable(*this);
+    grid_window_->AssignTable(grid_table_, wxGrid::wxGridSelectRows);
+
+    // We could implement some kind of automatic registration, but it doesn't
+    // seem to be worth it for now, as we only have a few custom converters,
+    // all of which defined in this single file, so it's simpler to just list
+    // them explicitly here.
+    table_sequence_converter{}.register_data_type(grid_window_);
+    table_double_range_converter{}.register_data_type(grid_window_);
+    table_date_converter{}.register_data_type(grid_window_);
 
     // Show headers.
     document().Modify(false);
-    list_model_->Reset(lmi::ssize(cell_parms()));
     Update();
 
-    list_window_->Select(list_model_->GetItem(0));
-
-    return list_window_;
+    return grid_window_;
 }
 
 CensusDocument& CensusView::document() const
@@ -1120,10 +1138,10 @@ oenum_mvc_dv_rc CensusView::edit_parameters
         );
 }
 
-int CensusView::selected_row()
+int CensusView::current_row()
 {
-    int row = list_model_->GetRow(list_window_->GetSelection());
-    LMI_ASSERT(0 <= row && row < bourn_cast<int>(list_model_->GetCount()));
+    auto const& row = grid_window_->GetGridCursorRow();
+    LMI_ASSERT(0 <= row && row < grid_table_->GetRowsCount());
     return row;
 }
 
@@ -1270,22 +1288,6 @@ void CensusView::apply_changes
 
 void CensusView::update_visible_columns()
 {
-    int width = autosize_columns_ ? wxCOL_WIDTH_AUTOSIZE : wxCOL_WIDTH_DEFAULT;
-
-    list_window_->ClearColumns();
-
-    // Column zero (cell serial number) is always shown.
-    list_window_->AppendColumn
-        (new(wx) wxDataViewColumn
-            ("Cell"
-            ,new(wx) wxDataViewTextRenderer("long", wxDATAVIEW_CELL_INERT)
-            ,CensusViewDataViewModel::Col_CellNum
-            ,width
-            ,wxALIGN_LEFT
-            ,wxDATAVIEW_COL_RESIZABLE
-            )
-        );
-
     // Display exactly those columns whose rows aren't all identical. For
     // this purpose, consider as "rows" the individual cells--and also the
     // case and class defaults, even though they aren't displayed in rows.
@@ -1293,27 +1295,51 @@ void CensusView::update_visible_columns()
     // still information--so if the user made them different from any cell
     // wrt some column, we respect that conscious decision.
     std::vector<std::string> const& all_headers(case_parms()[0].member_names());
+    std::vector<int> new_visible_columns;
     int column = 0;
     for(auto const& header : all_headers)
         {
-        ++column;
         if(column_value_varies_across_cells(header))
             {
-            any_member<Input> const& exemplar = list_model_->cell_at(0, column);
-            renderer_type_converter const& conv = renderer_type_converter::get(exemplar);
-            wxDataViewRenderer* renderer = conv.create_renderer(exemplar);
-            LMI_ASSERT(renderer);
-            list_window_->AppendColumn
-                (new(wx) wxDataViewColumn
-                    (insert_spaces_between_words(header)
-                    ,renderer
-                    ,column
-                    ,width
-                    ,wxALIGN_LEFT
-                    ,wxDATAVIEW_COL_RESIZABLE
-                    )
+            new_visible_columns.push_back(column);
+            }
+        ++column;
+        }
+
+    if(new_visible_columns != grid_table_->get_visible_columns())
+        {
+        auto const cursor_row = grid_window_->GetGridCursorRow();
+        auto const cursor_col = grid_window_->GetGridCursorCol();
+
+        auto const old_columns_count =
+            lmi::ssize(grid_table_->get_visible_columns()) + 1;
+        auto const new_columns_count =
+            lmi::ssize(new_visible_columns)                + 1;
+
+        wxGridUpdateLocker grid_update_locker(grid_window_);
+
+        grid_window_->DisableCellEditControl();
+
+        grid_table_->set_visible_columns(std::move(new_visible_columns));
+
+        // Bring the number of columns actually shown in the grid in sync with
+        // the number of columns in the table if necessary.
+        if(new_columns_count < old_columns_count)
+            {
+            grid_table_->DeleteCols
+                (new_columns_count
+                ,old_columns_count - new_columns_count
                 );
             }
+        else if(old_columns_count < new_columns_count)
+            {
+            grid_table_->AppendCols(new_columns_count - old_columns_count);
+            }
+
+        grid_window_->SetGridCursor
+            (cursor_row
+            ,std::min(cursor_col, new_columns_count - 1)
+            );
         }
 }
 
@@ -1329,7 +1355,7 @@ char const* CensusView::menubar_xrc_resource() const
 
 void CensusView::UponEditCell(wxCommandEvent&)
 {
-    int cell_number = selected_row();
+    int cell_number = current_row();
     Input& modifiable_parms = cell_parms()[cell_number];
     std::string const title = cell_title(cell_number);
 
@@ -1342,7 +1368,7 @@ void CensusView::UponEditCell(wxCommandEvent&)
 
 void CensusView::UponEditClass(wxCommandEvent&)
 {
-    int cell_number = selected_row();
+    int cell_number = current_row();
     std::string class_name = class_name_from_cell_number(cell_number);
     Input& modifiable_parms = *class_parms_from_class_name(class_name);
     Input const unmodified_parms(modifiable_parms);
@@ -1393,12 +1419,8 @@ void CensusView::UponColumnWidthVarying(wxCommandEvent&)
 {
     autosize_columns_ = true;
 
-    wxWindowUpdateLocker u(list_window_);
-    for(int j = 0; j < bourn_cast<int>(list_window_->GetColumnCount()); ++j)
-        {
-        list_window_->GetColumn(j)->SetWidth(wxCOL_WIDTH_AUTOSIZE);
-        }
-    Update();
+    // Pass false to avoid setting min size to the best size.
+    grid_window_->AutoSizeColumns(false);
 }
 
 /// Shrink all nonfrozen columns to default width.
@@ -1407,35 +1429,32 @@ void CensusView::UponColumnWidthFixed(wxCommandEvent&)
 {
     autosize_columns_ = false;
 
-    wxWindowUpdateLocker u(list_window_);
-    for(int j = 0; j < bourn_cast<int>(list_window_->GetColumnCount()); ++j)
+    wxWindowUpdateLocker u(grid_window_);
+    for(int j = 0; j < grid_window_->GetNumberCols(); ++j)
         {
-        list_window_->GetColumn(j)->SetWidth(wxCOL_WIDTH_DEFAULT);
+        grid_window_->SetColSize(j, WXGRID_DEFAULT_COL_WIDTH);
         }
-    Update();
 }
 
-void CensusView::UponRightClick(wxDataViewEvent& e)
+void CensusView::UponRightClick(wxGridEvent&)
 {
-    if(e.GetEventObject() != list_window_)
-        {
-        // This event should come only from the window pointed to by
-        // list_window_. Ignore it if it happens to come elsewhence.
-        e.Skip();
-        return;
-        }
-
     wxMenu* census_menu = wxXmlResource::Get()->LoadMenu("census_menu_ref");
     LMI_ASSERT(census_menu);
-    list_window_->PopupMenu(census_menu);
+    grid_window_->PopupMenu(census_menu);
     delete census_menu;
 }
 
-void CensusView::UponValueChanged(wxDataViewEvent&)
+void CensusView::UponValueChanged(wxGridEvent&)
 {
     Timer timer;
     Update();
     status() << "Update: " << timer.stop().elapsed_msec_str() << std::flush;
+}
+
+void CensusView::UponColumnAutoSize(wxGridSizeEvent& e)
+{
+    // Pass false to avoid setting min size to the best size.
+    grid_window_->AutoSizeColumn(e.GetRowOrCol(), false);
 }
 
 void CensusView::UponUpdateAlwaysDisabled(wxUpdateUIEvent& e)
@@ -1450,14 +1469,24 @@ void CensusView::UponUpdateAlwaysEnabled(wxUpdateUIEvent& e)
 
 void CensusView::UponUpdateSingleSelection(wxUpdateUIEvent& e)
 {
-    bool const is_single_sel = list_window_->GetSelection().IsOk();
-    e.Enable(is_single_sel);
-}
+    // We consider that in absence of any selected rows, the current row is the
+    // selected/active one, so what we actually check for here is that we do
+    // not have any rows other than, possibly, the current one, selected.
+    bool is_single_sel = true;
+    for(auto const& sel_block : grid_window_->GetSelectedRowBlocks())
+        {
+            auto const cursor_row = grid_window_->GetGridCursorRow();
+            if
+                (  sel_block.GetTopRow()    != cursor_row
+                || sel_block.GetBottomRow() != cursor_row
+                )
+                {
+                is_single_sel = false;
+                break;
+                }
+        }
 
-void CensusView::UponUpdateNonemptySelection(wxUpdateUIEvent& e)
-{
-    wxDataViewItemArray selection;
-    e.Enable(0 < list_window_->GetSelections(selection));
+    e.Enable(is_single_sel);
 }
 
 /// Conditionally enable copying.
@@ -1478,10 +1507,10 @@ void CensusView::UponUpdateNonemptySelection(wxUpdateUIEvent& e)
 void CensusView::UponUpdateColumnValuesVary(wxUpdateUIEvent& e)
 {
     static const std::string dob_header = insert_spaces_between_words("UseDOB");
-    int const n_cols = bourn_cast<int>(list_window_->GetColumnCount());
+    int const n_cols = grid_table_->GetColsCount();
     bool const disable =
             1 == n_cols
-        || (2 == n_cols && dob_header == list_window_->GetColumn(1)->GetTitle())
+        || (2 == n_cols && dob_header == grid_table_->GetColLabelValue(1))
         ;
     e.Enable(!disable);
 }
@@ -1497,9 +1526,9 @@ void CensusView::UponUpdateColumnValuesVary(wxUpdateUIEvent& e)
 
 void CensusView::Update()
 {
-    LMI_ASSERT(list_model_->GetCount() == cell_parms().size());
+    LMI_ASSERT(grid_table_->GetRowsCount() == lmi::ssize(cell_parms()));
 
-    wxWindowUpdateLocker u(list_window_);
+    wxWindowUpdateLocker u(grid_window_);
 
     update_class_names();
     update_visible_columns();
@@ -1522,7 +1551,7 @@ void CensusView::UponRunCase(wxCommandEvent&)
 
 void CensusView::UponRunCell(wxCommandEvent&)
 {
-    int cell_number = selected_row();
+    int cell_number = current_row();
     ViewOneCell(cell_number);
 }
 
@@ -1576,27 +1605,51 @@ void CensusView::UponAddCell(wxCommandEvent&)
     Timer timer;
 
     cell_parms().push_back(case_parms()[0]);
-    list_model_->RowAppended();
+    grid_window_->AppendRows();
 
     Update();
     document().Modify(true);
 
-    wxDataViewItem const& z = list_model_->GetItem(list_model_->GetCount() - 1);
-    list_window_->UnselectAll();
-    list_window_->Select(z);
-    list_window_->EnsureVisible(z);
+    grid_window_->GoToCell
+        (grid_table_->GetRowsCount() - 1
+        ,grid_window_->GetGridCursorCol()
+        );
+
+    grid_window_->SelectRow(grid_table_->GetRowsCount() - 1);
 
     status() << "Add: " << timer.stop().elapsed_msec_str() << std::flush;
 }
 
 void CensusView::UponDeleteCells(wxCommandEvent&)
 {
-    int n_items = bourn_cast<int>(list_model_->GetCount());
-    wxDataViewItemArray selection;
-    int n_sel_items = bourn_cast<int>(list_window_->GetSelections(selection));
-    LMI_ASSERT(n_sel_items == lmi::ssize(selection));
-    // This handler should have been disabled if no cell is selected.
-    LMI_ASSERT(0 < n_sel_items);
+    auto const n_items = grid_table_->GetRowsCount();
+
+    // Iterate over selected blocks, not rows, as this can be significantly
+    // more efficient: in a grid with 10,000 rows, the user can easily select
+    // all of them, but the selection consists of just a single block, so
+    // iterating over it is quick, while iterating over all the individual rows
+    // would take much longer.
+    auto sel_blocks = grid_window_->GetSelectedRowBlocks();
+
+    int n_sel_items = 0;
+
+    // If no rows are selected, use the current row.
+    if (sel_blocks.empty())
+        {
+        // Synthesize a block corresponding to the current row using 0 for the
+        // column values because we don't use them anyhow.
+        auto const cursor_row = grid_window_->GetGridCursorRow();
+        sel_blocks.push_back(wxGridBlockCoords{cursor_row, 0, cursor_row, 0});
+
+        n_sel_items = 1;
+        }
+    else // Compute the total number of selected rows
+        {
+        for(auto const& block : sel_blocks)
+            {
+            n_sel_items += block.GetBottomRow() - block.GetTopRow() + 1;
+            }
+        }
 
     if(n_items == n_sel_items)
         {
@@ -1631,37 +1684,31 @@ void CensusView::UponDeleteCells(wxCommandEvent&)
     wxBusyCursor reverie;
     Timer timer;
 
-    wxArrayInt erasures;
-    for(auto const& i : selection)
-        {
-        erasures.push_back(list_model_->GetRow(i));
-        }
-    std::sort(erasures.begin(), erasures.end());
+    auto const cursor_col = grid_window_->GetGridCursorCol();
 
     LMI_ASSERT(lmi::ssize(cell_parms()) == n_items);
 
-    for(int j = lmi::ssize(erasures) - 1; 0 <= j; --j)
+    wxGridUpdateLocker grid_update_locker(grid_window_);
+    grid_window_->ClearSelection();
+
+    // Annoyingly, range-for can't be used to iterate in the reverse direction
+    // before C++20, so do it manually.
+    for(auto i = sel_blocks.rbegin(); i != sel_blocks.rend(); ++i)
         {
-        cell_parms().erase(erasures[j] + cell_parms().begin());
+        auto const& block = *i;
+        auto const count = block.GetBottomRow() - block.GetTopRow() + 1;
+
+        auto const first = cell_parms().begin() + block.GetTopRow();
+        cell_parms().erase(first, first + count);
+        grid_window_->DeleteRows(block.GetTopRow(), count);
         }
     LMI_ASSERT(lmi::ssize(cell_parms()) == n_items - n_sel_items);
 
-    // Send notifications about changes to the wxDataViewCtrl model. Two things
-    // changed: some rows were deleted and cell number of some rows shifted
-    // accordingly.
-    list_model_->RowsDeleted(erasures);
-    for(int j = erasures.front(); j < lmi::ssize(cell_parms()); ++j)
-        {
-        list_model_->RowValueChanged(j, CensusViewDataViewModel::Col_CellNum);
-        }
-
-    int const newsel = std::min
-        (erasures.front()
+    int const new_cursor_row(std::min
+        (sel_blocks.front().GetTopRow()
         ,lmi::ssize(cell_parms()) - 1
-        );
-    wxDataViewItem const& z = list_model_->GetItem(newsel);
-    list_window_->Select(z);
-    list_window_->EnsureVisible(z);
+        ));
+    grid_window_->GoToCell(new_cursor_row, cursor_col);
 
     Update();
     document().Modify(true);
@@ -1845,7 +1892,7 @@ void CensusView::UponPasteCensus(wxCommandEvent&)
         return;
         }
 
-    auto selection = lmi::ssize(cell_parms());
+    auto const old_rows = grid_table_->GetNumberRows();
 
     if(!document().IsModified() && !document().GetDocumentSaved())
         {
@@ -1854,7 +1901,6 @@ void CensusView::UponPasteCensus(wxCommandEvent&)
         class_parms().clear();
         class_parms().push_back(archetype);
         cell_parms ().swap(cells);
-        selection = 0;
         }
     else if(configurable_settings::instance().census_paste_palimpsestically())
         {
@@ -1865,7 +1911,6 @@ void CensusView::UponPasteCensus(wxCommandEvent&)
         // each cell set to "Yes".
         for(auto& j : case_parms ()) {j["UseDOB"] = "Yes";}
         for(auto& j : class_parms()) {j["UseDOB"] = "Yes";}
-        selection = 0;
         }
     else
         {
@@ -1874,15 +1919,25 @@ void CensusView::UponPasteCensus(wxCommandEvent&)
         std::copy(cells.begin(), cells.end(), iip);
         }
 
+    wxGridUpdateLocker grid_update_locker(grid_window_);
+    grid_window_->ClearSelection();
+    grid_window_->DisableCellEditControl();
+
+    // Check if we need to update the number of rows. Notice that Update() will
+    // take care of the columns, so we don't need to do it here.
+    auto const new_rows = grid_table_->GetRowsCount();
+    if(new_rows < old_rows)
+        {
+        grid_table_->DeleteRows(new_rows, old_rows - new_rows);
+        }
+    else if(old_rows < new_rows)
+        {
+        grid_table_->AppendRows(new_rows - old_rows);
+        }
+    //else: The number of rows didn't change, so keep the same ones.
+
     document().Modify(true);
-    list_model_->Reset(lmi::ssize(cell_parms()));
     Update();
-    // Reset() leaves the listview unreachable from the keyboard
-    // because no row is selected--so select the first added row
-    // if possible, else the row after which no row was inserted.
-    wxDataViewItem const& z = list_model_->GetItem(selection);
-    list_window_->Select(z);
-    list_window_->EnsureVisible(z);
 
     LMI_ASSERT(1 == case_parms().size());
     LMI_ASSERT(!cell_parms ().empty());

--- a/census_view.hpp
+++ b/census_view.hpp
@@ -38,16 +38,17 @@
 #include <vector>
 
 class CensusDocument;
-class CensusViewDataViewModel;
+class CensusViewGridTable;
 
-class WXDLLIMPEXP_FWD_ADV wxDataViewEvent;
-class WXDLLIMPEXP_FWD_ADV wxDataViewCtrl;
+class WXDLLIMPEXP_FWD_ADV wxGrid;
+class WXDLLIMPEXP_FWD_ADV wxGridEvent;
+class WXDLLIMPEXP_FWD_ADV wxGridSizeEvent;
 
 class CensusView final
     :public ViewEx
 {
     friend class CensusDocument;
-    friend class CensusViewDataViewModel;
+    friend class CensusViewGridTable;
 
   public:
     CensusView();
@@ -66,8 +67,9 @@ class CensusView final
     char const* menubar_xrc_resource() const override;
 
     // Event handlers, in event-table order (reflecting GUI order)
-    void UponRightClick             (wxDataViewEvent&);
-    void UponValueChanged           (wxDataViewEvent&);
+    void UponRightClick             (wxGridEvent&);
+    void UponValueChanged           (wxGridEvent&);
+    void UponColumnAutoSize         (wxGridSizeEvent&);
     void UponEditCell               (wxCommandEvent&);
     void UponEditClass              (wxCommandEvent&);
     void UponEditCase               (wxCommandEvent&);
@@ -87,7 +89,6 @@ class CensusView final
     void UponUpdateAlwaysDisabled   (wxUpdateUIEvent&);
     void UponUpdateAlwaysEnabled    (wxUpdateUIEvent&);
     void UponUpdateSingleSelection  (wxUpdateUIEvent&);
-    void UponUpdateNonemptySelection(wxUpdateUIEvent&);
     void UponUpdateColumnValuesVary (wxUpdateUIEvent&);
 
     bool DoAllCells(mcenum_emission);
@@ -121,7 +122,7 @@ class CensusView final
         ,std::string const& title
         );
 
-    int selected_row();
+    int current_row();
 
     void update_class_names();
 
@@ -131,8 +132,8 @@ class CensusView final
 
     std::shared_ptr<Ledger const> composite_ledger_;
 
-    wxDataViewCtrl* list_window_;
-    wxObjectDataPtr<CensusViewDataViewModel> list_model_;
+    wxGrid*              grid_window_ {nullptr};
+    CensusViewGridTable* grid_table_  {nullptr};
 
     DECLARE_DYNAMIC_CLASS(CensusView)
     DECLARE_EVENT_TABLE()

--- a/input_sequence_entry.cpp
+++ b/input_sequence_entry.cpp
@@ -1346,6 +1346,7 @@ class InputSequenceTextCtrl
 
   private:
     void UponChar(wxKeyEvent& event);
+    void UponKeyDown(wxKeyEvent& event);
 };
 
 InputSequenceTextCtrl::InputSequenceTextCtrl(wxWindow* parent, wxWindowID id)
@@ -1363,11 +1364,22 @@ InputSequenceTextCtrl::InputSequenceTextCtrl(wxWindow* parent, wxWindowID id)
             ,wxEVT_CHAR
             ,&InputSequenceTextCtrl::UponChar
             );
+    ::Connect
+            (this
+            ,wxEVT_KEY_DOWN
+            ,&InputSequenceTextCtrl::UponKeyDown
+            );
 }
 
 void InputSequenceTextCtrl::UponChar(wxKeyEvent& event)
 {
     if(!GetParent()->ProcessWindowEvent(event))
+        event.Skip();
+}
+
+void InputSequenceTextCtrl::UponKeyDown(wxKeyEvent& event)
+{
+    if (!GetParent()->ProcessWindowEvent(event))
         event.Skip();
 }
 
@@ -1446,6 +1458,15 @@ bool InputSequenceEntry::Create
         );
 
     return true;
+}
+
+void InputSequenceEntry::open_editor()
+{
+    DoOpenEditor();
+
+    // Put focus back on the control itself as normal focus restoring logic
+    // doesn't work as we block some of the events in UponChildKillFocus().
+    text_->SetFocus();
 }
 
 void InputSequenceEntry::input(Input const& input)
@@ -1534,11 +1555,7 @@ void InputSequenceEntry::UponEnter(wxCommandEvent& event)
         return;
         }
 
-    DoOpenEditor();
-
-    // Put focus back on the control itself as normal focus restoring logic
-    // doesn't work as we block some of the events in UponChildKillFocus().
-    text_->SetFocus();
+    open_editor();
 }
 
 void InputSequenceEntry::UponOpenEditor(wxCommandEvent&)

--- a/input_sequence_entry.hpp
+++ b/input_sequence_entry.hpp
@@ -55,6 +55,8 @@ class InputSequenceEntry final
 
     void set_popup_title(wxString const& title) {title_ = title;}
 
+    void open_editor();
+
   private:
     void UponChildKillFocus(wxFocusEvent&);
     void UponEnter(wxCommandEvent&);

--- a/install_wx.sh
+++ b/install_wx.sh
@@ -33,7 +33,7 @@ set -vxe
 
 remote_host_url=${remote_host_url:-"https://github.com/wxWidgets/wxWidgets.git"}
 
-wx_commit_sha=${wx_commit_sha:-"f741031e69de73d5816cc56e99c9beba3ac820de"}
+wx_commit_sha=${wx_commit_sha:-"5a0723223dfac29998f323252fd1b286f902d7be"}
 
 wx_skip_clean=${wx_skip_clean:-"0"}
 

--- a/install_wxpdfdoc.sh
+++ b/install_wxpdfdoc.sh
@@ -33,7 +33,7 @@ set -vxe
 
 remote_host_url=${remote_host_url:-"https://github.com/vadz/wxpdfdoc.git"}
 
-wxpdfdoc_commit_sha=${wxpdfdoc_commit_sha:-"55366f01eed8549ca704f9d9825127868858aafb"}
+wxpdfdoc_commit_sha=${wxpdfdoc_commit_sha:-"acbd019d18e991cca46a80e1be58e637774d5d3b"}
 
 wxpdfdoc_skip_clean=${wxpdfdoc_skip_clean:-"0"}
 

--- a/wx_test_paste_census.cpp
+++ b/wx_test_paste_census.cpp
@@ -25,14 +25,15 @@
 #include "bourn_cast.hpp"
 #include "data_directory.hpp"
 #include "mvc_controller.hpp"
+#include "ssize_lmi.hpp"
 #include "wx_test_case.hpp"
 #include "wx_test_new.hpp"
 #include "wx_test_output.hpp"
 #include "wx_utility.hpp"
 
 #include <wx/app.h>
-#include <wx/dataview.h>
 #include <wx/dialog.h>
+#include <wx/grid.h>
 #include <wx/mdi.h>
 #include <wx/radiobox.h>
 #include <wx/testing.h>
@@ -47,10 +48,10 @@
 namespace
 {
 
-// Helper function to find the wxDataViewCtrl used for the census display.
+// Helper function to find the wxGrid used for the census display.
 //
 // Precondition: the currently active window must be a CensusView.
-wxDataViewCtrl* find_census_list_window()
+wxGrid* find_census_grid_window()
 {
     wxWindow* const top_window = wxTheApp->GetTopWindow();
     LMI_ASSERT(top_window);
@@ -66,28 +67,13 @@ wxDataViewCtrl* find_census_list_window()
     wxWindowList::const_iterator z = census_children.begin();
     LMI_ASSERT(z != census_children.end());
 
-    wxDataViewCtrl* const dvc = dynamic_cast<wxDataViewCtrl*>(*z);
-    LMI_ASSERT(dvc);
+    wxGrid* const grid = dynamic_cast<wxGrid*>(*z);
+    LMI_ASSERT(grid);
 
-    return dvc;
+    return grid;
 }
 
-// Retrieve the list model from list window.
-//
-// Precondition: this wxDataViewCtrl must actually use a list model.
-wxDataViewListModel* get_census_list_model(wxDataViewCtrl* dvc)
-{
-    wxDataViewModel* const model = dvc->GetModel();
-    LMI_ASSERT(model);
-
-    wxDataViewListModel* const
-        list_model = dynamic_cast<wxDataViewListModel*>(model);
-    LMI_ASSERT(list_model);
-
-    return list_model;
-}
-
-// Helper for building the diagnostic message in check_list_columns().
+// Helper for building the diagnostic message.
 std::string build_not_found_message(std::set<std::string> const& remaining)
 {
     std::ostringstream message;
@@ -116,8 +102,8 @@ std::string build_not_found_message(std::set<std::string> const& remaining)
 //
 // The 'when' parameter is used solely for the diagnostic messages in case of
 // the check failure.
-void check_list_columns
-    (wxDataViewCtrl* dvc
+void check_grid_columns
+    (wxGrid* grid
     ,char const* when
     ,std::set<std::string> const& expected
     ,std::string const& unexpected = std::string()
@@ -125,9 +111,9 @@ void check_list_columns
 {
     std::set<std::string> remaining(expected.begin(), expected.end());
 
-    for(int n = 0; n < bourn_cast<int>(dvc->GetColumnCount()); ++n)
+    for(int n = 0; n < grid->GetNumberCols(); ++n)
         {
-        std::string const title = dvc->GetColumn(n)->GetTitle().ToStdString();
+        std::string const title = grid->GetColLabelValue(n).ToStdString();
         LMI_ASSERT_WITH_MSG
             (title != unexpected
             ,"column '" << title << "' unexpectedly found " << when
@@ -147,17 +133,16 @@ void check_list_columns
 // Find the index of the column with the given title.
 //
 // Throws an exception if the column is not found.
-int find_model_column_by_title
-    (wxDataViewCtrl* dvc
+int find_table_column_by_title
+    (wxGrid* grid
     ,std::string const& title
     )
 {
-    for(int n = 0; n < bourn_cast<int>(dvc->GetColumnCount()); ++n)
+    for(int n = 0; n < grid->GetNumberCols(); ++n)
         {
-        wxDataViewColumn const* column = dvc->GetColumn(n);
-        if(column->GetTitle().ToStdString() == title)
+        if(grid->GetColLabelValue(n).ToStdString() == title)
             {
-            return column->GetModelColumn();
+            return n;
             }
         }
 
@@ -257,12 +242,13 @@ LMI_WX_TEST_CASE(paste_census)
 
     // Find the model containing the cells and check that it was filled in
     // correctly.
-    wxDataViewCtrl* const list_window = find_census_list_window();
-    wxDataViewListModel* const list_model = get_census_list_model(list_window);
-    LMI_ASSERT_EQUAL(bourn_cast<int>(list_model->GetCount()), number_of_rows);
+    wxGrid* const grid_window = find_census_grid_window();
+    wxGridTableBase* const table = grid_window->GetTable();
+    LMI_ASSERT(table);
+    LMI_ASSERT_EQUAL(table->GetNumberRows(), number_of_rows);
 
-    check_list_columns
-        (list_window
+    check_grid_columns
+        (grid_window
         ,"after pasting initial census data"
         ,column_titles
         );
@@ -270,17 +256,17 @@ LMI_WX_TEST_CASE(paste_census)
     // Change class defaults: this requires a selection, so ensure we have one
     // by clicking somewhere inside the control.
     ui.MouseMove
-        (list_window->ClientToScreen
+        (grid_window->ClientToScreen
             (wxPoint
-                (10 * list_window->GetCharWidth()
-                , 3 * list_window->GetCharHeight()
+                (10 * grid_window->GetCharWidth()
+                , 3 * grid_window->GetCharHeight()
                 )
             )
         );
     ui.MouseClick();
     wxYield();
 
-    LMI_ASSERT_EQUAL(list_window->GetSelectedItemsCount(), 1);
+    LMI_ASSERT_EQUAL(lmi::ssize(grid_window->GetSelectedRows()), 1);
 
     ui.Char('e', wxMOD_CONTROL | wxMOD_ALT); // "Census|Edit class defaults"
 
@@ -335,22 +321,20 @@ LMI_WX_TEST_CASE(paste_census)
         );
 
     // Check that all columns, including the "Gender" one, are still shown.
-    check_list_columns
-        (list_window
+    check_grid_columns
+        (grid_window
         ,"after changing gender in class defaults"
         ,column_titles
         );
 
     // Verify that the "Gender" column value is "Unisex" in every row now.
-    int const gender_column = find_model_column_by_title(list_window, "Gender");
-    LMI_ASSERT_EQUAL(bourn_cast<int>(list_model->GetCount()), number_of_rows);
+    int const gender_column = find_table_column_by_title(grid_window, "Gender");
+    LMI_ASSERT_EQUAL(table->GetNumberRows(), number_of_rows);
     // Only the first two rows are affected, because only they belong
     // to the first employee class.
     for(int row = 0; row < 2; ++row)
         {
-        wxVariant value;
-        list_model->GetValueByRow(value, row, gender_column);
-        LMI_ASSERT_EQUAL(value.GetString(), "Unisex");
+        LMI_ASSERT_EQUAL(table->GetValue(row, gender_column), "Unisex");
         }
 
     // Change the case defaults to get rid of the underwriting class.
@@ -404,11 +388,11 @@ LMI_WX_TEST_CASE(paste_census)
 
     // Check that we still have the same cells but that now the underwriting
     // class column has disappeared as its value has been fixed.
-    LMI_ASSERT_EQUAL(bourn_cast<int>(list_model->GetCount()), number_of_rows);
+    LMI_ASSERT_EQUAL(table->GetNumberRows(), number_of_rows);
 
     column_titles.erase("Underwriting Class");
-    check_list_columns
-        (list_window
+    check_grid_columns
+        (grid_window
         ,"after changing class in case defaults"
         ,column_titles
         ,"Underwriting Class"

--- a/wx_test_validate_output.cpp
+++ b/wx_test_validate_output.cpp
@@ -344,8 +344,11 @@ void validate_run_cell_and_copy_output
 
     wxUIActionSimulator ui;
 
-    ui.Char(WXK_HOME);           // Select the first cell.
-    ui.Char('r', wxMOD_CONTROL); // "Census|Run cell"
+    ui.Char(WXK_UP);                  // Clear the current selection if any.
+    ui.Char(WXK_HOME, wxMOD_CONTROL); // Go to the left top cell.
+    ui.Char(WXK_RIGHT, wxMOD_SHIFT);  // Select the first row.
+
+    ui.Char('r', wxMOD_CONTROL);      // "Census|Run cell"
     wxYield();
 
     LMI_ASSERT_WITH_MSG


### PR DESCRIPTION
This PR removes the old `wxDataViewCtrl`-based implementation and replaces it with the new `wxGrid`-based one.

It's not meant to be applied, please apply #143 instead, but some changes are better seen in the diff here than in the other PR (but not all, so the best is to view diffs in both PRs, switching between them as necessary).