### PR TITLE
Add a CI workflow building MSW 32 lmi binaries under Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+# Continuous integration workflow for lmi: build Linux and MSW binaries.
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-msw32-cross:
+    runs-on: ubuntu-20.04
+    name: Cross-compile for MSW-32
+    env:
+      LMI_COMPILER: gcc
+      LMI_TRIPLET: i686-w64-mingw32
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install required packages
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get --assume-yes install \
+            automake bc bsdmainutils bzip2 curl cvs default-jre \
+            g++-mingw-w64-i686 g++-multilib git jing libarchive-tools \
+            libtool libxml2-utils libxslt1-dev make patch pkg-config rsync \
+            shellcheck sudo trang unzip wine32 wget xsltproc
+
+      - name: Fix up libtool
+        run: sudo sed -i'' -e 's/^int _putenv/_CRTIMP int _putenv/' /usr/share/libtool/build-aux/ltmain.sh
+
+      - name: Set environment variables
+        run: |
+          echo "::set-env name=NORMAL_UID::`id --user`"
+          echo "::set-env name=coefficiency::--jobs=`nproc`"
+
+      - name: Create lmi directories
+        run: >
+          for d in /opt/lmi /etc/opt/lmi /srv/cache_for_lmi; do
+            sudo mkdir --parents $d;
+            sudo --preserve-env chown $NORMAL_UID $d;
+          done;
+          mkdir /srv/cache_for_lmi/downloads
+
+      - name: Build miscellanea
+        run: make $coefficiency --output-sync=recurse -f install_miscellanea.make
+
+      - name: Build libxml2
+        run: make $coefficiency --output-sync=recurse -f install_libxml2_libxslt.make
+
+      - name: Build wxWidgets
+        run: ./install_wx.sh
+
+      - name: Build wxPdfDoc
+        run: ./install_wxpdfdoc.sh
+
+      - name: Build lmi
+        run: make $coefficiency --output-sync=recurse install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,6 @@ jobs:
 
       - name: Build lmi
         run: make $coefficiency --output-sync=recurse install
+
+      - name: Build lmi with SO attributes
+        run: make $coefficiency --output-sync=recurse build_type=so_test USE_SO_ATTRIBUTES=1 all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,16 @@ jobs:
           done;
           mkdir /srv/cache_for_lmi/downloads
 
+      - name: Cache downloaded archives
+        uses: actions/cache@v2
+        with:
+          # Use combined key for files downloaded by both makefiles, even
+          # though this means that we would redownload the same files from the
+          # unchanged makefile if only one of them changes -- but they don't
+          # change often enough to make this a real problem in practice.
+          path: /srv/cache_for_lmi/downloads
+          key: downloads-${{ hashFiles('install_miscellanea.make') }}-${{ hashFiles('install_libxml2_libxslt.make') }}
+
       - name: Build miscellanea
         run: make $coefficiency --output-sync=recurse -f install_miscellanea.make
 

--- a/install_wx.sh
+++ b/install_wx.sh
@@ -115,6 +115,7 @@ config_options="
   --disable-ribbon
   --disable-richtext
   --disable-stc
+  --disable-sys-libs
   --disable-webview
   --enable-monolithic
   --enable-option-checking
@@ -122,9 +123,6 @@ config_options="
   --enable-stl
   --enable-vendor=$vendor
   --with-cxx=11
-  --with-expat=builtin
-  --with-libpng=builtin
-  --with-zlib=builtin
   --without-opengl
   --without-subdirs
   CPPFLAGS=-I$prefix/include


### PR DESCRIPTION
Extract the quintessence of lmi_setup_*.sh files into GitHub workflow to
rebuild lmi automatically for every pull request and push to master.