### PR TITLE
Try fixing CI workflow to avoid 32 bit packages installation errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
+          sudo apt-get install --assume-yes libgcc-s1:i386 # Avoid configuratiion error later
           sudo apt-get --assume-yes install \
             automake bc bsdmainutils bzip2 curl cvs default-jre \
             g++-mingw-w64-i686 g++-multilib git jing libarchive-tools \


### PR DESCRIPTION
Installing wine32 doesn't work any longer in Ubuntu 20.04 virtual
environment for some reason.